### PR TITLE
0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,54 @@ from html_compose import a, article, body, br, head, html, p, strong, title
 
 ## Features
 
-- Lazy evaluation
-- Natural syntax: Self attrs in `__init__`, children in `[brackets]` via `__getitem__`
+- Lazy evaluation leading to performance gains
+* Define children via `[]` syntax:
+  ```python
+  from html_compose import p, strong
+  p()["a", strong()["bold"], "statement"]
+  #<p>a <strong>bold</strong> statement
+  # The above is identical to
+  p().append(["a", strong()["bold"], "statement"])
+  ```
+* Skip constructor via same `[]` syntax:
+  ```python
+  from html_compose import ul, li
+  ul[
+      li["because sometimes"]
+      li["I forget"], 
+      li["the constructor"],
+      li["for text"],
+      li["elements"]
+  ]
+  ```
+* Define arguments in a variety of ways: 
+  ```python
+  from html_compose import div
+
+  ## With type hints
+  div(tabindex=1) 
+  div(attrs=[div.tabindex(1)])
+  ## Positionally
+  div([div.tabindex(1)])
+  div({"data-for-something": "foo"})
+
+  ## With class dictionary resolution
+  is_dark_mode = False
+  div(class_={"dark-mode": is_dark_mode, "flex": True})
+  # <div class="flex"></div>
+  
+  ## Combine the two `
+  div(attrs=[div.class_("flex")], class_={"dark-mode": True})
+  # <div class="flex dark-mode"></div>
+
 - Type hints for the editor generated from WhatWG spec
 
 ## Goals
 
 - Be a stable layer for further abstraction of client-server model applications and libraries
 - Put web developer documentation in the hands of developers via their IDE
-- Opinionate as few things as possible favoring expression, stay out of the way
+- Opinionate as few things as possible favoring expression; stay out of the way
+- Clearly mark any potentially breaking changes through discovered development optimizations in changelog
 
 ## Magic decisions
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+# 0.2.1
+* [breaking] BaseElement now places keyword arg `class` / `style` after `attrs=` when you include definitions for both 
+* [bug] Fix attr resolution breaking for dictionary values
+* Add constructor "skip" via __class_getitem__. Where you had to do li()["demo"] you can now li["demo"]
+* Docs/readme improvements
+
 # 0.2.0
 * Generate descriptions for attrs in elements along with full keyword arguments. We intentionally excluded onclick= and other onX attributes to avoid overloading the language server.
 * Element constructor docstring is a little nicer to read

--- a/doc/ideas/01_iterator.md
+++ b/doc/ideas/01_iterator.md
@@ -2,35 +2,41 @@
 
 ## Core Concepts
 
-1. Generators are beneficial to performance 
+1. Generators are beneficial to performance
 
-* Elements are generated one at a time and immediately consumed by the join operation. You never store the complete set in memory.
-* Each element is processed exactly once as it flows through the generator pipeline.
-* Lazy evaluation: The HTML is generated on-demand, which is particularly valuable when building conditional elements or working with large datasets.
-*
-2. String Iterators: 
-*  Used as the output of the `__html__` method, which represents sanitized elements and markup which is implemented as `deferred_resolve` in our base element class, 
+- Elements are generated one at a time and immediately consumed by the join operation. You never store the complete set in memory.
+- Each element is processed exactly once as it flows through the generator pipeline.
+- Lazy evaluation: The HTML is generated on-demand, which is particularly valuable when building conditional elements or working with large datasets.
+-
+
+2. String Iterators:
+
+- Used as the output of the `__html__` method, which represents sanitized elements and markup which is implemented as `deferred_resolve` in our base element class,
 
 3. Tree Resolution: The process of walking through the HTML element tree and resolving all children.
 
 ## Concept: Iterator flattening
+
 An iterator can contain iterators, like this:
+
 ```python
-ul[ (ul["one"], ul["two"]) ]
+ul[ (li["one"], li["two"]) ]
 ```
 
 This allows syntax like this:
+
 ```python
 def get_items(db):
-        return ( 
+        return (
             li[
                 h[row.name],
                 h2[row.type]
                 p[row.value]
-            ] for row in db.query.stuff("select name, type, value ...") 
+            ] for row in db.query.stuff("select name, type, value ...")
     )
 ul[ get_items(db_session) ]
 ```
+
 ## Concept: Tree Resolution
 
 To resolve element.children into a list of strings, we first have to recursively walk the html element tree and yield all resolved children
@@ -49,13 +55,12 @@ article[
 ]
 ```
 
-
 ### Deferred resolve
 
 The **deferred resolve** step will resolve an iterator that looks a lot like this, as a list:
 
 ```python
-def 
+def
 [
     "<article>",
 
@@ -68,9 +73,11 @@ def
     "</article>"
 ]
 ```
+
 As you can see, the static content that resolves is returned, but callables are returned as themselves.
 
 ### Full resolution
+
 We simply walk the iterator generated in the deferred resolve step and call any callables before returning to `str.join`.
 
 We believe a few cool things can be done with this regarding content generation and rendering.

--- a/doc/ideas/02_base_element.md
+++ b/doc/ideas/02_base_element.md
@@ -1,31 +1,69 @@
 # Idea
+
 The base element has tricks built into it so that you can write HTML faster.
 
-## Implemented
-(fill out something like this pls)
-* `[]` syntax is a wrapper for `Element.append` i.e. `div().append`, except that it returns itself so that it can be chained: `div[ div["a", "b", "c"] ]`
-* callable and iterator nesting `div()[callable, [ br(), "text" ]]`
-* multi-parameter lambda function: div(data=[1,2,3])[lambda x: x.data]
-    * 0 params: nothing
-    * param 1: parent node, if applicable
-    * param 2: its parent, if applicable
+## Concepts
 
-* `Element`.`attribute` i.e. `img.srcset()` with description, implemented as classes which are chldren of subclass.
-* LRU cache
-  * The basic attribute concat are called a lot and so they maintain an LRU cache configurable in size via `Element`.`ATTR_CACHE_SIZE` i.e. `div.ATTR_CACHE_SIZE`.
-  * The multi-parameter lambda function also has an LRU cache to reduce time spent getting function params. This only works because it can guarantee it is only working on strings.
-* The `class_` thing: You can't use `class` as an argument in Python. This alternative was chosen because it is identical to autocomplete.
-* Each element has a `data` field which can be used in lambdas.
+### [] syntax for children
 
-## Pending
-* `with` nesting
-```
+`[]` syntax is a wrapper for `Element.append` i.e. `div().append`, except that it returns itself so that it can be chained: `div[ div["a", "b", "c"] ]`
 
-with div(h1("Title")] as d:
-  p("This is like a translated markdown document")
-  br()
-  p("So anyway, I started ")
-  strong("blasting.")
+Under the hood, this is just `BaseElement.__getitem__`
 
+### [] syntax constructor
 
-```
+Normally you would construct an element like `h1()["My header"]`.
+
+You can also do `h1["My header"]`.
+
+You will notice this bypasses running the constructor.
+
+Under the hood, this is just `BaseElement.__class_getitem__` which just runs the constructor with no parameters.
+This shorthand can save a few keystrokes.
+
+### Iterators / callables
+
+You can nest iterators and even place callables in your children. i.e. `div()[lambda: "evaluated at render time", [ br(), "text" ]]`
+
+### Lambda parameters
+
+multi-parameter lambda function: `div()[lambda node, parent_if_avail: "Demo"]`
+_ 0 params: nothing
+_ param 1: parent node, if applicable \* param 2: its parent, if applicable
+
+Element attributes aren't currently intended to be accessed to prevent mistreating HTML as data or application state, so these parameters would most likely be more useful in a custom extension of an element.
+
+### Attribute classes
+
+You can access `Element`.`attribute` i.e. `img.srcset()` with description, implemented as classes which are chldren of subclass.
+These can be passed in element initialization `a(attrs=[a.href("https://google.com")])` and has the benefit of auto-complete.
+
+### LRU cache
+
+- The basic attribute concat are called a lot and so they maintain an LRU cache configurable in size via `Element`.`ATTR_CACHE_SIZE` i.e. `div.ATTR_CACHE_SIZE`. This only works because it can guarantee it is only working on strings.
+- The multi-parameter lambda function also has an LRU cache to reduce time spent getting function params.
+
+### Name conflicts
+
+Examples:
+
+- `class_`
+- `del_`
+
+You can't use `class` as an argument in Python because it is a keyword. We opt to call it `class_`
+
+This alternative was chosen because it is identical to autocomplete.
+
+The same rule is applied anywhere else a name conflicts with a keyword i.e. the `del` element.
+
+### Repeat attributes
+
+In the event `class` or `style` occur multiple times, they are concatenated with the correct delimeter in the order they're received.
+
+Because there's no clear way to concat other attributes, an exception is raised.
+
+### XSS prevention / automatic escape
+
+Unescaped child nodes i.e. strings are automatically escaped to prevent XSS.
+
+This is done by the palletsprojects `markupsafe` library.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "html-compose"
-version = "0.2.0"
+version = "0.2.1"
 description = "Composable HTML generation in python"
 authors = [
     { name = "jealouscloud", email = "github@noaha.org" }

--- a/src/html_compose/base_attribute.py
+++ b/src/html_compose/base_attribute.py
@@ -88,7 +88,7 @@ class BaseAttribute:
             _resolved = self.list_string_generator(data)
         # dictionary of key value pairs
         elif isinstance(data, dict):
-            _resolved = self.dict_string_generator()
+            _resolved = self.dict_string_generator(data)
         else:
             raise ValueError(f"Input data type {data} not supported")
 

--- a/src/html_compose/base_element.py
+++ b/src/html_compose/base_element.py
@@ -25,10 +25,13 @@ class BaseElement(ElementBase, GlobalAttrs):
 
     @classmethod
     def __class_getitem__(cls, key):
-        raise TypeError(
-            "Cannot use [] directly on the class. "
-            "Did you mean to call the class first? Example: div()['elements'] instead of div['elements']"
-        )
+        """
+        This implements a shortcut to the constructor for a given element.
+
+        Example:
+        If the user passes `h1["Demo"]` the user likely expects h1()["Demo"]
+        """
+        return cls()[key]
 
     def __getitem__(self, key):
         """

--- a/src/html_compose/base_element.py
+++ b/src/html_compose/base_element.py
@@ -114,11 +114,11 @@ class BaseElement(ElementBase, GlobalAttrs):
             if attr_name in self._attrs:
                 if attr_name == "class":
                     self._attrs[attr_name] = (
-                        f"{resolved_value} {self._attrs[attr_name]}"
+                        f"{self._attrs[attr_name]} {resolved_value}"
                     )
                 elif attr_name == "style":
                     self._attrs[attr_name] = (
-                        f"{resolved_value}; {self._attrs[attr_name]}"
+                        f"{self._attrs[attr_name]}; {resolved_value}"
                     )
                 else:
                     raise ValueError(

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -152,3 +152,8 @@ def test_class_getitem():
     """
     el = div["demo"]
     assert el.render() == "<div>demo</div>"
+
+
+def test_doubled_class():
+    el = div(attrs=[div.class_("flex")], class_={"dark-mode": True})
+    assert el.render() == '<div class="flex dark-mode"></div>'

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -64,9 +64,9 @@ def test_nested_callables():
 
 
 def test_resolve_none():
-    assert (
-        div()[None].render() == "<div></div>"
-    ), "Nonetype should result in empty string"
+    assert div()[None].render() == "<div></div>", (
+        "Nonetype should result in empty string"
+    )
 
 
 def test_xss():
@@ -142,3 +142,13 @@ def test_kw_arg_attr():
     assert (
         el.render() == '<div id="test" class="test-class" tabindex="1"></div>'
     )
+
+
+def test_class_getitem():
+    """
+    Sometimes I forget to construct elements that only contain a string.
+
+    A syntax alteration was added __class_getitem__ which this test verifies.
+    """
+    el = div["demo"]
+    assert el.render() == "<div>demo</div>"


### PR DESCRIPTION
* [breaking] BaseElement now places keyword arg `class` / `style` after `attrs=` when you include definitions for both 
* [bug] Fix attr resolution breaking for dictionary values
* Add constructor "skip" via __class_getitem__. Where you had to do li()["demo"] you can now li["demo"]
* Docs/readme improvements
* Add tests for new element features and features demonstrated in readme.