### PR TITLE
0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,49 @@ from html_compose import a, article, body, br, head, html, p, strong, title
 <html><head><title>Welcome, github wanderer!</title></head><body><article><p>Welcome to the internet <strong>github wanderer</strong>!</p><br /><p>Have you checked out this cool thing called a <a href="https://google.com">search engine</a>?</p></article></body></html>
 ```
 
+**Full autocomplete**
+```
+a([tab]
+  attrs= 
+  id= 
+  class_= 
+  download= 
+  href= 
+  hreflang= 
+  ping= 
+  referrerpolicy= 
+  rel= 
+  target= 
+  type= 
+  accesskey= 
+  autocapitalize= 
+  autocorrect= 
+  autofocus= 
+  contenteditable= 
+  dir= 
+  draggable= 
+  enterkeyhint= 
+  hidden= 
+  inert= 
+  inputmode= 
+  is_= 
+  itemid= 
+  itemprop= 
+  itemref= 
+  itemscope= 
+  itemtype= 
+  lang= 
+  nonce= 
+  popover= 
+  slot= 
+  spellcheck= 
+  style= 
+  tabindex= 
+  title= 
+  translate= 
+  writingsuggestions= 
+```
+
 ## Features ✨
 
 - ⚡ Lazy evaluation leading to performance gains

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ from html_compose import a, article, body, br, head, html, p, strong, title
     head()[title()[f"Welcome, {username}!"]],
     body()[
         article()[
-            p()["Welcome to the internet", strong()[username], "!"],
+            p()["Welcome to the internet ", strong()[username], "!"],
             br(),
             p()[
                 "Have you checked out this cool thing called a ",
@@ -22,7 +22,7 @@ from html_compose import a, article, body, br, head, html, p, strong, title
     ],
   ].render()
 )
-<html><head><title>Welcome, github wanderer!</title></head><body><article><p>Welcome to the internet<strong>github wanderer</strong>!</p><br /><p>Have you checked out this cool thing called a <a href="https://google.com">search engine</a>?</p></article></body></html>
+<html><head><title>Welcome, github wanderer!</title></head><body><article><p>Welcome to the internet <strong>github wanderer</strong>!</p><br /><p>Have you checked out this cool thing called a <a href="https://google.com">search engine</a>?</p></article></body></html>
 ```
 
 ## Features ✨

--- a/README.md
+++ b/README.md
@@ -113,7 +113,37 @@ a([tab]
   # <div class="flex dark-mode"></div>
   ```
 
-- 🎭 Type hints for the editor generated from WhatWG spec
+* 🎭 Type hints for the editor generated from WhatWG spec
+* ⚡ Live Reload server for rapid development  
+  Run your Python webserver (i.e. Flask, FastAPI, anything!) with live-reload superpowers powered by [livereload-js](https://www.npmjs.com/package/livereload-js). See browser updates in real-time!
+
+  Note: This feature requires optional dependencies. `pip install html-compose[live-reload]` or `pip install html-compose[full]''
+  `livereload.py`
+  ```python
+  import html_compose.live as live
+
+  live.server(
+      daemon=live.ShellCommand("flask --app ./src/my_webserver run"),
+      daemon_delay=1,
+      conds=[
+          live.WatchCond(path_glob="**/*.py", action=live.ShellCommand("date")),
+          live.WatchCond(
+              path_glob="./static/sass/**/*.scss",
+              action=live.ShellCommand(
+                  ["sass", "--update", "static/sass:static/css"]
+              ),
+              no_reload=True,  # Nobody reads -these- files so we don't need to reload the server
+          ),
+          live.WatchCond(
+              path_glob="./static/css/", 
+              action=None, # There's no action to take on css but this will cause the browser to update
+              delay=0.5
+          ),
+      ],
+      host="localhost",
+      port=51353
+  )
+  ```
 
 ## Goals 🛠️
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,8 @@
     live_server daemon function which will automatically run your script and Python server daemon, as well as any build commands
     cross-platform file watcher based on Rust Notify
 * Use numpy style docstring parameters with backticks because parameters with _ were being eaten by pylance. Parameter doc newlines should work in this format.
+* Command-line script is a module for further extension as `html-compose` 
+* Note in docstring that pretty printing can damage output due to the way HTML whitespace works. Development feature only.
 
 # 0.5.1
 * [breaking] Move pretty_print function to module function

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+# 0.6.0
+* Add livereload feature: 
+    A websocket server to auto-reload the browser
+    Automatic include of livereload-js through html_compose.HTML5Document 
+    live_server daemon function which will automatically run your script and Python server daemon, as well as any build commands
+    cross-platform file watcher based on Rust Notify
+* Use numpy style docstring parameters with backticks because parameters with _ were being eaten by pylance. Parameter doc newlines should work in this format.
+
 # 0.5.1
 * [breaking] Move pretty_print function to module function
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "html-compose"
-version = "0.5.1"
+version = "0.6.0"
 description = "Composable HTML generation in python"
 authors = [
     { name = "jealouscloud", email = "github@noaha.org" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,13 +40,13 @@ classifiers = [
 [project.optional-dependencies]
 
 live-reload = [
-    "websockets>=15.0.1",
-    "pyinotify>=0.9.6; sys_platform == 'linux'"
+    "watchfiles>=1.0.4",
+    "websockets>=15.0.1"
 ]
 
 
 full = [
-    "pyinotify>=0.9.6; sys_platform == 'linux'",
+    "watchfiles>=1.0.4",
     "websockets>=15.0.1",
     "beautifulsoup4>=4.12.3"
 ]
@@ -66,7 +66,7 @@ dev-dependencies = [
     "mypy>=1.15.0",
     "types-beautifulsoup4>=4.12.0.20250204",
     "ipython>=8.33.0",
-    "pyinotify>=0.9.6; sys_platform == 'linux'",
+    "watchfiles>=1.0.4",
 ]
 [project.scripts]
 "html-convert" = "html_compose.cli:html_convert"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev-dependencies = [
     "types-beautifulsoup4>=4.12.0.20250204",
     "ipython>=8.33.0",
     "watchfiles>=1.0.4",
+    "websockets>=15.0.1",
 ]
 [project.scripts]
 "html-convert" = "html_compose.cli:html_convert"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ dev-dependencies = [
     "ipython>=8.33.0",
 ]
 [project.scripts]
-"html-convert" = "html_compose:from_html"
+"html-convert" = "html_compose.cli:html_convert"
+"html-compose" = "html_compose.cli:cli"
 
 [tool.rye.scripts]  # Run as "rye run <command>"
 build-elements = { chain = ["python tools/generate_elements.py --copy", 'fix-lint', 'fix-fmt' ] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,22 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 
+
+[project.optional-dependencies]
+
+live-reload = [
+    "websockets>=15.0.1",
+    "pyinotify>=0.9.6; sys_platform == 'linux'"
+]
+
+
+full = [
+    "pyinotify>=0.9.6; sys_platform == 'linux'",
+    "websockets>=15.0.1",
+    "beautifulsoup4>=4.12.3"
+]
+
+
 [build-system]
 requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
@@ -50,6 +66,7 @@ dev-dependencies = [
     "mypy>=1.15.0",
     "types-beautifulsoup4>=4.12.0.20250204",
     "ipython>=8.33.0",
+    "pyinotify>=0.9.6; sys_platform == 'linux'",
 ]
 [project.scripts]
 "html-convert" = "html_compose.cli:html_convert"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,6 @@ indent-width = 4
 
 # Assume Python 3.10
 target-version = "py310"
+
+[tool.ruff.format]
+skip-magic-trailing-comma = true

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -58,6 +58,7 @@ pure-eval==0.2.3
     # via stack-data
 pygments==2.19.1
     # via ipython
+pyinotify==0.9.6
 pyright==1.1.396
 pytest==8.3.3
 requests==2.32.3

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -90,3 +90,4 @@ urllib3==2.2.3
 watchfiles==1.0.4
 wcwidth==0.2.13
     # via prompt-toolkit
+websockets==15.0.1

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,6 +10,8 @@
 #   universal: false
 
 -e file:.
+anyio==4.9.0
+    # via watchfiles
 asttokens==3.0.0
     # via stack-data
 beautifulsoup4==4.12.3
@@ -21,12 +23,14 @@ charset-normalizer==3.4.0
 decorator==5.2.1
     # via ipython
 exceptiongroup==1.2.2
+    # via anyio
     # via ipython
     # via pytest
 executing==2.2.0
     # via stack-data
 hext==1.0.11
 idna==3.10
+    # via anyio
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -58,10 +62,11 @@ pure-eval==0.2.3
     # via stack-data
 pygments==2.19.1
     # via ipython
-pyinotify==0.9.6
 pyright==1.1.396
 pytest==8.3.3
 requests==2.32.3
+sniffio==1.3.1
+    # via anyio
 soupsieve==2.6
     # via beautifulsoup4
 stack-data==0.6.3
@@ -76,10 +81,12 @@ types-beautifulsoup4==4.12.0.20250204
 types-html5lib==1.1.11.20241018
     # via types-beautifulsoup4
 typing-extensions==4.12.2
+    # via anyio
     # via ipython
     # via mypy
     # via pyright
 urllib3==2.2.3
     # via requests
+watchfiles==1.0.4
 wcwidth==0.2.13
     # via prompt-toolkit

--- a/src/html_compose/__init__.py
+++ b/src/html_compose/__init__.py
@@ -52,37 +52,6 @@ def doctype(dtype: str = "html"):
     return unsafe_text(f"<!DOCTYPE {dtype}>")
 
 
-def from_html():
-    """
-    Command-line tool to translate HTML to Python code using html_compose
-
-    This function reads from stdin by default, but accepts an optional filename as argument
-    """
-    import argparse
-    import fileinput
-
-    from . import translate_html
-
-    parser = argparse.ArgumentParser(description="HTML to Markdown translator")
-    parser.add_argument(
-        "html",
-        default="-",
-        nargs="?",
-        help="HTML file to translate (default: stdin)",
-    )
-    args = parser.parse_args()
-    is_stdin = args.html == "-"
-    if is_stdin:
-        print("Reading from stdin. Press Ctrl+D to finish.")
-
-    html_content = "\n".join(
-        [line for line in fileinput.input(files=args.html, encoding="utf-8")]
-    )
-    if is_stdin:
-        print("---\n")
-    print(translate_html.translate(html_content))
-
-
 from .base_element import BaseElement
 from .document import HTML5Document
 

--- a/src/html_compose/__init__.py
+++ b/src/html_compose/__init__.py
@@ -41,8 +41,9 @@ def pretty_print(html_str: str, features="html.parser") -> str:
     # so we lazy load bs4
     from bs4 import BeautifulSoup  # type: ignore[import-untyped]
 
-    p = BeautifulSoup(html_str, features="html.parser")
-    return p.prettify()
+    return BeautifulSoup(html_str, features="html.parser").prettify(
+        formatter="html5"
+    )
 
 
 def doctype(dtype: str = "html"):

--- a/src/html_compose/__init__.py
+++ b/src/html_compose/__init__.py
@@ -29,12 +29,14 @@ def unsafe_text(value: Union[str, Markup]) -> Markup:
 
 def pretty_print(html_str: str, features="html.parser") -> str:
     """
-    Pretty print HTML
+    Pretty print HTML.  
+    DO NOT do this for production since it introduces whitespace and may
+    affect your output.
 
     :param html_str: HTML string to print
     :param features: BeautifulSoup tree builder to print with
     :return: Pretty printed HTML string
-    """
+    """  # fmt: skip
     # Production instances probably don't use this
     # so we lazy load bs4
     from bs4 import BeautifulSoup  # type: ignore[import-untyped]

--- a/src/html_compose/base_element.py
+++ b/src/html_compose/base_element.py
@@ -2,16 +2,9 @@ from typing import Callable, Generator, Optional, Union
 
 from . import escape_text, unsafe_text, util_funcs
 from .attributes import BaseAttribute, GlobalAttrs
-from .base_types import (
-    ElementBase,
-    Node,
-    _HasHtml,
-)
+from .base_types import ElementBase, Node, _HasHtml
 
-SPECIAL_ATTRS = {
-    "class": GlobalAttrs.class_,
-    "style": GlobalAttrs.style,
-}
+SPECIAL_ATTRS = {"class": GlobalAttrs.class_, "style": GlobalAttrs.style}
 
 
 class BaseElement(ElementBase):

--- a/src/html_compose/cli.py
+++ b/src/html_compose/cli.py
@@ -1,0 +1,52 @@
+import argparse
+import fileinput
+
+from . import translate_html
+
+
+def from_html(args):
+    is_stdin = args.html == "-"
+
+    if is_stdin:
+        print("Reading from stdin. Press Ctrl+D to finish.")
+
+    html_content = "\n".join(
+        [line for line in fileinput.input(files=args.html, encoding="utf-8")]
+    )
+    if is_stdin:
+        print("---\n")
+    print(translate_html.translate(html_content))
+
+def parse_html_translate(parser):
+    parser.add_argument(
+        "html",
+        default="-",
+        nargs="?",
+        help="HTML file to translate (default: stdin)",
+    )
+
+
+def html_convert():
+    parser = argparse.ArgumentParser(description="HTML to python translator")
+    parse_html_translate(parser)
+    args = parser.parse_args()
+    from_html(args)
+
+
+def cli():
+    """
+    Command-line tool to translate HTML to Python code using html_compose
+
+    This function reads from stdin by default, but accepts an optional filename as argument
+    """
+    HTML_CONVERT = "html-convert"
+    parser = argparse.ArgumentParser(description="html-compose cli")
+    subparsers = parser.add_subparsers(dest="command")
+
+    html_parser = subparsers.add_parser(
+        HTML_CONVERT, help="Translate HTML to html-compose"
+    )
+    parse_html_translate(html_parser)
+    args = parser.parse_args()
+    if args.command == HTML_CONVERT:
+        from_html(args)

--- a/src/html_compose/cli.py
+++ b/src/html_compose/cli.py
@@ -10,12 +10,23 @@ def from_html(args):
     if is_stdin:
         print("Reading from stdin. Press Ctrl+D to finish.")
 
-    html_content = "\n".join(
-        [line for line in fileinput.input(files=args.html, encoding="utf-8")]
-    )
+    try:
+        html_content = "\n".join(
+            [
+                line
+                for line in fileinput.input(files=args.html, encoding="utf-8")
+            ]
+        )
+    except Exception as exc:
+        print("Failed to read HTML content: {}".format(exc))
+        return
+    except KeyboardInterrupt:
+        return
+
     if is_stdin:
         print("---\n")
     print(translate_html.translate(html_content))
+
 
 def parse_html_translate(parser):
     parser.add_argument(
@@ -39,7 +50,7 @@ def cli():
 
     This function reads from stdin by default, but accepts an optional filename as argument
     """
-    HTML_CONVERT = "html-convert"
+    HTML_CONVERT = "convert"
     parser = argparse.ArgumentParser(description="html-compose cli")
     subparsers = parser.add_subparsers(dest="command")
 
@@ -50,3 +61,5 @@ def cli():
     args = parser.parse_args()
     if args.command == HTML_CONVERT:
         from_html(args)
+    else:
+        parser.print_help()

--- a/src/html_compose/document.py
+++ b/src/html_compose/document.py
@@ -2,6 +2,7 @@ from typing import Optional, Union
 
 from . import base_types, doctype, pretty_print
 from . import elements as el
+from .util_funcs import get_livereload_env
 
 
 def HTML5Document(
@@ -26,6 +27,7 @@ def HTML5Document(
     """
     # Enable HTML5 and prevent quirks mode
     header = doctype("html")
+
     head_el = el.head()[
         el.meta(  # enable mobile rendering
             name="viewport", content="width=device-width, initial-scale=1.0"
@@ -33,6 +35,26 @@ def HTML5Document(
         el.title()[title] if title else None,
         head if head else None,
     ]
+    # None if disabled
+    live_reload_flags = get_livereload_env()
+    # Feature: Live reloading for development
+    if live_reload_flags:
+        # Add livereload script to the head
+        # Livereload: https://github.com/livereload/livereload-js
+        # We used an SRI hash generator to prevent supply-chain attacks
+        # https://www.srihash.org/
+        VERSION = "v4.0.2"
+        repo = "https://raw.githubusercontent.com/livereload/livereload-js"
+        uri = f"{repo}/refs/tags/{VERSION}/dist/livereload.min.js"
+        head_el.append(
+            el.script(
+                {
+                    "src": f"{uri}?{live_reload_flags}",
+                    "integrity": "sha384-JpRTIH2FPXE1xxxYlwSn2HF2U5br0oTSUBvdF0F5YcNmUTvJvh/o1+rDUdy9NGVs",
+                    "crossorigin": "anonymous",
+                }
+            )
+        )
     if isinstance(body, el.body):
         body_el = body
     else:

--- a/src/html_compose/document.py
+++ b/src/html_compose/document.py
@@ -37,10 +37,7 @@ def HTML5Document(
         body_el = body
     else:
         body_el = el.body()[body]
-    html = el.html(lang=lang)[
-        head_el,
-        body_el,
-    ]
+    html = el.html(lang=lang)[head_el, body_el]
     result = f"{header}\n{html.render()}"
     if prettify:
         return pretty_print(result)

--- a/src/html_compose/document.py
+++ b/src/html_compose/document.py
@@ -16,6 +16,9 @@ def HTML5Document(
     Return an HTML5 document with the given title and content.
     It also defines meta viewport for mobile support.
 
+    When using livereload, an environment variable is set which adds
+    livereload-js to the head of the document.
+
     :param title: The title of the document
     :param lang: The language of the document.
                  English is "en", or consult HTML documentation
@@ -38,10 +41,11 @@ def HTML5Document(
     # None if disabled
     live_reload_flags = get_livereload_env()
     # Feature: Live reloading for development
+    # Fires when HTMLCOMPOSE_LIVERELOAD=1
     if live_reload_flags:
         # Add livereload script to the head
         # Livereload: https://github.com/livereload/livereload-js
-        # We used an SRI hash generator to prevent supply-chain attacks
+        # We pin version and used an SRI hash generator to prevent supply-chain attacks
         # https://www.srihash.org/
         VERSION = "v4.0.2"
         repo = "https://raw.githubusercontent.com/livereload/livereload-js"

--- a/src/html_compose/elements.py
+++ b/src/html_compose/elements.py
@@ -159,60 +159,116 @@ class a(BaseElement):
         Initialize 'a' (Hyperlink) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param download: Whether to download the resource instead of navigating to it, and its filename if so
-        :param href: Address of the hyperlink
-            | Valid URL potentially surrounded by spaces
-        :param hreflang: Language of the linked resource
-            | Valid BCP 47 language tag
-        :param ping: URLs to ping
-            | Set of space-separated tokens consisting of valid non-empty URLs
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param rel: Relationship between the location in the document containing the hyperlink and the destination resource
-            | Unordered set of unique space-separated tokens*
-        :param target: Navigable for hyperlink navigation
-            | Valid navigable target name or keyword
-        :param type: Hint for the type of the referenced resource
-            | Valid MIME type string
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `download` :
+            Whether to download the resource instead of navigating to it, and its filename if so
+        `href` :
+            Address of the hyperlink  
+        
+            Valid URL potentially surrounded by spaces
+        `hreflang` :
+            Language of the linked resource  
+        
+            Valid BCP 47 language tag
+        `ping` :
+            URLs to ping  
+        
+            Set of space-separated tokens consisting of valid non-empty URLs
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `rel` :
+            Relationship between the location in the document containing the hyperlink and the destination resource  
+        
+            Unordered set of unique space-separated tokens*
+        `target` :
+            Navigable for hyperlink navigation  
+        
+            Valid navigable target name or keyword
+        `type` :
+            Hint for the type of the referenced resource  
+        
+            Valid MIME type string
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "a", void_element=False, attrs=attrs, children=children
@@ -389,45 +445,86 @@ class abbr(BaseElement):
         Initialize 'abbr' (Abbreviation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "abbr", void_element=False, attrs=attrs, children=children
@@ -588,45 +685,86 @@ class address(BaseElement):
         Initialize 'address' (Contact information for a page or article element) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "address", void_element=False, attrs=attrs, children=children
@@ -798,60 +936,116 @@ class area(BaseElement):
         Initialize 'area' (Hyperlink or dead area on an image map) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param alt: Replacement text for use when images are not available
-        :param coords: Coordinates for the shape to be created in an image map
-            | Valid list of floating-point numbers*
-        :param download: Whether to download the resource instead of navigating to it, and its filename if so
-        :param href: Address of the hyperlink
-            | Valid URL potentially surrounded by spaces
-        :param ping: URLs to ping
-            | Set of space-separated tokens consisting of valid non-empty URLs
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param rel: Relationship between the location in the document containing the hyperlink and the destination resource
-            | Unordered set of unique space-separated tokens*
-        :param shape: The kind of shape to be created in an image map
-        :param target: Navigable for hyperlink navigation
-            | Valid navigable target name or keyword
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `alt` :
+            Replacement text for use when images are not available
+        `coords` :
+            Coordinates for the shape to be created in an image map  
+        
+            Valid list of floating-point numbers*
+        `download` :
+            Whether to download the resource instead of navigating to it, and its filename if so
+        `href` :
+            Address of the hyperlink  
+        
+            Valid URL potentially surrounded by spaces
+        `ping` :
+            URLs to ping  
+        
+            Set of space-separated tokens consisting of valid non-empty URLs
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `rel` :
+            Relationship between the location in the document containing the hyperlink and the destination resource  
+        
+            Unordered set of unique space-separated tokens*
+        `shape` :
+            The kind of shape to be created in an image map
+        `target` :
+            Navigable for hyperlink navigation  
+        
+            Valid navigable target name or keyword
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "area", void_element=True, attrs=attrs, children=children
@@ -1030,45 +1224,86 @@ class article(BaseElement):
         Initialize 'article' (Self-contained syndicatable or reusable composition) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "article", void_element=False, attrs=attrs, children=children
@@ -1229,45 +1464,86 @@ class aside(BaseElement):
         Initialize 'aside' (Sidebar for tangentially related content) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "aside", void_element=False, attrs=attrs, children=children
@@ -1439,53 +1715,102 @@ class audio(BaseElement):
         Initialize 'audio' (Audio player) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param autoplay: Hint that the media resource can be started automatically when the page is loaded
-        :param controls: Show user agent controls
-        :param crossorigin: How the element handles crossorigin requests
-        :param loop: Whether to loop the media resource
-        :param muted: Whether to mute the media resource by default
-        :param preload: Hints how much buffering the media resource will likely need
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `autoplay` :
+            Hint that the media resource can be started automatically when the page is loaded
+        `controls` :
+            Show user agent controls
+        `crossorigin` :
+            How the element handles crossorigin requests
+        `loop` :
+            Whether to loop the media resource
+        `muted` :
+            Whether to mute the media resource by default
+        `preload` :
+            Hints how much buffering the media resource will likely need
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "audio", void_element=False, attrs=attrs, children=children
@@ -1660,45 +1985,86 @@ class b(BaseElement):
         Initialize 'b' (Keywords) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "b", void_element=False, attrs=attrs, children=children
@@ -1861,49 +2227,94 @@ class base(BaseElement):
         Initialize 'base' (Base URL and default target navigable for hyperlinks and forms) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param href: Document base URL
-            | Valid URL potentially surrounded by spaces
-        :param target: Default navigable for hyperlink navigation and form submission
-            | Valid navigable target name or keyword
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `href` :
+            Document base URL  
+        
+            Valid URL potentially surrounded by spaces
+        `target` :
+            Default navigable for hyperlink navigation and form submission  
+        
+            Valid navigable target name or keyword
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "base", void_element=True, attrs=attrs, children=children
@@ -2068,45 +2479,86 @@ class bdi(BaseElement):
         Initialize 'bdi' (Text directionality isolation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "bdi", void_element=False, attrs=attrs, children=children
@@ -2267,45 +2719,86 @@ class bdo(BaseElement):
         Initialize 'bdo' (Text directionality formatting) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "bdo", void_element=False, attrs=attrs, children=children
@@ -2467,47 +2960,90 @@ class blockquote(BaseElement):
         Initialize 'blockquote' (A section quoted from another source) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param cite: Link to the source of the quotation or more information about the edit
-            | Valid URL potentially surrounded by spaces
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `cite` :
+            Link to the source of the quotation or more information about the edit  
+        
+            Valid URL potentially surrounded by spaces
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "blockquote", void_element=False, attrs=attrs, children=children
@@ -2670,45 +3206,86 @@ class body(BaseElement):
         Initialize 'body' (Document body) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "body", void_element=False, attrs=attrs, children=children
@@ -2869,45 +3446,86 @@ class br(BaseElement):
         Initialize 'br' (Line break, e.g. in poem or postal address) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "br", void_element=True, attrs=attrs, children=children
@@ -3093,61 +3711,118 @@ class button(BaseElement):
         Initialize 'button' (Button control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param disabled: Whether the form control is disabled
-        :param form: Associates the element with a form element
-            | ID*
-        :param formaction: URL to use for form submission
-            | Valid non-empty URL potentially surrounded by spaces
-        :param formenctype: Entry list encoding type to use for form submission
-        :param formmethod: Variant to use for form submission
-        :param formnovalidate: Bypass form control validation for form submission
-        :param formtarget: Navigable for form submission
-            | Valid navigable target name or keyword
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param popovertarget: Targets a popover element to toggle, show, or hide
-            | ID*
-        :param popovertargetaction: Indicates whether a targeted popover element is to be toggled, shown, or hidden
-        :param type: Type of button
-        :param value: Value to be used for form submission
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `disabled` :
+            Whether the form control is disabled
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `formaction` :
+            URL to use for form submission  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `formenctype` :
+            Entry list encoding type to use for form submission
+        `formmethod` :
+            Variant to use for form submission
+        `formnovalidate` :
+            Bypass form control validation for form submission
+        `formtarget` :
+            Navigable for form submission  
+        
+            Valid navigable target name or keyword
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `popovertarget` :
+            Targets a popover element to toggle, show, or hide  
+        
+            ID*
+        `popovertargetaction` :
+            Indicates whether a targeted popover element is to be toggled, shown, or hidden
+        `type` :
+            Type of button
+        `value` :
+            Value to be used for form submission
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "button", void_element=False, attrs=attrs, children=children
@@ -3334,47 +4009,90 @@ class canvas(BaseElement):
         Initialize 'canvas' (Scriptable bitmap canvas) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param height: Vertical dimension
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `height` :
+            Vertical dimension
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "canvas", void_element=False, attrs=attrs, children=children
@@ -3539,45 +4257,86 @@ class caption(BaseElement):
         Initialize 'caption' (Table caption) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "caption", void_element=False, attrs=attrs, children=children
@@ -3738,45 +4497,86 @@ class cite(BaseElement):
         Initialize 'cite' (Title of a work) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "cite", void_element=False, attrs=attrs, children=children
@@ -3937,45 +4737,86 @@ class code(BaseElement):
         Initialize 'code' (Computer code) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "code", void_element=False, attrs=attrs, children=children
@@ -4137,47 +4978,90 @@ class col(BaseElement):
         Initialize 'col' (Table column) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param span: Number of columns spanned by the element
-            | Valid non-negative integer greater than zero
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `span` :
+            Number of columns spanned by the element  
+        
+            Valid non-negative integer greater than zero
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "col", void_element=True, attrs=attrs, children=children
@@ -4341,47 +5225,90 @@ class colgroup(BaseElement):
         Initialize 'colgroup' (Group of columns in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param span: Number of columns spanned by the element
-            | Valid non-negative integer greater than zero
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `span` :
+            Number of columns spanned by the element  
+        
+            Valid non-negative integer greater than zero
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "colgroup", void_element=False, attrs=attrs, children=children
@@ -4545,46 +5472,88 @@ class data(BaseElement):
         Initialize 'data' (Machine-readable equivalent) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param value: Machine-readable value
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `value` :
+            Machine-readable value
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "data", void_element=False, attrs=attrs, children=children
@@ -4747,45 +5716,86 @@ class datalist(BaseElement):
         Initialize 'datalist' (Container for options for combo box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "datalist", void_element=False, attrs=attrs, children=children
@@ -4946,45 +5956,86 @@ class dd(BaseElement):
         Initialize 'dd' (Content for corresponding dt element(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "dd", void_element=False, attrs=attrs, children=children
@@ -5147,49 +6198,94 @@ class del_(BaseElement):
         Initialize 'del' (A removal from the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param cite: Link to the source of the quotation or more information about the edit
-            | Valid URL potentially surrounded by spaces
-        :param datetime: Date and (optionally) time of the change
-            | Valid date string with optional time
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `cite` :
+            Link to the source of the quotation or more information about the edit  
+        
+            Valid URL potentially surrounded by spaces
+        `datetime` :
+            Date and (optionally) time of the change  
+        
+            Valid date string with optional time
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "del", void_element=False, attrs=attrs, children=children
@@ -5356,47 +6452,90 @@ class details(BaseElement):
         Initialize 'details' (Disclosure control for hiding details) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param name: Name of group of mutually-exclusive details elements
-        :param open: Whether the details are visible
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `name` :
+            Name of group of mutually-exclusive details elements
+        `open` :
+            Whether the details are visible
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "details", void_element=False, attrs=attrs, children=children
@@ -5561,45 +6700,86 @@ class dfn(BaseElement):
         Initialize 'dfn' (Defining instance) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "dfn", void_element=False, attrs=attrs, children=children
@@ -5761,46 +6941,88 @@ class dialog(BaseElement):
         Initialize 'dialog' (Dialog box or window) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param open: Whether the dialog box is showing
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `open` :
+            Whether the dialog box is showing
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "dialog", void_element=False, attrs=attrs, children=children
@@ -5963,45 +7185,86 @@ class div(BaseElement):
         Initialize 'div' (Generic flow container, or container for name-value groups in dl elements) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "div", void_element=False, attrs=attrs, children=children
@@ -6162,45 +7425,86 @@ class dl(BaseElement):
         Initialize 'dl' (Association list consisting of zero or more name-value groups) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "dl", void_element=False, attrs=attrs, children=children
@@ -6361,45 +7665,86 @@ class dt(BaseElement):
         Initialize 'dt' (Legend for corresponding dd element(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "dt", void_element=False, attrs=attrs, children=children
@@ -6560,45 +7905,86 @@ class em(BaseElement):
         Initialize 'em' (Stress emphasis) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "em", void_element=False, attrs=attrs, children=children
@@ -6763,51 +8149,98 @@ class embed(BaseElement):
         Initialize 'embed' (Plugin) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param height: Vertical dimension
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param type: Type of embedded resource
-            | Valid MIME type string
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `height` :
+            Vertical dimension
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `type` :
+            Type of embedded resource  
+        
+            Valid MIME type string
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "embed", void_element=True, attrs=attrs, children=children
@@ -6979,49 +8412,94 @@ class fieldset(BaseElement):
         Initialize 'fieldset' (Group of form controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param disabled: Whether the descendant form controls, except any inside legend, are disabled
-        :param form: Associates the element with a form element
-            | ID*
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `disabled` :
+            Whether the descendant form controls, except any inside legend, are disabled
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "fieldset", void_element=False, attrs=attrs, children=children
@@ -7188,45 +8666,86 @@ class figcaption(BaseElement):
         Initialize 'figcaption' (Caption for figure) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "figcaption", void_element=False, attrs=attrs, children=children
@@ -7387,45 +8906,86 @@ class figure(BaseElement):
         Initialize 'figure' (Figure with optional caption) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "figure", void_element=False, attrs=attrs, children=children
@@ -7586,45 +9146,86 @@ class footer(BaseElement):
         Initialize 'footer' (Footer for a page or section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "footer", void_element=False, attrs=attrs, children=children
@@ -7802,56 +9403,108 @@ class form(BaseElement):
         Initialize 'form' (User-submittable form) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accept_charset: Character encodings to use for form submission
-            | ASCII case-insensitive match for "UTF-8"
-        :param action: URL to use for form submission
-            | Valid non-empty URL potentially surrounded by spaces
-        :param autocomplete: Default setting for autofill feature for controls in the form
-        :param enctype: Entry list encoding type to use for form submission
-        :param method: Variant to use for form submission
-        :param name: Name of form to use in the document.forms API
-        :param novalidate: Bypass form control validation for form submission
-        :param target: Navigable for form submission
-            | Valid navigable target name or keyword
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accept_charset` :
+            Character encodings to use for form submission  
+        
+            ASCII case-insensitive match for "UTF-8"
+        `action` :
+            URL to use for form submission  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `autocomplete` :
+            Default setting for autofill feature for controls in the form
+        `enctype` :
+            Entry list encoding type to use for form submission
+        `method` :
+            Variant to use for form submission
+        `name` :
+            Name of form to use in the document.forms API
+        `novalidate` :
+            Bypass form control validation for form submission
+        `target` :
+            Navigable for form submission  
+        
+            Valid navigable target name or keyword
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "form", void_element=False, attrs=attrs, children=children
@@ -8028,45 +9681,86 @@ class h1(BaseElement):
         Initialize 'h1' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "h1", void_element=False, attrs=attrs, children=children
@@ -8227,45 +9921,86 @@ class h2(BaseElement):
         Initialize 'h2' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "h2", void_element=False, attrs=attrs, children=children
@@ -8426,45 +10161,86 @@ class h3(BaseElement):
         Initialize 'h3' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "h3", void_element=False, attrs=attrs, children=children
@@ -8625,45 +10401,86 @@ class h4(BaseElement):
         Initialize 'h4' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "h4", void_element=False, attrs=attrs, children=children
@@ -8824,45 +10641,86 @@ class h5(BaseElement):
         Initialize 'h5' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "h5", void_element=False, attrs=attrs, children=children
@@ -9023,45 +10881,86 @@ class h6(BaseElement):
         Initialize 'h6' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "h6", void_element=False, attrs=attrs, children=children
@@ -9222,45 +11121,86 @@ class head(BaseElement):
         Initialize 'head' (Container for document metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "head", void_element=False, attrs=attrs, children=children
@@ -9421,45 +11361,86 @@ class header(BaseElement):
         Initialize 'header' (Introductory or navigational aids for a page or section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "header", void_element=False, attrs=attrs, children=children
@@ -9620,45 +11601,86 @@ class hgroup(BaseElement):
         Initialize 'hgroup' (Heading container) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "hgroup", void_element=False, attrs=attrs, children=children
@@ -9819,45 +11841,86 @@ class hr(BaseElement):
         Initialize 'hr' (Thematic break) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "hr", void_element=True, attrs=attrs, children=children
@@ -10018,45 +12081,86 @@ class html(BaseElement):
         Initialize 'html' (Root element) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "html", void_element=False, attrs=attrs, children=children
@@ -10217,45 +12321,86 @@ class i(BaseElement):
         Initialize 'i' (Alternate voice) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "i", void_element=False, attrs=attrs, children=children
@@ -10426,61 +12571,118 @@ class iframe(BaseElement):
         Initialize 'iframe' (Child navigable) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param allow: Permissions policy to be applied to the iframe's contents
-            | Serialized permissions policy
-        :param allowfullscreen: Whether to allow the iframe's contents to use requestFullscreen()
-        :param height: Vertical dimension
-        :param loading: Used when determining loading deferral
-        :param name: Name of content navigable
-            | Valid navigable target name or keyword
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param sandbox: Security rules for nested content
-            | Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of "allow-downloads" "allow-forms" "allow-modals" "allow-orientation-lock" "allow-pointer-lock" "allow-popups" "allow-popups-to-escape-sandbox" "allow-presentation" "allow-same-origin" "allow-scripts" "allow-top-navigation" "allow-top-navigation-by-user-activation" "allow-top-navigation-to-custom-protocols"
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param srcdoc: A document to render in the iframe
-            | The source of an iframe srcdoc document*
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `allow` :
+            Permissions policy to be applied to the iframe's contents  
+        
+            Serialized permissions policy
+        `allowfullscreen` :
+            Whether to allow the iframe's contents to use requestFullscreen()
+        `height` :
+            Vertical dimension
+        `loading` :
+            Used when determining loading deferral
+        `name` :
+            Name of content navigable  
+        
+            Valid navigable target name or keyword
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `sandbox` :
+            Security rules for nested content  
+        
+            Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of "allow-downloads" "allow-forms" "allow-modals" "allow-orientation-lock" "allow-pointer-lock" "allow-popups" "allow-popups-to-escape-sandbox" "allow-presentation" "allow-same-origin" "allow-scripts" "allow-top-navigation" "allow-top-navigation-by-user-activation" "allow-top-navigation-to-custom-protocols"
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `srcdoc` :
+            A document to render in the iframe  
+        
+            The source of an iframe srcdoc document*
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "iframe", void_element=True, attrs=attrs, children=children
@@ -10678,63 +12880,122 @@ class img(BaseElement):
         Initialize 'img' (Image) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param alt: Replacement text for use when images are not available
-        :param crossorigin: How the element handles crossorigin requests
-        :param decoding: Decoding hint to use when processing this image for presentation
-        :param fetchpriority: Sets the priority for fetches initiated by the element
-        :param height: Vertical dimension
-        :param ismap: Whether the image is a server-side image map
-        :param loading: Used when determining loading deferral
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param sizes: Image sizes for different page layouts
-            | Valid source size list
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param srcset: Images to use in different situations, e.g., high-resolution displays, small monitors, etc.
-            | Comma-separated list of image candidate strings
-        :param usemap: Name of image map to use
-            | Valid hash-name reference*
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `alt` :
+            Replacement text for use when images are not available
+        `crossorigin` :
+            How the element handles crossorigin requests
+        `decoding` :
+            Decoding hint to use when processing this image for presentation
+        `fetchpriority` :
+            Sets the priority for fetches initiated by the element
+        `height` :
+            Vertical dimension
+        `ismap` :
+            Whether the image is a server-side image map
+        `loading` :
+            Used when determining loading deferral
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `sizes` :
+            Image sizes for different page layouts  
+        
+            Valid source size list
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `srcset` :
+            Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
+        
+            Comma-separated list of image candidate strings
+        `usemap` :
+            Name of image map to use  
+        
+            Valid hash-name reference*
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "img", void_element=True, attrs=attrs, children=children
@@ -10970,93 +13231,182 @@ class input(BaseElement):  # type: ignore[misc]
         Initialize 'input' (Form control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accept: Hint for expected file type in file upload controls
-            | Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*
-        :param alpha: Allow the color's alpha component to be set
-        :param alt: Replacement text for use when images are not available
-        :param autocomplete: Hint for form autofill feature
-            | Autofill field name and related tokens*
-        :param checked: Whether the control is checked
-        :param colorspace: The color space of the serialized color
-        :param dirname: Name of form control to use for sending the element's directionality in form submission
-        :param disabled: Whether the form control is disabled
-        :param form: Associates the element with a form element
-            | ID*
-        :param formaction: URL to use for form submission
-            | Valid non-empty URL potentially surrounded by spaces
-        :param formenctype: Entry list encoding type to use for form submission
-        :param formmethod: Variant to use for form submission
-        :param formnovalidate: Bypass form control validation for form submission
-        :param formtarget: Navigable for form submission
-            | Valid navigable target name or keyword
-        :param height: Vertical dimension
-        :param list: List of autocomplete options
-            | ID*
-        :param max: Maximum value
-            | Varies*
-        :param maxlength: Maximum length of value
-        :param min: Minimum value
-            | Varies*
-        :param minlength: Minimum length of value
-        :param multiple: Whether to allow multiple values
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param pattern: Pattern to be matched by the form control's value
-            | Regular expression matching the JavaScript Pattern production
-        :param placeholder: User-visible label to be placed within the form control
-        :param popovertarget: Targets a popover element to toggle, show, or hide
-            | ID*
-        :param popovertargetaction: Indicates whether a targeted popover element is to be toggled, shown, or hidden
-        :param readonly: Whether to allow the value to be edited by the user
-        :param required: Whether the control is required for form submission
-        :param size: Size of the control
-            | Valid non-negative integer greater than zero
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param step: Granularity to be matched by the form control's value
-        :param title: Description of pattern (when used with pattern attribute)
-        :param type: Type of form control
-            | input type keyword
-        :param value: Value of the form control
-            | Varies*
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accept` :
+            Hint for expected file type in file upload controls  
+        
+            Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*
+        `alpha` :
+            Allow the color's alpha component to be set
+        `alt` :
+            Replacement text for use when images are not available
+        `autocomplete` :
+            Hint for form autofill feature  
+        
+            Autofill field name and related tokens*
+        `checked` :
+            Whether the control is checked
+        `colorspace` :
+            The color space of the serialized color
+        `dirname` :
+            Name of form control to use for sending the element's directionality in form submission
+        `disabled` :
+            Whether the form control is disabled
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `formaction` :
+            URL to use for form submission  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `formenctype` :
+            Entry list encoding type to use for form submission
+        `formmethod` :
+            Variant to use for form submission
+        `formnovalidate` :
+            Bypass form control validation for form submission
+        `formtarget` :
+            Navigable for form submission  
+        
+            Valid navigable target name or keyword
+        `height` :
+            Vertical dimension
+        `list` :
+            List of autocomplete options  
+        
+            ID*
+        `max` :
+            Maximum value  
+        
+            Varies*
+        `maxlength` :
+            Maximum length of value
+        `min` :
+            Minimum value  
+        
+            Varies*
+        `minlength` :
+            Minimum length of value
+        `multiple` :
+            Whether to allow multiple values
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `pattern` :
+            Pattern to be matched by the form control's value  
+        
+            Regular expression matching the JavaScript Pattern production
+        `placeholder` :
+            User-visible label to be placed within the form control
+        `popovertarget` :
+            Targets a popover element to toggle, show, or hide  
+        
+            ID*
+        `popovertargetaction` :
+            Indicates whether a targeted popover element is to be toggled, shown, or hidden
+        `readonly` :
+            Whether to allow the value to be edited by the user
+        `required` :
+            Whether the control is required for form submission
+        `size` :
+            Size of the control  
+        
+            Valid non-negative integer greater than zero
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `step` :
+            Granularity to be matched by the form control's value
+        `title` :
+            Description of pattern (when used with pattern attribute)
+        `type` :
+            Type of form control  
+        
+            input type keyword
+        `value` :
+            Value of the form control  
+        
+            Varies*
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "input", void_element=True, attrs=attrs, children=children
@@ -11287,49 +13637,94 @@ class ins(BaseElement):
         Initialize 'ins' (An addition to the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param cite: Link to the source of the quotation or more information about the edit
-            | Valid URL potentially surrounded by spaces
-        :param datetime: Date and (optionally) time of the change
-            | Valid date string with optional time
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `cite` :
+            Link to the source of the quotation or more information about the edit  
+        
+            Valid URL potentially surrounded by spaces
+        `datetime` :
+            Date and (optionally) time of the change  
+        
+            Valid date string with optional time
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "ins", void_element=False, attrs=attrs, children=children
@@ -11494,45 +13889,86 @@ class kbd(BaseElement):
         Initialize 'kbd' (User input) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "kbd", void_element=False, attrs=attrs, children=children
@@ -11694,47 +14130,90 @@ class label(BaseElement):
         Initialize 'label' (Caption for a form control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param for_: Associate the label with form control
-            | ID*
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `for_` :
+            Associate the label with form control  
+        
+            ID*
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "label", void_element=False, attrs=attrs, children=children
@@ -11897,45 +14376,86 @@ class legend(BaseElement):
         Initialize 'legend' (Caption for fieldset) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "legend", void_element=False, attrs=attrs, children=children
@@ -12097,46 +14617,88 @@ class li(BaseElement):
         Initialize 'li' (List item) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param value: Ordinal value of the list item
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `value` :
+            Ordinal value of the list item
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "li", void_element=False, attrs=attrs, children=children
@@ -12319,74 +14881,144 @@ class link(BaseElement):  # type: ignore[misc]
         Initialize 'link' (Link metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param as_: Potential destination for a preload request (for rel="preload" and rel="modulepreload")
-            | Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
-        :param blocking: Whether the element is potentially render-blocking
-            | Unordered set of unique space-separated tokens*
-        :param color: Color to use when customizing a site's icon (for rel="mask-icon")
-            | CSS <color>
-        :param crossorigin: How the element handles crossorigin requests
-        :param disabled: Whether the link is disabled
-        :param fetchpriority: Sets the priority for fetches initiated by the element
-        :param href: Address of the hyperlink
-            | Valid non-empty URL potentially surrounded by spaces
-        :param hreflang: Language of the linked resource
-            | Valid BCP 47 language tag
-        :param imagesizes: Image sizes for different page layouts (for rel="preload")
-            | Valid source size list
-        :param imagesrcset: Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")
-            | Comma-separated list of image candidate strings
-        :param integrity: Integrity metadata used in Subresource Integrity checks [SRI]
-        :param media: Applicable media
-            | Valid media query list
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param rel: Relationship between the document containing the hyperlink and the destination resource
-            | Unordered set of unique space-separated tokens*
-        :param sizes: Sizes of the icons (for rel="icon")
-            | Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of sizes*
-        :param title: CSS style sheet set name
-        :param title: Title of the link
-        :param type: Hint for the type of the referenced resource
-            | Valid MIME type string
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `as_` :
+            Potential destination for a preload request (for rel="preload" and rel="modulepreload")  
+        
+            Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
+        `blocking` :
+            Whether the element is potentially render-blocking  
+        
+            Unordered set of unique space-separated tokens*
+        `color` :
+            Color to use when customizing a site's icon (for rel="mask-icon")  
+        
+            CSS <color>
+        `crossorigin` :
+            How the element handles crossorigin requests
+        `disabled` :
+            Whether the link is disabled
+        `fetchpriority` :
+            Sets the priority for fetches initiated by the element
+        `href` :
+            Address of the hyperlink  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `hreflang` :
+            Language of the linked resource  
+        
+            Valid BCP 47 language tag
+        `imagesizes` :
+            Image sizes for different page layouts (for rel="preload")  
+        
+            Valid source size list
+        `imagesrcset` :
+            Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")  
+        
+            Comma-separated list of image candidate strings
+        `integrity` :
+            Integrity metadata used in Subresource Integrity checks [SRI]
+        `media` :
+            Applicable media  
+        
+            Valid media query list
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `rel` :
+            Relationship between the document containing the hyperlink and the destination resource  
+        
+            Unordered set of unique space-separated tokens*
+        `sizes` :
+            Sizes of the icons (for rel="icon")  
+        
+            Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of sizes*
+        `title` :
+            CSS style sheet set name
+        `title` :
+            Title of the link
+        `type` :
+            Hint for the type of the referenced resource  
+        
+            Valid MIME type string
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "link", void_element=True, attrs=attrs, children=children
@@ -12579,45 +15211,86 @@ class main(BaseElement):
         Initialize 'main' (Container for the dominant contents of the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "main", void_element=False, attrs=attrs, children=children
@@ -12779,46 +15452,88 @@ class map(BaseElement):
         Initialize 'map' (Image map) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param name: Name of image map to reference from the usemap attribute
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `name` :
+            Name of image map to reference from the usemap attribute
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "map", void_element=False, attrs=attrs, children=children
@@ -12981,45 +15696,86 @@ class mark(BaseElement):
         Initialize 'mark' (Highlight) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "mark", void_element=False, attrs=attrs, children=children
@@ -13180,45 +15936,86 @@ class menu(BaseElement):
         Initialize 'menu' (Menu of commands) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "menu", void_element=False, attrs=attrs, children=children
@@ -13395,51 +16192,98 @@ class meta(BaseElement):
         Initialize 'meta' (Text metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param charset: Character encoding declaration
-        :param content: Value of the element
-        :param http_equiv: Pragma directive
-        :param media: Applicable media
-            | Valid media query list
-        :param name: Metadata name
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `charset` :
+            Character encoding declaration
+        `content` :
+            Value of the element
+        `http_equiv` :
+            Pragma directive
+        `media` :
+            Applicable media  
+        
+            Valid media query list
+        `name` :
+            Metadata name
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "meta", void_element=True, attrs=attrs, children=children
@@ -13616,51 +16460,98 @@ class meter(BaseElement):
         Initialize 'meter' (Gauge) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param high: Low limit of high range
-        :param low: High limit of low range
-        :param max: Upper bound of range
-        :param min: Lower bound of range
-        :param optimum: Optimum value in gauge
-        :param value: Current value of the element
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `high` :
+            Low limit of high range
+        `low` :
+            High limit of low range
+        `max` :
+            Upper bound of range
+        `min` :
+            Lower bound of range
+        `optimum` :
+            Optimum value in gauge
+        `value` :
+            Current value of the element
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "meter", void_element=False, attrs=attrs, children=children
@@ -13833,45 +16724,86 @@ class nav(BaseElement):
         Initialize 'nav' (Section with navigational links) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "nav", void_element=False, attrs=attrs, children=children
@@ -14032,45 +16964,86 @@ class noscript(BaseElement):
         Initialize 'noscript' (Fallback content for script) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "noscript", void_element=False, attrs=attrs, children=children
@@ -14237,55 +17210,106 @@ class object(BaseElement):
         Initialize 'object' (Image, child navigable, or plugin) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param data: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param form: Associates the element with a form element
-            | ID*
-        :param height: Vertical dimension
-        :param name: Name of content navigable
-            | Valid navigable target name or keyword
-        :param type: Type of embedded resource
-            | Valid MIME type string
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `data` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `height` :
+            Vertical dimension
+        `name` :
+            Name of content navigable  
+        
+            Valid navigable target name or keyword
+        `type` :
+            Type of embedded resource  
+        
+            Valid MIME type string
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "object", void_element=False, attrs=attrs, children=children
@@ -14461,48 +17485,92 @@ class ol(BaseElement):
         Initialize 'ol' (Ordered list) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param reversed: Number the list backwards
-        :param start: Starting value of the list
-        :param type: Kind of list marker
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `reversed` :
+            Number the list backwards
+        `start` :
+            Starting value of the list
+        `type` :
+            Kind of list marker
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "ol", void_element=False, attrs=attrs, children=children
@@ -14671,47 +17739,90 @@ class optgroup(BaseElement):
         Initialize 'optgroup' (Group of options in a list box) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param disabled: Whether the form control is disabled
-        :param label: User-visible label
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `disabled` :
+            Whether the form control is disabled
+        `label` :
+            User-visible label
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "optgroup", void_element=False, attrs=attrs, children=children
@@ -14880,49 +17991,94 @@ class option(BaseElement):
         Initialize 'option' (Option in a list box or combo box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param disabled: Whether the form control is disabled
-        :param label: User-visible label
-        :param selected: Whether the option is selected by default
-        :param value: Value to be used for form submission
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `disabled` :
+            Whether the form control is disabled
+        `label` :
+            User-visible label
+        `selected` :
+            Whether the option is selected by default
+        `value` :
+            Value to be used for form submission
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "option", void_element=False, attrs=attrs, children=children
@@ -15094,50 +18250,96 @@ class output(BaseElement):
         Initialize 'output' (Calculated output value) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param for_: Specifies controls from which the output was calculated
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param form: Associates the element with a form element
-            | ID*
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `for_` :
+            Specifies controls from which the output was calculated  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "output", void_element=False, attrs=attrs, children=children
@@ -15304,45 +18506,86 @@ class p(BaseElement):
         Initialize 'p' (Paragraph) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "p", void_element=False, attrs=attrs, children=children
@@ -15503,45 +18746,86 @@ class picture(BaseElement):
         Initialize 'picture' (Image) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "picture", void_element=False, attrs=attrs, children=children
@@ -15702,45 +18986,86 @@ class pre(BaseElement):
         Initialize 'pre' (Block of preformatted text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "pre", void_element=False, attrs=attrs, children=children
@@ -15903,47 +19228,90 @@ class progress(BaseElement):
         Initialize 'progress' (Progress bar) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param max: Upper bound of range
-        :param value: Current value of the element
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `max` :
+            Upper bound of range
+        `value` :
+            Current value of the element
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "progress", void_element=False, attrs=attrs, children=children
@@ -16109,47 +19477,90 @@ class q(BaseElement):
         Initialize 'q' (Quotation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param cite: Link to the source of the quotation or more information about the edit
-            | Valid URL potentially surrounded by spaces
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `cite` :
+            Link to the source of the quotation or more information about the edit  
+        
+            Valid URL potentially surrounded by spaces
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "q", void_element=False, attrs=attrs, children=children
@@ -16312,45 +19723,86 @@ class rp(BaseElement):
         Initialize 'rp' (Parenthesis for ruby annotation text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "rp", void_element=False, attrs=attrs, children=children
@@ -16511,45 +19963,86 @@ class rt(BaseElement):
         Initialize 'rt' (Ruby annotation text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "rt", void_element=False, attrs=attrs, children=children
@@ -16710,45 +20203,86 @@ class ruby(BaseElement):
         Initialize 'ruby' (Ruby annotation(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "ruby", void_element=False, attrs=attrs, children=children
@@ -16909,45 +20443,86 @@ class s(BaseElement):
         Initialize 's' (Inaccurate text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "s", void_element=False, attrs=attrs, children=children
@@ -17108,45 +20683,86 @@ class samp(BaseElement):
         Initialize 'samp' (Computer output) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "samp", void_element=False, attrs=attrs, children=children
@@ -17321,59 +20937,114 @@ class script(BaseElement):
         Initialize 'script' (Embedded script) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param async_: Execute script when available, without blocking while fetching
-        :param blocking: Whether the element is potentially render-blocking
-            | Unordered set of unique space-separated tokens*
-        :param crossorigin: How the element handles crossorigin requests
-        :param defer: Defer script execution
-        :param fetchpriority: Sets the priority for fetches initiated by the element
-        :param integrity: Integrity metadata used in Subresource Integrity checks [SRI]
-        :param nomodule: Prevents execution in user agents that support module scripts
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param type: Type of script
-            | "module"; a valid MIME type string that is not a JavaScript MIME type essence match
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `async_` :
+            Execute script when available, without blocking while fetching
+        `blocking` :
+            Whether the element is potentially render-blocking  
+        
+            Unordered set of unique space-separated tokens*
+        `crossorigin` :
+            How the element handles crossorigin requests
+        `defer` :
+            Defer script execution
+        `fetchpriority` :
+            Sets the priority for fetches initiated by the element
+        `integrity` :
+            Integrity metadata used in Subresource Integrity checks [SRI]
+        `nomodule` :
+            Prevents execution in user agents that support module scripts
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `type` :
+            Type of script  
+        
+            "module"; a valid MIME type string that is not a JavaScript MIME type essence match
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "script", void_element=False, attrs=attrs, children=children
@@ -17554,45 +21225,86 @@ class search(BaseElement):
         Initialize 'search' (Container for search controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "search", void_element=False, attrs=attrs, children=children
@@ -17753,45 +21465,86 @@ class section(BaseElement):
         Initialize 'section' (Generic document or application section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "section", void_element=False, attrs=attrs, children=children
@@ -17959,55 +21712,106 @@ class select(BaseElement):
         Initialize 'select' (List box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param autocomplete: Hint for form autofill feature
-            | Autofill field name and related tokens*
-        :param disabled: Whether the form control is disabled
-        :param form: Associates the element with a form element
-            | ID*
-        :param multiple: Whether to allow multiple values
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param required: Whether the control is required for form submission
-        :param size: Size of the control
-            | Valid non-negative integer greater than zero
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `autocomplete` :
+            Hint for form autofill feature  
+        
+            Autofill field name and related tokens*
+        `disabled` :
+            Whether the form control is disabled
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `multiple` :
+            Whether to allow multiple values
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `required` :
+            Whether the control is required for form submission
+        `size` :
+            Size of the control  
+        
+            Valid non-negative integer greater than zero
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "select", void_element=False, attrs=attrs, children=children
@@ -18183,46 +21987,88 @@ class slot(BaseElement):
         Initialize 'slot' (Shadow tree slot) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param name: Name of shadow tree slot
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `name` :
+            Name of shadow tree slot
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "slot", void_element=False, attrs=attrs, children=children
@@ -18385,45 +22231,86 @@ class small(BaseElement):
         Initialize 'small' (Side comment) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "small", void_element=False, attrs=attrs, children=children
@@ -18591,57 +22478,110 @@ class source(BaseElement):
         Initialize 'source' (Image source for img or media source for video or audio) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param height: Vertical dimension
-        :param media: Applicable media
-            | Valid media query list
-        :param sizes: Image sizes for different page layouts
-            | Valid source size list
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param srcset: Images to use in different situations, e.g., high-resolution displays, small monitors, etc.
-            | Comma-separated list of image candidate strings
-        :param type: Type of embedded resource
-            | Valid MIME type string
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `height` :
+            Vertical dimension
+        `media` :
+            Applicable media  
+        
+            Valid media query list
+        `sizes` :
+            Image sizes for different page layouts  
+        
+            Valid source size list
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `srcset` :
+            Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
+        
+            Comma-separated list of image candidate strings
+        `type` :
+            Type of embedded resource  
+        
+            Valid MIME type string
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "source", void_element=True, attrs=attrs, children=children
@@ -18816,45 +22756,86 @@ class span(BaseElement):
         Initialize 'span' (Generic phrasing container) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "span", void_element=False, attrs=attrs, children=children
@@ -19015,45 +22996,86 @@ class strong(BaseElement):
         Initialize 'strong' (Importance) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "strong", void_element=False, attrs=attrs, children=children
@@ -19216,49 +23238,94 @@ class style(BaseElement):  # type: ignore[misc]
         Initialize 'style' (Embedded styling information) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param blocking: Whether the element is potentially render-blocking
-            | Unordered set of unique space-separated tokens*
-        :param media: Applicable media
-            | Valid media query list
-        :param title: CSS style sheet set name
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `blocking` :
+            Whether the element is potentially render-blocking  
+        
+            Unordered set of unique space-separated tokens*
+        `media` :
+            Applicable media  
+        
+            Valid media query list
+        `title` :
+            CSS style sheet set name
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "style", void_element=False, attrs=attrs, children=children
@@ -19423,45 +23490,86 @@ class sub(BaseElement):
         Initialize 'sub' (Subscript) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "sub", void_element=False, attrs=attrs, children=children
@@ -19622,45 +23730,86 @@ class summary(BaseElement):
         Initialize 'summary' (Caption for details) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "summary", void_element=False, attrs=attrs, children=children
@@ -19821,45 +23970,86 @@ class sup(BaseElement):
         Initialize 'sup' (Superscript) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "sup", void_element=False, attrs=attrs, children=children
@@ -20020,45 +24210,86 @@ class svg(BaseElement):
         Initialize 'svg' (SVG root) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "svg", void_element=False, attrs=attrs, children=children
@@ -20219,45 +24450,86 @@ class table(BaseElement):
         Initialize 'table' (Table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "table", void_element=False, attrs=attrs, children=children
@@ -20418,45 +24690,86 @@ class tbody(BaseElement):
         Initialize 'tbody' (Group of rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "tbody", void_element=False, attrs=attrs, children=children
@@ -20620,50 +24933,96 @@ class td(BaseElement):
         Initialize 'td' (Table cell) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param colspan: Number of columns that the cell is to span
-            | Valid non-negative integer greater than zero
-        :param headers: The header cells for this cell
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param rowspan: Number of rows that the cell is to span
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `colspan` :
+            Number of columns that the cell is to span  
+        
+            Valid non-negative integer greater than zero
+        `headers` :
+            The header cells for this cell  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `rowspan` :
+            Number of rows that the cell is to span
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "td", void_element=False, attrs=attrs, children=children
@@ -20834,49 +25193,94 @@ class template(BaseElement):
         Initialize 'template' (Template) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param shadowrootclonable: Sets clonable on a declarative shadow root
-        :param shadowrootdelegatesfocus: Sets delegates focus on a declarative shadow root
-        :param shadowrootmode: Enables streaming declarative shadow roots
-        :param shadowrootserializable: Sets serializable on a declarative shadow root
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `shadowrootclonable` :
+            Sets clonable on a declarative shadow root
+        `shadowrootdelegatesfocus` :
+            Sets delegates focus on a declarative shadow root
+        `shadowrootmode` :
+            Enables streaming declarative shadow roots
+        `shadowrootserializable` :
+            Sets serializable on a declarative shadow root
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "template", void_element=True, attrs=attrs, children=children
@@ -21065,62 +25469,120 @@ class textarea(BaseElement):
         Initialize 'textarea' (Multiline text controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param autocomplete: Hint for form autofill feature
-            | Autofill field name and related tokens*
-        :param cols: Maximum number of characters per line
-            | Valid non-negative integer greater than zero
-        :param dirname: Name of form control to use for sending the element's directionality in form submission
-        :param disabled: Whether the form control is disabled
-        :param form: Associates the element with a form element
-            | ID*
-        :param maxlength: Maximum length of value
-        :param minlength: Minimum length of value
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param placeholder: User-visible label to be placed within the form control
-        :param readonly: Whether to allow the value to be edited by the user
-        :param required: Whether the control is required for form submission
-        :param rows: Number of lines to show
-            | Valid non-negative integer greater than zero
-        :param wrap: How the value of the form control is to be wrapped for form submission
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `autocomplete` :
+            Hint for form autofill feature  
+        
+            Autofill field name and related tokens*
+        `cols` :
+            Maximum number of characters per line  
+        
+            Valid non-negative integer greater than zero
+        `dirname` :
+            Name of form control to use for sending the element's directionality in form submission
+        `disabled` :
+            Whether the form control is disabled
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `maxlength` :
+            Maximum length of value
+        `minlength` :
+            Minimum length of value
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `placeholder` :
+            User-visible label to be placed within the form control
+        `readonly` :
+            Whether to allow the value to be edited by the user
+        `required` :
+            Whether the control is required for form submission
+        `rows` :
+            Number of lines to show  
+        
+            Valid non-negative integer greater than zero
+        `wrap` :
+            How the value of the form control is to be wrapped for form submission
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "textarea", void_element=False, attrs=attrs, children=children
@@ -21307,45 +25769,86 @@ class tfoot(BaseElement):
         Initialize 'tfoot' (Group of footer rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "tfoot", void_element=False, attrs=attrs, children=children
@@ -21513,52 +26016,100 @@ class th(BaseElement):
         Initialize 'th' (Table header cell) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param abbr: Alternative label to use for the header cell when referencing the cell in other contexts
-        :param colspan: Number of columns that the cell is to span
-            | Valid non-negative integer greater than zero
-        :param headers: The header cells for this cell
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param rowspan: Number of rows that the cell is to span
-        :param scope: Specifies which cells the header cell applies to
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `abbr` :
+            Alternative label to use for the header cell when referencing the cell in other contexts
+        `colspan` :
+            Number of columns that the cell is to span  
+        
+            Valid non-negative integer greater than zero
+        `headers` :
+            The header cells for this cell  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `rowspan` :
+            Number of rows that the cell is to span
+        `scope` :
+            Specifies which cells the header cell applies to
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "th", void_element=False, attrs=attrs, children=children
@@ -21729,45 +26280,86 @@ class thead(BaseElement):
         Initialize 'thead' (Group of heading rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "thead", void_element=False, attrs=attrs, children=children
@@ -21929,47 +26521,90 @@ class time(BaseElement):
         Initialize 'time' (Machine-readable equivalent of date- or time-related data) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param datetime: Machine-readable value
-            | Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `datetime` :
+            Machine-readable value  
+        
+            Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "time", void_element=False, attrs=attrs, children=children
@@ -22132,45 +26767,86 @@ class title(BaseElement):
         Initialize 'title' (Document title) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "title", void_element=False, attrs=attrs, children=children
@@ -22331,45 +27007,86 @@ class tr(BaseElement):
         Initialize 'tr' (Table row) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "tr", void_element=False, attrs=attrs, children=children
@@ -22546,52 +27263,100 @@ class track(BaseElement):
         Initialize 'track' (Timed text track) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param default: Enable the track if no other text track is more suitable
-        :param kind: The type of text track
-        :param label: User-visible label
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param srclang: Language of the text track
-            | Valid BCP 47 language tag
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `default` :
+            Enable the track if no other text track is more suitable
+        `kind` :
+            The type of text track
+        `label` :
+            User-visible label
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `srclang` :
+            Language of the text track  
+        
+            Valid BCP 47 language tag
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "track", void_element=True, attrs=attrs, children=children
@@ -22762,45 +27527,86 @@ class u(BaseElement):
         Initialize 'u' (Unarticulated annotation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "u", void_element=False, attrs=attrs, children=children
@@ -22961,45 +27767,86 @@ class ul(BaseElement):
         Initialize 'ul' (List) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "ul", void_element=False, attrs=attrs, children=children
@@ -23160,45 +28007,86 @@ class var(BaseElement):
         Initialize 'var' (Variable) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "var", void_element=False, attrs=attrs, children=children
@@ -23374,58 +28262,112 @@ class video(BaseElement):
         Initialize 'video' (Video player) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param autoplay: Hint that the media resource can be started automatically when the page is loaded
-        :param controls: Show user agent controls
-        :param crossorigin: How the element handles crossorigin requests
-        :param height: Vertical dimension
-        :param loop: Whether to loop the media resource
-        :param muted: Whether to mute the media resource by default
-        :param playsinline: Encourage the user agent to display video content within the element's playback area
-        :param poster: Poster frame to show prior to video playback
-            | Valid non-empty URL potentially surrounded by spaces
-        :param preload: Hints how much buffering the media resource will likely need
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `autoplay` :
+            Hint that the media resource can be started automatically when the page is loaded
+        `controls` :
+            Show user agent controls
+        `crossorigin` :
+            How the element handles crossorigin requests
+        `height` :
+            Vertical dimension
+        `loop` :
+            Whether to loop the media resource
+        `muted` :
+            Whether to mute the media resource by default
+        `playsinline` :
+            Encourage the user agent to display video content within the element's playback area
+        `poster` :
+            Poster frame to show prior to video playback  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `preload` :
+            Hints how much buffering the media resource will likely need
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "video", void_element=False, attrs=attrs, children=children
@@ -23608,45 +28550,86 @@ class wbr(BaseElement):
         Initialize 'wbr' (Line breaking opportunity) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """  # fmt: skip
         super().__init__(
             "wbr", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/live/__init__.py
+++ b/src/html_compose/live/__init__.py
@@ -1,0 +1,5 @@
+from .live_server import live_server
+from .watcher import ShellCommand, WatchCond, Watcher
+
+server = live_server
+__all__ = ["server", "ShellCommand", "WatchCond", "Watcher"]

--- a/src/html_compose/live/live_server.py
+++ b/src/html_compose/live/live_server.py
@@ -6,27 +6,50 @@ from .watcher import ShellCommand, WatchCond, Watcher
 
 def live_server(
     daemon: ShellCommand,
-    daemon_delay: int,
+    daemon_delay: float,
     conds: list[WatchCond],
-    no_inotify: bool = False,
-    host="localhost",
-    port="51353",
+    force_polling: bool = False,
+    host: str = "localhost",
+    port: int = 51353,
     print_paths=True,
     loop_delay=1,
 ) -> None:
-    w = Watcher(conds, no_inotify)
+    """
+    Run a live-reload server that also runs and reloads your Python server.
+
+    Delays are deduplicated after file changes by various delay properties
+    to prevent chains of restarts.
+
+    :param daemon: Command to run in the background, typically a Python server
+    :type daemon: ShellCommand
+    :param daemon_delay: Delay in seconds before restarting the daemon after a change.
+    :type daemon_delay: float
+    :param conds: List of watch conditions, which are a path and action.
+    :type conds:
+    :param force_polling: Force slow stat() polling backend - useful if your platform is unable to support OS based watching.
+    :type force_polling: bool
+    :param host: Host for livereload server websocket to listen on
+    :type host: str
+    :param port: Port for livereload server websocket to listen on
+    :type port: int
+    :param print_paths: Enumerate paths being monitored
+    :type print_paths:
+    :param loop_delay: Set delay between checks for changes. Usually unnecessary.
+    :type loop_delay:
+    """
+    w = Watcher(conds, force_polling=force_polling)
     oh = w.overhead()
     if print_paths:
         for path in oh["paths"]:
-            print(f"Monitoring {path}")
+            print(f"Monitoring for changes: {path}")
 
-    if w.has_inotify:
+    if not w.force_polling:
         print(
-            f"Monitoring {oh['path_count']} paths via inotify and "
-            f"{oh['recursive_count']} recursive paths"
+            f"Monitoring {oh['path_count']} path(s) via RustNotify. "
+            f"{oh['recursive_count']} path(s) are monitored recursively."
         )
     else:
-        print(f"Monitoring {oh['path_count']} paths for changes via stat")
+        print(f"Monitoring {oh['path_count']} path(s) for changes via polling")
 
     # Set livereload environment variables
     daemon.env.update(generate_livereload_env(host, port))
@@ -38,7 +61,7 @@ def live_server(
             hits = w.changed()
             if hits:
                 paths_hit = set()
-                conds_hit = set()
+                conds_hit: set[WatchCond] = set()
                 for hit in hits:
                     paths_hit.add(hit.path)
 
@@ -48,18 +71,27 @@ def live_server(
                 for path in paths_hit:
                     print(f"Changed: {path}")
 
-                delay = 0
+                delay = 0.0
+                reload_tripped = False
                 for cond in conds_hit:
-                    delay = max(delay, cond.delay)
                     cond.run()
-                daemon_cmd.delay = delay + daemon_delay
-                print(f"Reloading daemon after {daemon_cmd.delay} seconds...")
-                daemon_cmd.run()
+                    if cond.no_reload:
+                        continue
+                    delay = max(delay, cond.delay)
+                    reload_tripped = True
+
+                if reload_tripped:
+                    daemon_cmd.delay = delay + daemon_delay
+                    print(
+                        f"Reloading daemon after {daemon_cmd.delay} seconds..."
+                    )
+                    daemon_cmd.run()
             sleep(loop_delay)
     except KeyboardInterrupt:
-        # Stop inotify and daemon
-        if w.notifier:
-            w.notifier.stop()
+        print("Exiting...")
+    finally:
+        for watch in w.rust_watches:
+            watch.close()
 
         if daemon_cmd.process:
             proc = daemon_cmd.process

--- a/src/html_compose/live/live_server.py
+++ b/src/html_compose/live/live_server.py
@@ -66,10 +66,10 @@ def live_server(
     daemon.env.update(generate_livereload_env(host, port))
 
     daemon_task = ProcessTask(daemon, delay=0, sync=False)
-
     # Run livereload server
     server = run_server(host, port)
     tr = TaskRunner()
+    tr.add_task(daemon_task)
     tr.run()  # Start task runner thread
     pending_reload: set[str] = set()
 

--- a/src/html_compose/live/live_server.py
+++ b/src/html_compose/live/live_server.py
@@ -1,0 +1,67 @@
+from time import sleep
+
+from ..util_funcs import generate_livereload_env
+from .watcher import ShellCommand, WatchCond, Watcher
+
+
+def live_server(
+    daemon: ShellCommand,
+    daemon_delay: int,
+    conds: list[WatchCond],
+    no_inotify: bool = False,
+    host="localhost",
+    port="51353",
+    print_paths=True,
+    loop_delay=1,
+) -> None:
+    w = Watcher(conds, no_inotify)
+    oh = w.overhead()
+    if print_paths:
+        for path in oh["paths"]:
+            print(f"Monitoring {path}")
+
+    if w.has_inotify:
+        print(
+            f"Monitoring {oh['path_count']} paths via inotify and "
+            f"{oh['recursive_count']} recursive paths"
+        )
+    else:
+        print(f"Monitoring {oh['path_count']} paths for changes via stat")
+
+    # Set livereload environment variables
+    daemon.env.update(generate_livereload_env(host, port))
+
+    daemon_cmd = WatchCond(path_glob="", action=daemon)
+    daemon_cmd.run()
+    try:
+        while True:
+            hits = w.changed()
+            if hits:
+                paths_hit = set()
+                conds_hit = set()
+                for hit in hits:
+                    paths_hit.add(hit.path)
+
+                    for cond in hit.conds:
+                        conds_hit.add(cond)
+
+                for path in paths_hit:
+                    print(f"Changed: {path}")
+
+                delay = 0
+                for cond in conds_hit:
+                    delay = max(delay, cond.delay)
+                    cond.run()
+                daemon_cmd.delay = delay + daemon_delay
+                print(f"Reloading daemon after {daemon_cmd.delay} seconds...")
+                daemon_cmd.run()
+            sleep(loop_delay)
+    except KeyboardInterrupt:
+        # Stop inotify and daemon
+        if w.notifier:
+            w.notifier.stop()
+
+        if daemon_cmd.process:
+            proc = daemon_cmd.process
+            proc.terminate()
+            proc.wait()

--- a/src/html_compose/live/livereload_server.py
+++ b/src/html_compose/live/livereload_server.py
@@ -1,0 +1,70 @@
+import json
+import threading
+from time import sleep
+from typing import Optional
+
+from websockets.sync.server import Server, serve
+
+sockets = set()
+server: Optional[Server] = None
+
+
+def run_ws(websocket):
+    """
+    Run livereload-js websocket server.
+    ref: https://web.archive.org/web/20180208220539/http://livereload.com/api/protocol/
+    """
+    sockets.add(websocket)
+    try:
+        for message in websocket:
+            msg = json.loads(message)
+            command = msg["command"]
+            # Each client MUST be greeted with a hello
+            if command == "hello":
+                protocols = msg["protocols"]
+                our_protocol = "http://livereload.com/protocols/official-7"
+
+                assert our_protocol in protocols, "Expected protocol not found"
+
+                websocket.send(
+                    json.dumps(
+                        {"command": "hello", "protocols": [our_protocol]}
+                    )
+                )
+            # We ignore all other commands for now
+    finally:
+        sockets.remove(websocket)
+
+
+def reload_because(paths: list[str]) -> None:
+    """
+    Trigger a livereload in the browser
+    Provide list of paths to livereload-js
+    Not really sure why we're sending paths, but that's how it's done in livereload-js
+    """
+    for socket in sockets:
+        for path in paths:
+            socket.send(json.dumps({"command": "reload", "path": path}))
+
+
+def live_reloader(host, port):
+    with serve(run_ws, host, port) as srv:
+        global server
+        server = srv
+        server.serve_forever()
+
+
+def close():
+    if server:
+        server.shutdown()
+
+
+def run_server(host, port) -> Server:
+    print(f"Starting livereload WebSocket server at ws://{host}:{port}")
+    threading.Thread(
+        target=live_reloader, args=(host, port), daemon=True
+    ).start()
+    global server
+    while server is None:
+        sleep(0.25)
+    return server

--- a/src/html_compose/live/watcher.py
+++ b/src/html_compose/live/watcher.py
@@ -1,25 +1,29 @@
 import glob
 import os
-import re
 import stat
 import subprocess
-from fnmatch import fnmatch
+from pathlib import Path
 from threading import Thread
 from time import sleep, time
 from typing import Callable, Optional, Union
 
-try:
-    import pyinotify
-except ImportError:
-    pyinotify = None
+from watchfiles._rust_notify import RustNotify
+
+from .. import util_funcs
+
+CWD = Path(".").absolute()
 
 
 class ShellCommand:
     def __init__(
-        self, command: Union[str, list[str]], env: Optional[list[str]] = None
+        self,
+        command: Union[str, list[str]],
+        env: Optional[dict[str, str]] = None,
     ):
         self.command = command
         self.env = os.environ.copy()
+        if env:
+            self.env.update(env)
 
 
 class WatchCond:
@@ -30,9 +34,10 @@ class WatchCond:
     def __init__(
         self,
         path_glob: Union[str, list[str]],
-        action: Union[ShellCommand, Callable],
+        action: Optional[Union[ShellCommand, Callable]],
         ignore_glob: Optional[Union[str, list[str]]] = None,
         delay: float = 0,
+        no_reload: bool = False,
     ):
         """
         Initialize a WatchCond.
@@ -42,8 +47,9 @@ class WatchCond:
         :param ignore_glob: Glob patterns to ignore.
         :param delay: Delay in seconds before running the action after a change.
 
+                      The timer resets after each change to de-duplicate file change events.
+        :param no_reload: If True, do not reload the daemon after a change. This is useful for generators like sass.
 
-                      The timer resets after each change.
         """
         self.path_glob = path_glob
         if isinstance(path_glob, str):
@@ -59,23 +65,26 @@ class WatchCond:
         self.action = action
         self.delay = delay
         self.update_count = 0
+        self.no_reload = no_reload
         self.process: Optional[subprocess.Popen] = None
 
     def try_path_hit(self, path: str) -> bool:
         """Check if a given path matches any of the glob patterns."""
 
-        for glob_pattern in self.ignore_glob:
-            if fnmatch(path, glob_pattern):
+        for pattern in self.ignore_glob:
+            if util_funcs.glob_matcher(pattern, path):
                 return True
 
-        for glob_pattern in self.path_glob:
-            if fnmatch(path, glob_pattern):
+        for pattern in self.path_glob:
+            if util_funcs.glob_matcher(pattern, path):
                 return True
 
         return False
 
     def run(self):
         """Run the action for changes."""
+        if not self.action:
+            return
 
         def _run(update_id):
             # Delay mechanism:
@@ -106,8 +115,16 @@ class WatchCond:
             if callable(self.action):
                 self.action()
             else:
+                if not isinstance(self.action, ShellCommand):
+                    raise ValueError(
+                        "Action must be a ShellCommand or callable"
+                    )
+
+                # If the command is an array, pass it directly
+                # If it's a string, it's a shell command
+                shell = isinstance(self.action.command, str)
                 self.process = subprocess.Popen(
-                    self.action.command, shell=True, env=self.action.env
+                    self.action.command, shell=shell, env=self.action.env
                 )
 
         if self.delay > 0:
@@ -125,35 +142,55 @@ class Hit:
 class Watcher:
     """Simple file watcher with support for both stat and inotify."""
 
-    def __init__(self, conds: list[WatchCond], no_inotify=False):
-        self.mtimes = {}
-        self.changes = []
+    def __init__(self, conds: list[WatchCond], force_polling: bool):
         self.conds = conds
         self.watch_globs = []
-        self.inotify_paths = set()
-        self.notifier = None
-        # Setup inotify if available
-        self.has_inotify = pyinotify is not None and not no_inotify
-        if self.has_inotify:
-            self.wm = pyinotify.WatchManager()
-            self.notifier = None
-            self._setup_inotify()
+        self.mtimes: dict[str, int] = {}
+        self.force_polling = force_polling
+
         for cond in conds:
             for g in cond.path_glob:
-                self.add_pattern(g)
+                self.watch_globs.append(g)
 
-        if self.has_inotify:
-            self._watch_inotify()
-            pass
+        self.rust_watches = []
+        if not self.force_polling:
+            recursive = []
+            non_recursive = []
+            for path, is_recursive in self._get_fswatch_dirs():
+                if is_recursive:
+                    recursive.append(path)
+                else:
+                    non_recursive.append(path)
+            if recursive:
+                rn = RustNotify(
+                    recursive,
+                    recursive=True,
+                    debug=False,
+                    force_polling=False,
+                    poll_delay_ms=0,
+                    ignore_permission_denied=True,
+                )
+                self.rust_watches.append(rn)
+            if non_recursive:
+                nr = RustNotify(
+                    non_recursive,
+                    recursive=False,
+                    debug=False,
+                    force_polling=False,
+                    poll_delay_ms=0,
+                    ignore_permission_denied=True,
+                )
+                self.rust_watches.append(nr)
 
     def overhead(self):
-        if self.has_inotify:
+        if not self.force_polling:
             recursive_count = 0
             dirs = set()
-            for wglob, recursive in self.inotify_paths:
+            fswatch_dirs = self._get_fswatch_dirs()
+            for path, recursive in fswatch_dirs:
                 if recursive:
                     recursive_count += 1
-                dirs.add(wglob)
+                dirs.add(path)
             return {
                 "path_count": len(dirs),
                 "recursive_count": recursive_count,
@@ -163,71 +200,45 @@ class Watcher:
             paths = list(self._resolve_paths())
             return {"path_count": len(list(paths)), "paths": paths}
 
-    def _setup_inotify(self):
-        """Setup inotify event handler."""
+    def _get_fswatch_dirs(self):
+        # We handle a few kinds of watch expressions:
+        # dir/: Watch dir/ recursively
+        # ./file.py: Watch just a single file
+        # ./src/*.py: Watch ./src/ non-recursively for .py files
+        # dir/**/*.py: Watch dir/ recursively
+        # **/*.py: watch ./ recursively
+        dirs = set()
+        for cond in self.conds:
+            for pattern in cond.path_glob:
+                recursive = False
+                if pattern.endswith("/"):
+                    recursive = True
 
-        class EventHandler(pyinotify.ProcessEvent):
-            def __init__(self, watcher: Watcher):
-                self.watcher = watcher
+                path_component = Path(pattern)
+                if "**" in path_component.parts:
+                    recursive = True
+                    for i, part in reversed(
+                        list(enumerate(path_component.parts))
+                    ):
+                        if part == "**":
+                            pattern = str(Path(*path_component.parts[0:i]))
+                            if not pattern:
+                                pattern = "."
 
-            def process_default(self, event):
-                if not event.dir and os.path.isfile(event.pathname):
-                    rule_hits = self.watcher._get_matching_rules(event.pathname)
-                    if rule_hits:
-                        self.watcher.changes.append(
-                            Hit(event.pathname, rule_hits)
-                        )
+                for p in glob.glob(pattern):
+                    path = Path(p)
+                    if not recursive and path.is_file():
+                        # If this is a file glob, get the containing dir
+                        p = path.parent
 
-        self.handler = EventHandler(self)
-        self.notifier = pyinotify.ThreadedNotifier(self.wm, self.handler)
-        self.notifier.start()
+                    as_t = (str(p), recursive)
+                    if as_t in dirs:
+                        continue
 
-    def _watch_inotify(self):
-        for wglob in self.watch_globs:
-            recursive = False
-            if wglob.endswith("/"):
-                recursive = True
-            re_parse = re.search(r"^(.*)[*]{2}", wglob)
-            if re_parse:
-                wglob = re_parse.group(1)
-                recursive = True
-            if not recursive:
-                wglob = os.path.dirname(wglob)
-                if not wglob:
-                    wglob = "."
-            as_t = (wglob, recursive)
-            if as_t in self.inotify_paths:
-                continue
+                    dirs.add(as_t)
+        return dirs
 
-            self.inotify_paths.add(as_t)
-            mask = (
-                pyinotify.IN_MODIFY | pyinotify.IN_CREATE | pyinotify.IN_DELETE
-            )
-            self.wm.add_watch(wglob, mask, do_glob=True, rec=recursive)
-
-    def add_pattern(self, pattern):
-        """Add a glob pattern to watch."""
-
-        # Add to inotify if possible
-        if self.has_inotify:
-            # Extract directory part from glob
-            dir_path = os.path.dirname(pattern)
-            if not dir_path:
-                dir_path = "."
-
-            if dir_path in self.watch_globs:
-                # Already watching, ignore
-                return
-            self.watch_globs.append(pattern)
-            # Watch the directory containing the glob
-            mask = (
-                pyinotify.IN_MODIFY | pyinotify.IN_CREATE | pyinotify.IN_DELETE
-            )
-            self.wm.add_watch(dir_path, mask, do_glob=True, rec=True)
-        else:
-            self.watch_globs.append(pattern)
-
-    def _get_matching_rules(self, path) -> Optional[list[WatchCond]]:
+    def _get_matching_rules(self, path) -> list[WatchCond]:
         """Find the first glob pattern that matches the path."""
         rules = []
         for cond in self.conds:
@@ -235,7 +246,7 @@ class Watcher:
             if cond.try_path_hit(path):
                 rules.append(cond)
 
-        return rules if rules else None
+        return rules
 
     def _resolve_paths(self):
         """Resolve all glob patterns to file paths."""
@@ -247,23 +258,7 @@ class Watcher:
                     if cond.try_path_hit(match):
                         yield match
 
-    def changed(self) -> list[Hit]:
-        """Check if any watched files have changed.
-
-        Returns (path, matching_glob) if a change was detected, None otherwise.
-        """
-        # Return any queued inotify changes first
-        if self.changes:
-            changes = self.changes
-            self.changes = []
-
-            return changes
-
-        # Don't stat if inotify is available and just had nothing
-        if self.has_inotify:
-            return
-
-        # Fall back to stat-based checking
+    def stat_watcher(self):
         paths = self._resolve_paths()
         changes = []
         current_mtimes = {}
@@ -286,7 +281,7 @@ class Watcher:
                 # Might be deleted, we'll catch it later
                 continue
 
-            current_mtimes[path] = mtime
+            current_mtimes[path] = int(mtime)
             old_mtime = self.mtimes.get(path, None)
 
             if old_mtime != mtime:
@@ -302,4 +297,48 @@ class Watcher:
                     changes.append(Hit(path, matching_rules))
 
         self.mtimes = current_mtimes
+        return changes
+
+    def changed(self) -> list[Hit]:
+        """Check if any watched files have changed.
+
+        Returns (path, matching_glob) if a change was detected, None otherwise.
+        """
+        if self.force_polling:
+            return self.stat_watcher()
+
+        changes = []
+        for watch in self.rust_watches:
+            # Check and immediately return
+            result = watch.watch(
+                debounce_ms=100, step_ms=1, timeout_ms=1, stop_event=None
+            )
+            if result == "signal":
+                # Probably a ctrl + C
+                raise KeyboardInterrupt()
+            if result == "timeout":
+                continue
+            # We don't have a stop event and that's the only other type.
+            # Alas, ignore it.
+            if isinstance(result, str):
+                print(
+                    "watcher: Not sure what to do with",
+                    repr(result),
+                    " submit a git issue to html-compose",
+                )
+                continue
+
+            assert isinstance(result, set), (
+                f"Unexpected result type: {type(result)}"
+            )
+
+            result_tuples: set[tuple[int, str]] = result
+            for watch_id, path in result_tuples:
+                # RustWatch returns full paths, convert to relative
+                path = str(Path(path).relative_to(CWD))
+                matching_rules = self._get_matching_rules(path)
+                if matching_rules:
+                    changes.append(Hit(path, matching_rules))
+                else:
+                    print(f"No matching rules for {path}")
         return changes

--- a/src/html_compose/live/watcher.py
+++ b/src/html_compose/live/watcher.py
@@ -339,6 +339,5 @@ class Watcher:
                 matching_rules = self._get_matching_rules(path)
                 if matching_rules:
                     changes.append(Hit(path, matching_rules))
-                else:
-                    print(f"No matching rules for {path}")
+
         return changes

--- a/src/html_compose/live/watcher.py
+++ b/src/html_compose/live/watcher.py
@@ -10,7 +10,7 @@ from typing import Callable, Optional, Union
 
 from watchfiles._rust_notify import RustNotify
 
-from .. import util_funcs
+from ..util_funcs import glob_matcher
 
 CWD = Path(".").absolute()
 
@@ -175,11 +175,11 @@ class WatchCond:
         """Check if a given path matches any of the glob patterns."""
 
         for pattern in self.ignore_glob:
-            if util_funcs.glob_matcher(pattern, path):
+            if glob_matcher(pattern, path):
                 return True
 
         for pattern in self.path_glob:
-            if util_funcs.glob_matcher(pattern, path):
+            if glob_matcher(pattern, path):
                 return True
 
         return False

--- a/src/html_compose/live/watcher.py
+++ b/src/html_compose/live/watcher.py
@@ -1,0 +1,305 @@
+import glob
+import os
+import re
+import stat
+import subprocess
+from fnmatch import fnmatch
+from threading import Thread
+from time import sleep, time
+from typing import Callable, Optional, Union
+
+try:
+    import pyinotify
+except ImportError:
+    pyinotify = None
+
+
+class ShellCommand:
+    def __init__(
+        self, command: Union[str, list[str]], env: Optional[list[str]] = None
+    ):
+        self.command = command
+        self.env = os.environ.copy()
+
+
+class WatchCond:
+    """
+    A condition for watching file(s) and trigger action.
+    """
+
+    def __init__(
+        self,
+        path_glob: Union[str, list[str]],
+        action: Union[ShellCommand, Callable],
+        ignore_glob: Optional[Union[str, list[str]]] = None,
+        delay: float = 0,
+    ):
+        """
+        Initialize a WatchCond.
+
+        :param path_glob: Glob pattern(s) to watch for changes.
+        :param action: Action to run when a change is detected. Shell command or function.
+        :param ignore_glob: Glob patterns to ignore.
+        :param delay: Delay in seconds before running the action after a change.
+
+
+                      The timer resets after each change.
+        """
+        self.path_glob = path_glob
+        if isinstance(path_glob, str):
+            self.path_glob = [path_glob]
+
+        if not ignore_glob:
+            ignore_glob = []
+
+        if isinstance(ignore_glob, str):
+            self.ignore_glob = [ignore_glob]
+        else:
+            self.ignore_glob = ignore_glob
+        self.action = action
+        self.delay = delay
+        self.update_count = 0
+        self.process: Optional[subprocess.Popen] = None
+
+    def try_path_hit(self, path: str) -> bool:
+        """Check if a given path matches any of the glob patterns."""
+
+        for glob_pattern in self.ignore_glob:
+            if fnmatch(path, glob_pattern):
+                return True
+
+        for glob_pattern in self.path_glob:
+            if fnmatch(path, glob_pattern):
+                return True
+
+        return False
+
+    def run(self):
+        """Run the action for changes."""
+
+        def _run(update_id):
+            # Delay mechanism:
+            # We sleep for small periods before running the action
+            # If the hit mechanism fires in the middle of a delay,
+            # we just stop.
+            if self.delay:
+                delay = self.delay
+                start = time()
+                while delay > 2 and self.update_count == update_id:
+                    now = time()
+                    delay -= now - start
+                    start = now
+                    sleep(1)
+
+                if self.delay > 0:
+                    sleep(self.delay)
+
+                if self.update_count != update_id:
+                    # Let someone else start a delay thread
+                    return
+
+            if self.process:
+                self.process.terminate()
+                # Wait on the process to actually end
+                self.process.wait()
+
+            if callable(self.action):
+                self.action()
+            else:
+                self.process = subprocess.Popen(
+                    self.action.command, shell=True, env=self.action.env
+                )
+
+        if self.delay > 0:
+            Thread(target=_run, args=(self.update_count,), daemon=True).start()
+        else:
+            _run(self.update_count)
+
+
+class Hit:
+    def __init__(self, path: str, conds: list[WatchCond]):
+        self.path = path
+        self.conds = conds
+
+
+class Watcher:
+    """Simple file watcher with support for both stat and inotify."""
+
+    def __init__(self, conds: list[WatchCond], no_inotify=False):
+        self.mtimes = {}
+        self.changes = []
+        self.conds = conds
+        self.watch_globs = []
+        self.inotify_paths = set()
+        self.notifier = None
+        # Setup inotify if available
+        self.has_inotify = pyinotify is not None and not no_inotify
+        if self.has_inotify:
+            self.wm = pyinotify.WatchManager()
+            self.notifier = None
+            self._setup_inotify()
+        for cond in conds:
+            for g in cond.path_glob:
+                self.add_pattern(g)
+
+        if self.has_inotify:
+            self._watch_inotify()
+            pass
+
+    def overhead(self):
+        if self.has_inotify:
+            recursive_count = 0
+            dirs = set()
+            for wglob, recursive in self.inotify_paths:
+                if recursive:
+                    recursive_count += 1
+                dirs.add(wglob)
+            return {
+                "path_count": len(dirs),
+                "recursive_count": recursive_count,
+                "paths": dirs,
+            }
+        else:
+            paths = list(self._resolve_paths())
+            return {"path_count": len(list(paths)), "paths": paths}
+
+    def _setup_inotify(self):
+        """Setup inotify event handler."""
+
+        class EventHandler(pyinotify.ProcessEvent):
+            def __init__(self, watcher: Watcher):
+                self.watcher = watcher
+
+            def process_default(self, event):
+                if not event.dir and os.path.isfile(event.pathname):
+                    rule_hits = self.watcher._get_matching_rules(event.pathname)
+                    if rule_hits:
+                        self.watcher.changes.append(
+                            Hit(event.pathname, rule_hits)
+                        )
+
+        self.handler = EventHandler(self)
+        self.notifier = pyinotify.ThreadedNotifier(self.wm, self.handler)
+        self.notifier.start()
+
+    def _watch_inotify(self):
+        for wglob in self.watch_globs:
+            recursive = False
+            if wglob.endswith("/"):
+                recursive = True
+            re_parse = re.search(r"^(.*)[*]{2}", wglob)
+            if re_parse:
+                wglob = re_parse.group(1)
+                recursive = True
+            if not recursive:
+                wglob = os.path.dirname(wglob)
+                if not wglob:
+                    wglob = "."
+            as_t = (wglob, recursive)
+            if as_t in self.inotify_paths:
+                continue
+
+            self.inotify_paths.add(as_t)
+            mask = (
+                pyinotify.IN_MODIFY | pyinotify.IN_CREATE | pyinotify.IN_DELETE
+            )
+            self.wm.add_watch(wglob, mask, do_glob=True, rec=recursive)
+
+    def add_pattern(self, pattern):
+        """Add a glob pattern to watch."""
+
+        # Add to inotify if possible
+        if self.has_inotify:
+            # Extract directory part from glob
+            dir_path = os.path.dirname(pattern)
+            if not dir_path:
+                dir_path = "."
+
+            if dir_path in self.watch_globs:
+                # Already watching, ignore
+                return
+            self.watch_globs.append(pattern)
+            # Watch the directory containing the glob
+            mask = (
+                pyinotify.IN_MODIFY | pyinotify.IN_CREATE | pyinotify.IN_DELETE
+            )
+            self.wm.add_watch(dir_path, mask, do_glob=True, rec=True)
+        else:
+            self.watch_globs.append(pattern)
+
+    def _get_matching_rules(self, path) -> Optional[list[WatchCond]]:
+        """Find the first glob pattern that matches the path."""
+        rules = []
+        for cond in self.conds:
+            # Check if the path matches the glob pattern
+            if cond.try_path_hit(path):
+                rules.append(cond)
+
+        return rules if rules else None
+
+    def _resolve_paths(self):
+        """Resolve all glob patterns to file paths."""
+
+        # Add all files matching watch patterns
+        for pattern in self.watch_globs:
+            for match in glob.iglob(pattern, recursive=True):
+                for cond in self.conds:
+                    if cond.try_path_hit(match):
+                        yield match
+
+    def changed(self) -> list[Hit]:
+        """Check if any watched files have changed.
+
+        Returns (path, matching_glob) if a change was detected, None otherwise.
+        """
+        # Return any queued inotify changes first
+        if self.changes:
+            changes = self.changes
+            self.changes = []
+
+            return changes
+
+        # Don't stat if inotify is available and just had nothing
+        if self.has_inotify:
+            return
+
+        # Fall back to stat-based checking
+        paths = self._resolve_paths()
+        changes = []
+        current_mtimes = {}
+        changed = set()
+        if not self.mtimes:
+            current_mtimes = self.mtimes
+
+        for path in paths:
+            try:
+                if path in changed:
+                    # Already processed this file
+                    continue
+
+                st = os.stat(path)
+                if not stat.S_ISREG(st.st_mode):
+                    # Not a regular file, skip it
+                    continue
+                mtime = st.st_mtime
+            except OSError:
+                # Might be deleted, we'll catch it later
+                continue
+
+            current_mtimes[path] = mtime
+            old_mtime = self.mtimes.get(path, None)
+
+            if old_mtime != mtime:
+                matching_rules = self._get_matching_rules(path)
+                changes.append(Hit(path, matching_rules))
+                changed.add(path)
+
+        # Check for deleted files
+        for path in self.mtimes.keys():
+            if path not in current_mtimes:
+                matching_rules = self._get_matching_rules(path)
+                if matching_rules:
+                    changes.append(Hit(path, matching_rules))
+
+        self.mtimes = current_mtimes
+        return changes

--- a/src/html_compose/live/watcher.py
+++ b/src/html_compose/live/watcher.py
@@ -81,7 +81,7 @@ class ProcessTask(Task):
 
 
 class TaskRunner:
-    def __init__(self):
+    def __init__(self) -> None:
         self.lock = RLock()
         self.tasks: list[tuple[int, float, Task]] = []
         self.cancelled = False
@@ -390,9 +390,9 @@ class Watcher:
                 )
                 continue
 
-            assert isinstance(result, set), (
-                f"Unexpected result type: {type(result)}"
-            )
+            assert isinstance(
+                result, set
+            ), f"Unexpected result type: {type(result)}"
 
             result_tuples: set[tuple[int, str]] = result
             for watch_id, path in result_tuples:

--- a/src/html_compose/translate_html.py
+++ b/src/html_compose/translate_html.py
@@ -84,6 +84,10 @@ def translate(html: str) -> str:
         return "".join(result)
 
     elements = [process_element(child) for child in soup.children]
+
+    if not tags:
+        return "No HTML tags found"
+
     return "\n\n".join(
         [f"from html_compose import {', '.join(tags)}"]
         + [e for e in elements if e]

--- a/src/html_compose/translate_html.py
+++ b/src/html_compose/translate_html.py
@@ -1,9 +1,11 @@
+import inspect
 import re
 from typing import Union
 
 from bs4 import BeautifulSoup, NavigableString, Tag
 from bs4.element import Doctype
 
+from . import elements as el_list
 from .util_funcs import safe_name
 
 
@@ -43,23 +45,61 @@ def translate(html: str) -> str:
     """
     soup = BeautifulSoup(html, features="html.parser")
 
-    tags = set()
+    tags = {}
 
     def process_element(element) -> Union[str, None]:
         if isinstance(element, Doctype):
             dt: Doctype = element
-            tags.add("doctype")
+            tags["doctype"] = None
             return f"doctype({repr(dt)})"
         elif isinstance(element, NavigableString):
             return read_string(element)
 
         assert isinstance(element, Tag)
         safe_tag_name = safe_name(element.name)
+        if safe_tag_name not in tags:
+            tags[safe_tag_name] = getattr(el_list, safe_tag_name)
+        tag_cls = tags[safe_tag_name]
 
-        tags.add(safe_tag_name)
         result = [safe_tag_name]
         if element.attrs:
-            result.extend(["(", repr(element.attrs), ")"])
+            param_attrs = {}
+            dict_attrs = {}
+            tag_keys = inspect.signature(tag_cls.__init__).parameters.keys()
+
+            for key, value in element.attrs.items():
+                if key in ("attrs", "self", "children"):
+                    # These are params of the constructor but the HTML given
+                    # clashes with them
+                    dict_attrs[key] = value
+                    continue
+
+                safe_attr_name = safe_name(key)
+
+                if safe_attr_name in tag_keys:
+                    param_attrs[safe_attr_name] = value
+                else:
+                    # This is an unknown attribute,
+                    # let's include it as a dictionary key/value
+                    dict_attrs[key] = value
+
+            # Build element constructor call
+            result.append("(")
+
+            # Dict attributes first positionally
+            if dict_attrs:
+                result.append(repr(dict_attrs))
+
+            # Matching keyword args
+            if param_attrs:
+                if dict_attrs:
+                    result.append(", ")
+                params = []
+                for key, value in param_attrs.items():
+                    params.append(f"{key}={repr(value)}")
+                result.append(", ".join(params))
+
+            result.append(")")
         else:
             result.append("()")
 
@@ -85,6 +125,6 @@ def translate(html: str) -> str:
         return "No HTML tags found"
 
     return "\n\n".join(
-        [f"from html_compose import {', '.join(tags)}"]
+        [f"from html_compose import {', '.join(tags.keys())}"]
         + [e for e in elements if e]
     )

--- a/src/html_compose/translate_html.py
+++ b/src/html_compose/translate_html.py
@@ -1,11 +1,7 @@
 import re
 from typing import Union
 
-from bs4 import (
-    BeautifulSoup,
-    NavigableString,
-    Tag,
-)
+from bs4 import BeautifulSoup, NavigableString, Tag
 from bs4.element import Doctype
 
 from .util_funcs import safe_name

--- a/src/html_compose/translate_html.py
+++ b/src/html_compose/translate_html.py
@@ -1,6 +1,6 @@
 import inspect
 import re
-from typing import Union
+from typing import Any, Union
 
 from bs4 import BeautifulSoup, NavigableString, Tag
 from bs4.element import Doctype
@@ -45,7 +45,7 @@ def translate(html: str) -> str:
     """
     soup = BeautifulSoup(html, features="html.parser")
 
-    tags = {}
+    tags: dict[str, Any] = {}
 
     def process_element(element) -> Union[str, None]:
         if isinstance(element, Doctype):

--- a/src/html_compose/util_funcs.py
+++ b/src/html_compose/util_funcs.py
@@ -1,6 +1,7 @@
 import inspect
 from functools import lru_cache
-from typing import Any, Generator, Iterable
+from os import getenv
+from typing import Any, Generator, Iterable, Optional
 
 
 def join_attrs(k, value_trusted):
@@ -61,3 +62,18 @@ def safe_name(name):
         name = name.replace("-", "_")
 
     return name
+
+
+def get_livereload_env() -> Optional[str]:
+    enabled = getenv("HTMLCOMPOSE_LIVERELOAD") == "1"
+    if not enabled:
+        return None
+    flags = getenv("HTMLCOMPOSE_LIVERELOAD_FLAGS")
+    return flags
+
+
+def generate_livereload_env(host, port):
+    return {
+        "HTMLCOMPOSE_LIVERELOAD_FLAGS": f"port={port}&host={host}",
+        "HTMLCOMPOSE_LIVERELOAD": "1",
+    }

--- a/src/html_compose/util_funcs.py
+++ b/src/html_compose/util_funcs.py
@@ -1,6 +1,7 @@
 import inspect
 from functools import lru_cache
 from os import getenv
+from pathlib import PurePath
 from typing import Any, Generator, Iterable, Optional
 
 
@@ -77,3 +78,94 @@ def generate_livereload_env(host, port):
         "HTMLCOMPOSE_LIVERELOAD_FLAGS": f"port={port}&host={host}",
         "HTMLCOMPOSE_LIVERELOAD": "1",
     }
+
+
+def glob_matcher(pattern, path):
+    """
+    Implementation of glob matcher which supports:
+      recursive globbing i.e. **
+      dir name matching via trailing /
+
+    Notes:
+      In Python 3.13 PurePath implemented full_match, but we don't
+      have that in 3.10.
+    """
+    pure_path = PurePath(path)
+    pure_pattern = PurePath(pattern)
+    path_parts = pure_path.parts
+    glob_parts = pure_pattern.parts
+    is_double_star = "**" in pattern
+
+    def _segment_match(pattern_segment, path_segment):
+        """Match a single path segment against a pattern segment."""
+        # fnmatch doesn't handle asterisk matching quite the same,
+        # so we use PurePath.match for * and? patterns.
+        return PurePath(path_segment).match(pattern_segment)
+
+    def _section_match(
+        pattern_segment: tuple, path_section: tuple, terminates=False
+    ):
+        """
+
+        Match a single path segment against a pattern segment.
+        Uses PurePath's match for * and ? patterns.
+
+        :param pattern_segment: Description
+        :type pattern_segment:
+        :param path_section: Description
+        :type path_section:
+        :return: Description
+        :rtype: bool"""
+        if len(pattern_segment) > len(path_section):
+            return False
+
+        if terminates and (len(pattern_segment) != len(path_section)):
+            return False
+
+        # We match segment by segment because PurePath will do weird generalizations
+        # such as matching "*.txt" against dir/file.txt
+        for i, seg in enumerate(pattern_segment):
+            if not _segment_match(seg, path_section[i]):
+                return False
+
+        return True
+
+    # Simple: We can just match the path_parts against the glob_parts
+    if not is_double_star:
+        if pattern.endswith("/"):
+            last_section = path_parts[0 : len(glob_parts)]
+            return _section_match(glob_parts, last_section, terminates=False)
+
+        return _section_match(glob_parts, path_parts, terminates=True)
+
+    # Oops, there's a double star.
+    # Build lists split on **
+    glob_sections = []
+    glob_section = []
+
+    for part in glob_parts:
+        if part == "**":
+            glob_sections.append(glob_section)
+            glob_section = []
+        else:
+            glob_section.append(part)
+
+    if glob_section:
+        glob_sections.append(glob_section)
+
+    j = 0
+    for i, current in enumerate(glob_sections):
+        is_last_glob = i == len(glob_sections) - 1
+        term = is_last_glob and not pattern.endswith("/")
+        matched = False
+        while j < len(path_parts):
+            if _section_match(current, path_parts[j:], terminates=term):
+                matched = True
+                break
+            if i > 0:
+                j += 1
+            else:
+                break
+        if not matched:
+            return False
+    return True

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -126,11 +126,7 @@ def test_doc():
 def test_generic_attr():
     from html_compose.attributes import BaseAttribute
 
-    el = div(
-        attrs={
-            "data-foo": "bar",
-        }
-    )
+    el = div(attrs={"data-foo": "bar"})
     assert el.render() == '<div data-foo="bar"></div>'
     el = div(attrs=[BaseAttribute("data-foo", "bar")])
     assert el.render() == '<div data-foo="bar"></div>'

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,3 +1,5 @@
+from bs4 import BeautifulSoup
+
 import html_compose.translate_html as t
 
 
@@ -106,4 +108,6 @@ def test_translate():
     lines = [line for line in t.translate(ht).strip().splitlines() if line]
     lines[1] = lines[1] + ".render()"
     output = eval("\n".join(lines[1:]))
-    assert output == expected.render()
+    soup1 = BeautifulSoup(output, "html.parser")
+    soup2 = BeautifulSoup(expected.render(), "html.parser")
+    assert str(soup1) == str(soup2)

--- a/tests/test_util_funcs.py
+++ b/tests/test_util_funcs.py
@@ -1,4 +1,4 @@
-from html_compose.util_funcs import flatten_iterable
+from html_compose.util_funcs import flatten_iterable, glob_matcher
 
 
 def test_iterator_flatten():
@@ -21,3 +21,101 @@ def test_iterator_flatten():
 
     bytes_demo = [1, 2, 3, bytes([1, 2, 3, 4])]
     assert list(flatten_iterable(bytes_demo)) == [1, 2, 3, bytes([1, 2, 3, 4])]
+
+
+def test_glob_func():
+    test_cases = [
+        # Basic matching
+        ("file.txt", "file.txt", True),
+        ("dir/file.txt", "dir/file.txt", True),
+        # * as entire segment - matches one segment
+        ("*/file.txt", "dir/file.txt", True),
+        ("*/file.txt", "dir1/dir2/file.txt", False),
+        # * as part of segment - matches any characters
+        ("dir/file*.txt", "dir/file1.txt", True),
+        ("dir/file*.txt", "dir/fileabc.txt", True),
+        ("dir/*.txt", "dir/file.txt", True),
+        # ** - matches any number of segments
+        ("**/file.txt", "file.txt", True),
+        ("./**/file.txt", "file.txt", True),
+        ("**/file.txt", "dir/file.txt", True),
+        ("**/file.txt", "dir1/dir2/file.txt", True),
+        ("dir/**/file.txt", "dir/file.txt", True),
+        ("dir/**/file.txt", "dir/subdir/file.txt", True),
+        ("dir/**/file.txt", "dir/subdir1/subdir2/file.txt", True),
+        (
+            "dir/**/files/**/file.txt",
+            "dir/subdir1/subdir2/files/file.txt",
+            True,
+        ),
+        # Combinations
+        ("**/*.txt", "file.txt", True),
+        ("**/*.txt", "dir/file.txt", True),
+        ("dir/**/*.txt", "dir/file.txt", True),
+        ("dir/**/*.txt", "dir/subdir/file.txt", True),
+        ("dir/**/*file*.txt", "dir/subdir/myfile1.txt", True),
+        # Non-matches
+        ("file.txt", "file.csv", False),
+        ("dir/file.txt", "dir2/file.txt", False),
+        (
+            "*.txt",
+            "dir/file.txt",
+            False,
+        ),  # * doesn't match directory separators
+        ("dir/*.txt", "dir/subdir/file.txt", False),
+        ("dir/red/**/src*.txt", "dir/red/red/srcfile.txt", True),
+        ("dir/red/**/src/demo.txt", "dir/red/red/src/no/file.txt", False),
+        # Test case for multiple potential matches with **
+        (
+            "**/nextsection/file.txt",
+            "demo/nextsection/nextsection/file.txt",
+            True,
+        ),
+        (
+            "**/nextsection/other.txt",
+            "demo/nextsection/nextsection/other.txt",
+            True,
+        ),
+        (
+            "**/nextsection/**/final.txt",
+            "demo/nextsection/nextsection/final.txt",
+            True,
+        ),
+        (
+            "**/nextsection/**/final.txt",
+            "demo/nextsection/something/nextsection/final.txt",
+            True,
+        ),
+        # Test case to verify greedy vs non-greedy behavior
+        (
+            "demo/**/nextsection/final.txt",
+            "demo/nextsection/nextsection/final.txt",
+            True,
+        ),
+        (
+            "demo/**/nextsection/final.txt",
+            "demo/something/nextsection/final.txt",
+            True,
+        ),
+        # Test case to verify first match is used
+        (
+            "**/nextsection/end.txt",
+            "path/nextsection/nextsection/end.txt",
+            True,
+        ),
+        (
+            "**/nextsection/end.txt",
+            "path/nextsection/other/nextsection/end.txt",
+            True,
+        ),
+        # Test case for trailing slash, which is shorthand "path contains"
+        (
+            "**/dir_cursive/",
+            "path/nextsection/dir_cursive/nextsection/end.txt",
+            True,
+        ),
+    ]
+    for pattern, target, expected in test_cases:
+        assert (
+            glob_matcher(pattern, target) == expected
+        ), f"Test failed for pattern {pattern} and target {target}"

--- a/tools/generate_attributes.py
+++ b/tools/generate_attributes.py
@@ -7,12 +7,7 @@ from generator_common import get_path, safe_name, type_for_value
 
 
 def generate_class_template(
-    safe_class_name,
-    element_name,
-    attr_name,
-    attr_desc,
-    value_desc,
-    type_data,
+    safe_class_name, element_name, attr_name, attr_desc, value_desc, type_data
 ):
     safe_class_name = safe_class_name.lower()
     if element_name == "Global Attribute":
@@ -132,9 +127,7 @@ def other_attrs():
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate HTML attrs.")
     parser.add_argument(
-        "--copy",
-        action="store_true",
-        help="Copy the output to project",
+        "--copy", action="store_true", help="Copy the output to project"
     )
     args = parser.parse_args()
     spec = json.loads(get_path("spec_reference.json").read_text())

--- a/tools/generate_elements.py
+++ b/tools/generate_elements.py
@@ -23,10 +23,13 @@ def generate_attrs(attr_class, attr_list) -> list[processed_attr]:  # -> list:
     for attr in attr_list:
         attrdef = ReadAttr(attr)
         dupe = attrdefs.get(attrdef.name, None)
-        docstring = [f":param {attrdef.safe_name}: {attrdef.description}"]
+        docstring = [f"`{attrdef.safe_name}` :"]
 
+        docstring.append(f"    {attrdef.description}")
         if not value_hint_to_python_type(attrdef.value_desc):
-            docstring.append(f"    | {attrdef.value_desc}")
+            docstring[-1] += "  "  # markdown newline
+            docstring.append("")
+            docstring.append(f"    {attrdef.value_desc}")
 
         def_dict = {"attr": attrdef, "docstring": docstring}
         if dupe:
@@ -124,7 +127,8 @@ def gen_elements():
             extra_attrs = ""
             attr_assignment = ""
             attr_docstrings = [
-                ":param attrs: A list or dictionary of attributes for the element"
+                "`attrs`: ",
+                "    A list or dictionary of attributes for the element",
             ]
 
             attr_list = []
@@ -209,6 +213,8 @@ def gen_elements():
                 f"        Initialize '{real_element}' ({desc}) element.  ",
                 f"        Documentation: {docs}",
                 "",
+                "        Parameters",
+                "        ----------",
                 "        " + "\n        ".join(attr_docstrings),
                 '        """ #fmt: skip',
                 "        super().__init__(",
@@ -221,7 +227,7 @@ def gen_elements():
             ]
             result.append("\n".join(template))
 
-    header = f"""from typing import TypeAlias, Union, Literal, Optional
+    header = f"""from typing import Union, Literal, Optional
 
 from .attributes import GlobalAttrs, {", ".join(attr_imports)}
 from .base_attribute import BaseAttribute

--- a/tools/generate_elements.py
+++ b/tools/generate_elements.py
@@ -124,7 +124,7 @@ def gen_elements():
             extra_attrs = ""
             attr_assignment = ""
             attr_docstrings = [
-                ":param attrs: A list or dictionary of attributes for the element",
+                ":param attrs: A list or dictionary of attributes for the element"
             ]
 
             attr_list = []

--- a/tools/generated/elements.py
+++ b/tools/generated/elements.py
@@ -1,4 +1,4 @@
-from typing import TypeAlias, Union, Literal, Optional
+from typing import Union, Literal, Optional
 
 from .attributes import GlobalAttrs, AnchorAttrs, AreaAttrs, AudioAttrs, BaseAttrs, BlockquoteAttrs, BodyAttrs, ButtonAttrs, CanvasAttrs, ColAttrs, ColgroupAttrs, DataAttrs, DelAttrs, DetailsAttrs, DialogAttrs, EmbedAttrs, FieldsetAttrs, FormAttrs, IframeAttrs, ImgAttrs, InputAttrs, InsAttrs, LabelAttrs, LiAttrs, LinkAttrs, MapAttrs, MetaAttrs, MeterAttrs, ObjectAttrs, OlAttrs, OptgroupAttrs, OptionAttrs, OutputAttrs, ProgressAttrs, QAttrs, ScriptAttrs, SelectAttrs, SlotAttrs, SourceAttrs, StyleAttrs, TdAttrs, TemplateAttrs, TextareaAttrs, ThAttrs, TimeAttrs, TrackAttrs, VideoAttrs
 from .base_attribute import BaseAttribute
@@ -70,60 +70,116 @@ class a(BaseElement):
         Initialize 'a' (Hyperlink) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param download: Whether to download the resource instead of navigating to it, and its filename if so
-        :param href: Address of the hyperlink
-            | Valid URL potentially surrounded by spaces
-        :param hreflang: Language of the linked resource
-            | Valid BCP 47 language tag
-        :param ping: URLs to ping
-            | Set of space-separated tokens consisting of valid non-empty URLs
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param rel: Relationship between the location in the document containing the hyperlink and the destination resource
-            | Unordered set of unique space-separated tokens*
-        :param target: Navigable for hyperlink navigation
-            | Valid navigable target name or keyword
-        :param type: Hint for the type of the referenced resource
-            | Valid MIME type string
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `download` :
+            Whether to download the resource instead of navigating to it, and its filename if so
+        `href` :
+            Address of the hyperlink  
+        
+            Valid URL potentially surrounded by spaces
+        `hreflang` :
+            Language of the linked resource  
+        
+            Valid BCP 47 language tag
+        `ping` :
+            URLs to ping  
+        
+            Set of space-separated tokens consisting of valid non-empty URLs
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `rel` :
+            Relationship between the location in the document containing the hyperlink and the destination resource  
+        
+            Unordered set of unique space-separated tokens*
+        `target` :
+            Navigable for hyperlink navigation  
+        
+            Valid navigable target name or keyword
+        `type` :
+            Hint for the type of the referenced resource  
+        
+            Valid MIME type string
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "a",
@@ -263,45 +319,86 @@ class abbr(BaseElement):
         Initialize 'abbr' (Abbreviation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "abbr",
@@ -425,45 +522,86 @@ class address(BaseElement):
         Initialize 'address' (Contact information for a page or article element) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "address",
@@ -596,60 +734,116 @@ class area(BaseElement):
         Initialize 'area' (Hyperlink or dead area on an image map) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param alt: Replacement text for use when images are not available
-        :param coords: Coordinates for the shape to be created in an image map
-            | Valid list of floating-point numbers*
-        :param download: Whether to download the resource instead of navigating to it, and its filename if so
-        :param href: Address of the hyperlink
-            | Valid URL potentially surrounded by spaces
-        :param ping: URLs to ping
-            | Set of space-separated tokens consisting of valid non-empty URLs
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param rel: Relationship between the location in the document containing the hyperlink and the destination resource
-            | Unordered set of unique space-separated tokens*
-        :param shape: The kind of shape to be created in an image map
-        :param target: Navigable for hyperlink navigation
-            | Valid navigable target name or keyword
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `alt` :
+            Replacement text for use when images are not available
+        `coords` :
+            Coordinates for the shape to be created in an image map  
+        
+            Valid list of floating-point numbers*
+        `download` :
+            Whether to download the resource instead of navigating to it, and its filename if so
+        `href` :
+            Address of the hyperlink  
+        
+            Valid URL potentially surrounded by spaces
+        `ping` :
+            URLs to ping  
+        
+            Set of space-separated tokens consisting of valid non-empty URLs
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `rel` :
+            Relationship between the location in the document containing the hyperlink and the destination resource  
+        
+            Unordered set of unique space-separated tokens*
+        `shape` :
+            The kind of shape to be created in an image map
+        `target` :
+            Navigable for hyperlink navigation  
+        
+            Valid navigable target name or keyword
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "area",
@@ -791,45 +985,86 @@ class article(BaseElement):
         Initialize 'article' (Self-contained syndicatable or reusable composition) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "article",
@@ -953,45 +1188,86 @@ class aside(BaseElement):
         Initialize 'aside' (Sidebar for tangentially related content) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "aside",
@@ -1122,53 +1398,102 @@ class audio(BaseElement):
         Initialize 'audio' (Audio player) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param autoplay: Hint that the media resource can be started automatically when the page is loaded
-        :param controls: Show user agent controls
-        :param crossorigin: How the element handles crossorigin requests
-        :param loop: Whether to loop the media resource
-        :param muted: Whether to mute the media resource by default
-        :param preload: Hints how much buffering the media resource will likely need
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `autoplay` :
+            Hint that the media resource can be started automatically when the page is loaded
+        `controls` :
+            Show user agent controls
+        `crossorigin` :
+            How the element handles crossorigin requests
+        `loop` :
+            Whether to loop the media resource
+        `muted` :
+            Whether to mute the media resource by default
+        `preload` :
+            Hints how much buffering the media resource will likely need
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "audio",
@@ -1306,45 +1631,86 @@ class b(BaseElement):
         Initialize 'b' (Keywords) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "b",
@@ -1470,49 +1836,94 @@ class base(BaseElement):
         Initialize 'base' (Base URL and default target navigable for hyperlinks and forms) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param href: Document base URL
-            | Valid URL potentially surrounded by spaces
-        :param target: Default navigable for hyperlink navigation and form submission
-            | Valid navigable target name or keyword
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `href` :
+            Document base URL  
+        
+            Valid URL potentially surrounded by spaces
+        `target` :
+            Default navigable for hyperlink navigation and form submission  
+        
+            Valid navigable target name or keyword
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "base",
@@ -1640,45 +2051,86 @@ class bdi(BaseElement):
         Initialize 'bdi' (Text directionality isolation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "bdi",
@@ -1802,45 +2254,86 @@ class bdo(BaseElement):
         Initialize 'bdo' (Text directionality formatting) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "bdo",
@@ -1965,47 +2458,90 @@ class blockquote(BaseElement):
         Initialize 'blockquote' (A section quoted from another source) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param cite: Link to the source of the quotation or more information about the edit
-            | Valid URL potentially surrounded by spaces
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `cite` :
+            Link to the source of the quotation or more information about the edit  
+        
+            Valid URL potentially surrounded by spaces
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "blockquote",
@@ -2131,45 +2667,86 @@ class body(BaseElement):
         Initialize 'body' (Document body) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "body",
@@ -2293,45 +2870,86 @@ class br(BaseElement):
         Initialize 'br' (Line break, e.g. in poem or postal address) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "br",
@@ -2467,61 +3085,118 @@ class button(BaseElement):
         Initialize 'button' (Button control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param disabled: Whether the form control is disabled
-        :param form: Associates the element with a form element
-            | ID*
-        :param formaction: URL to use for form submission
-            | Valid non-empty URL potentially surrounded by spaces
-        :param formenctype: Entry list encoding type to use for form submission
-        :param formmethod: Variant to use for form submission
-        :param formnovalidate: Bypass form control validation for form submission
-        :param formtarget: Navigable for form submission
-            | Valid navigable target name or keyword
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param popovertarget: Targets a popover element to toggle, show, or hide
-            | ID*
-        :param popovertargetaction: Indicates whether a targeted popover element is to be toggled, shown, or hidden
-        :param type: Type of button
-        :param value: Value to be used for form submission
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `disabled` :
+            Whether the form control is disabled
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `formaction` :
+            URL to use for form submission  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `formenctype` :
+            Entry list encoding type to use for form submission
+        `formmethod` :
+            Variant to use for form submission
+        `formnovalidate` :
+            Bypass form control validation for form submission
+        `formtarget` :
+            Navigable for form submission  
+        
+            Valid navigable target name or keyword
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `popovertarget` :
+            Targets a popover element to toggle, show, or hide  
+        
+            ID*
+        `popovertargetaction` :
+            Indicates whether a targeted popover element is to be toggled, shown, or hidden
+        `type` :
+            Type of button
+        `value` :
+            Value to be used for form submission
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "button",
@@ -2671,47 +3346,90 @@ class canvas(BaseElement):
         Initialize 'canvas' (Scriptable bitmap canvas) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param height: Vertical dimension
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `height` :
+            Vertical dimension
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "canvas",
@@ -2839,45 +3557,86 @@ class caption(BaseElement):
         Initialize 'caption' (Table caption) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "caption",
@@ -3001,45 +3760,86 @@ class cite(BaseElement):
         Initialize 'cite' (Title of a work) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "cite",
@@ -3163,45 +3963,86 @@ class code(BaseElement):
         Initialize 'code' (Computer code) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "code",
@@ -3326,47 +4167,90 @@ class col(BaseElement):
         Initialize 'col' (Table column) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param span: Number of columns spanned by the element
-            | Valid non-negative integer greater than zero
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `span` :
+            Number of columns spanned by the element  
+        
+            Valid non-negative integer greater than zero
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "col",
@@ -3493,47 +4377,90 @@ class colgroup(BaseElement):
         Initialize 'colgroup' (Group of columns in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param span: Number of columns spanned by the element
-            | Valid non-negative integer greater than zero
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `span` :
+            Number of columns spanned by the element  
+        
+            Valid non-negative integer greater than zero
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "colgroup",
@@ -3660,46 +4587,88 @@ class data(BaseElement):
         Initialize 'data' (Machine-readable equivalent) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param value: Machine-readable value
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `value` :
+            Machine-readable value
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "data",
@@ -3825,45 +4794,86 @@ class datalist(BaseElement):
         Initialize 'datalist' (Container for options for combo box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "datalist",
@@ -3987,45 +4997,86 @@ class dd(BaseElement):
         Initialize 'dd' (Content for corresponding dt element(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "dd",
@@ -4151,49 +5202,94 @@ class del_(BaseElement):
         Initialize 'del' (A removal from the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param cite: Link to the source of the quotation or more information about the edit
-            | Valid URL potentially surrounded by spaces
-        :param datetime: Date and (optionally) time of the change
-            | Valid date string with optional time
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `cite` :
+            Link to the source of the quotation or more information about the edit  
+        
+            Valid URL potentially surrounded by spaces
+        `datetime` :
+            Date and (optionally) time of the change  
+        
+            Valid date string with optional time
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "del",
@@ -4323,47 +5419,90 @@ class details(BaseElement):
         Initialize 'details' (Disclosure control for hiding details) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param name: Name of group of mutually-exclusive details elements
-        :param open: Whether the details are visible
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `name` :
+            Name of group of mutually-exclusive details elements
+        `open` :
+            Whether the details are visible
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "details",
@@ -4491,45 +5630,86 @@ class dfn(BaseElement):
         Initialize 'dfn' (Defining instance) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "dfn",
@@ -4654,46 +5834,88 @@ class dialog(BaseElement):
         Initialize 'dialog' (Dialog box or window) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param open: Whether the dialog box is showing
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `open` :
+            Whether the dialog box is showing
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "dialog",
@@ -4819,45 +6041,86 @@ class div(BaseElement):
         Initialize 'div' (Generic flow container, or container for name-value groups in dl elements) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "div",
@@ -4981,45 +6244,86 @@ class dl(BaseElement):
         Initialize 'dl' (Association list consisting of zero or more name-value groups) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "dl",
@@ -5143,45 +6447,86 @@ class dt(BaseElement):
         Initialize 'dt' (Legend for corresponding dd element(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "dt",
@@ -5305,45 +6650,86 @@ class em(BaseElement):
         Initialize 'em' (Stress emphasis) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "em",
@@ -5471,51 +6857,98 @@ class embed(BaseElement):
         Initialize 'embed' (Plugin) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param height: Vertical dimension
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param type: Type of embedded resource
-            | Valid MIME type string
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `height` :
+            Vertical dimension
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `type` :
+            Type of embedded resource  
+        
+            Valid MIME type string
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "embed",
@@ -5650,49 +7083,94 @@ class fieldset(BaseElement):
         Initialize 'fieldset' (Group of form controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param disabled: Whether the descendant form controls, except any inside legend, are disabled
-        :param form: Associates the element with a form element
-            | ID*
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `disabled` :
+            Whether the descendant form controls, except any inside legend, are disabled
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "fieldset",
@@ -5822,45 +7300,86 @@ class figcaption(BaseElement):
         Initialize 'figcaption' (Caption for figure) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "figcaption",
@@ -5984,45 +7503,86 @@ class figure(BaseElement):
         Initialize 'figure' (Figure with optional caption) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "figure",
@@ -6146,45 +7706,86 @@ class footer(BaseElement):
         Initialize 'footer' (Footer for a page or section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "footer",
@@ -6316,56 +7917,108 @@ class form(BaseElement):
         Initialize 'form' (User-submittable form) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accept_charset: Character encodings to use for form submission
-            | ASCII case-insensitive match for "UTF-8"
-        :param action: URL to use for form submission
-            | Valid non-empty URL potentially surrounded by spaces
-        :param autocomplete: Default setting for autofill feature for controls in the form
-        :param enctype: Entry list encoding type to use for form submission
-        :param method: Variant to use for form submission
-        :param name: Name of form to use in the document.forms API
-        :param novalidate: Bypass form control validation for form submission
-        :param target: Navigable for form submission
-            | Valid navigable target name or keyword
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accept_charset` :
+            Character encodings to use for form submission  
+        
+            ASCII case-insensitive match for "UTF-8"
+        `action` :
+            URL to use for form submission  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `autocomplete` :
+            Default setting for autofill feature for controls in the form
+        `enctype` :
+            Entry list encoding type to use for form submission
+        `method` :
+            Variant to use for form submission
+        `name` :
+            Name of form to use in the document.forms API
+        `novalidate` :
+            Bypass form control validation for form submission
+        `target` :
+            Navigable for form submission  
+        
+            Valid navigable target name or keyword
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "form",
@@ -6505,45 +8158,86 @@ class h1(BaseElement):
         Initialize 'h1' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "h1",
@@ -6667,45 +8361,86 @@ class h2(BaseElement):
         Initialize 'h2' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "h2",
@@ -6829,45 +8564,86 @@ class h3(BaseElement):
         Initialize 'h3' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "h3",
@@ -6991,45 +8767,86 @@ class h4(BaseElement):
         Initialize 'h4' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "h4",
@@ -7153,45 +8970,86 @@ class h5(BaseElement):
         Initialize 'h5' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "h5",
@@ -7315,45 +9173,86 @@ class h6(BaseElement):
         Initialize 'h6' (Heading) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "h6",
@@ -7477,45 +9376,86 @@ class head(BaseElement):
         Initialize 'head' (Container for document metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "head",
@@ -7639,45 +9579,86 @@ class header(BaseElement):
         Initialize 'header' (Introductory or navigational aids for a page or section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "header",
@@ -7801,45 +9782,86 @@ class hgroup(BaseElement):
         Initialize 'hgroup' (Heading container) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "hgroup",
@@ -7963,45 +9985,86 @@ class hr(BaseElement):
         Initialize 'hr' (Thematic break) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "hr",
@@ -8125,45 +10188,86 @@ class html(BaseElement):
         Initialize 'html' (Root element) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "html",
@@ -8287,45 +10391,86 @@ class i(BaseElement):
         Initialize 'i' (Alternate voice) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "i",
@@ -8459,61 +10604,118 @@ class iframe(BaseElement):
         Initialize 'iframe' (Child navigable) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param allow: Permissions policy to be applied to the iframe's contents
-            | Serialized permissions policy
-        :param allowfullscreen: Whether to allow the iframe's contents to use requestFullscreen()
-        :param height: Vertical dimension
-        :param loading: Used when determining loading deferral
-        :param name: Name of content navigable
-            | Valid navigable target name or keyword
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param sandbox: Security rules for nested content
-            | Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of "allow-downloads" "allow-forms" "allow-modals" "allow-orientation-lock" "allow-pointer-lock" "allow-popups" "allow-popups-to-escape-sandbox" "allow-presentation" "allow-same-origin" "allow-scripts" "allow-top-navigation" "allow-top-navigation-by-user-activation" "allow-top-navigation-to-custom-protocols"
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param srcdoc: A document to render in the iframe
-            | The source of an iframe srcdoc document*
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `allow` :
+            Permissions policy to be applied to the iframe's contents  
+        
+            Serialized permissions policy
+        `allowfullscreen` :
+            Whether to allow the iframe's contents to use requestFullscreen()
+        `height` :
+            Vertical dimension
+        `loading` :
+            Used when determining loading deferral
+        `name` :
+            Name of content navigable  
+        
+            Valid navigable target name or keyword
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `sandbox` :
+            Security rules for nested content  
+        
+            Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of "allow-downloads" "allow-forms" "allow-modals" "allow-orientation-lock" "allow-pointer-lock" "allow-popups" "allow-popups-to-escape-sandbox" "allow-presentation" "allow-same-origin" "allow-scripts" "allow-top-navigation" "allow-top-navigation-by-user-activation" "allow-top-navigation-to-custom-protocols"
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `srcdoc` :
+            A document to render in the iframe  
+        
+            The source of an iframe srcdoc document*
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "iframe",
@@ -8670,63 +10872,122 @@ class img(BaseElement):
         Initialize 'img' (Image) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param alt: Replacement text for use when images are not available
-        :param crossorigin: How the element handles crossorigin requests
-        :param decoding: Decoding hint to use when processing this image for presentation
-        :param fetchpriority: Sets the priority for fetches initiated by the element
-        :param height: Vertical dimension
-        :param ismap: Whether the image is a server-side image map
-        :param loading: Used when determining loading deferral
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param sizes: Image sizes for different page layouts
-            | Valid source size list
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param srcset: Images to use in different situations, e.g., high-resolution displays, small monitors, etc.
-            | Comma-separated list of image candidate strings
-        :param usemap: Name of image map to use
-            | Valid hash-name reference*
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `alt` :
+            Replacement text for use when images are not available
+        `crossorigin` :
+            How the element handles crossorigin requests
+        `decoding` :
+            Decoding hint to use when processing this image for presentation
+        `fetchpriority` :
+            Sets the priority for fetches initiated by the element
+        `height` :
+            Vertical dimension
+        `ismap` :
+            Whether the image is a server-side image map
+        `loading` :
+            Used when determining loading deferral
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `sizes` :
+            Image sizes for different page layouts  
+        
+            Valid source size list
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `srcset` :
+            Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
+        
+            Comma-separated list of image candidate strings
+        `usemap` :
+            Name of image map to use  
+        
+            Valid hash-name reference*
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "img",
@@ -8910,93 +11171,182 @@ class input(BaseElement): # type: ignore[misc]
         Initialize 'input' (Form control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accept: Hint for expected file type in file upload controls
-            | Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*
-        :param alpha: Allow the color's alpha component to be set
-        :param alt: Replacement text for use when images are not available
-        :param autocomplete: Hint for form autofill feature
-            | Autofill field name and related tokens*
-        :param checked: Whether the control is checked
-        :param colorspace: The color space of the serialized color
-        :param dirname: Name of form control to use for sending the element's directionality in form submission
-        :param disabled: Whether the form control is disabled
-        :param form: Associates the element with a form element
-            | ID*
-        :param formaction: URL to use for form submission
-            | Valid non-empty URL potentially surrounded by spaces
-        :param formenctype: Entry list encoding type to use for form submission
-        :param formmethod: Variant to use for form submission
-        :param formnovalidate: Bypass form control validation for form submission
-        :param formtarget: Navigable for form submission
-            | Valid navigable target name or keyword
-        :param height: Vertical dimension
-        :param list: List of autocomplete options
-            | ID*
-        :param max: Maximum value
-            | Varies*
-        :param maxlength: Maximum length of value
-        :param min: Minimum value
-            | Varies*
-        :param minlength: Minimum length of value
-        :param multiple: Whether to allow multiple values
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param pattern: Pattern to be matched by the form control's value
-            | Regular expression matching the JavaScript Pattern production
-        :param placeholder: User-visible label to be placed within the form control
-        :param popovertarget: Targets a popover element to toggle, show, or hide
-            | ID*
-        :param popovertargetaction: Indicates whether a targeted popover element is to be toggled, shown, or hidden
-        :param readonly: Whether to allow the value to be edited by the user
-        :param required: Whether the control is required for form submission
-        :param size: Size of the control
-            | Valid non-negative integer greater than zero
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param step: Granularity to be matched by the form control's value
-        :param title: Description of pattern (when used with pattern attribute)
-        :param type: Type of form control
-            | input type keyword
-        :param value: Value of the form control
-            | Varies*
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accept` :
+            Hint for expected file type in file upload controls  
+        
+            Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*
+        `alpha` :
+            Allow the color's alpha component to be set
+        `alt` :
+            Replacement text for use when images are not available
+        `autocomplete` :
+            Hint for form autofill feature  
+        
+            Autofill field name and related tokens*
+        `checked` :
+            Whether the control is checked
+        `colorspace` :
+            The color space of the serialized color
+        `dirname` :
+            Name of form control to use for sending the element's directionality in form submission
+        `disabled` :
+            Whether the form control is disabled
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `formaction` :
+            URL to use for form submission  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `formenctype` :
+            Entry list encoding type to use for form submission
+        `formmethod` :
+            Variant to use for form submission
+        `formnovalidate` :
+            Bypass form control validation for form submission
+        `formtarget` :
+            Navigable for form submission  
+        
+            Valid navigable target name or keyword
+        `height` :
+            Vertical dimension
+        `list` :
+            List of autocomplete options  
+        
+            ID*
+        `max` :
+            Maximum value  
+        
+            Varies*
+        `maxlength` :
+            Maximum length of value
+        `min` :
+            Minimum value  
+        
+            Varies*
+        `minlength` :
+            Minimum length of value
+        `multiple` :
+            Whether to allow multiple values
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `pattern` :
+            Pattern to be matched by the form control's value  
+        
+            Regular expression matching the JavaScript Pattern production
+        `placeholder` :
+            User-visible label to be placed within the form control
+        `popovertarget` :
+            Targets a popover element to toggle, show, or hide  
+        
+            ID*
+        `popovertargetaction` :
+            Indicates whether a targeted popover element is to be toggled, shown, or hidden
+        `readonly` :
+            Whether to allow the value to be edited by the user
+        `required` :
+            Whether the control is required for form submission
+        `size` :
+            Size of the control  
+        
+            Valid non-negative integer greater than zero
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `step` :
+            Granularity to be matched by the form control's value
+        `title` :
+            Description of pattern (when used with pattern attribute)
+        `type` :
+            Type of form control  
+        
+            input type keyword
+        `value` :
+            Value of the form control  
+        
+            Varies*
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "input",
@@ -9190,49 +11540,94 @@ class ins(BaseElement):
         Initialize 'ins' (An addition to the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param cite: Link to the source of the quotation or more information about the edit
-            | Valid URL potentially surrounded by spaces
-        :param datetime: Date and (optionally) time of the change
-            | Valid date string with optional time
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `cite` :
+            Link to the source of the quotation or more information about the edit  
+        
+            Valid URL potentially surrounded by spaces
+        `datetime` :
+            Date and (optionally) time of the change  
+        
+            Valid date string with optional time
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "ins",
@@ -9360,45 +11755,86 @@ class kbd(BaseElement):
         Initialize 'kbd' (User input) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "kbd",
@@ -9523,47 +11959,90 @@ class label(BaseElement):
         Initialize 'label' (Caption for a form control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param for_: Associate the label with form control
-            | ID*
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `for_` :
+            Associate the label with form control  
+        
+            ID*
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "label",
@@ -9689,45 +12168,86 @@ class legend(BaseElement):
         Initialize 'legend' (Caption for fieldset) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "legend",
@@ -9852,46 +12372,88 @@ class li(BaseElement):
         Initialize 'li' (List item) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param value: Ordinal value of the list item
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `value` :
+            Ordinal value of the list item
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "li",
@@ -10033,74 +12595,144 @@ class link(BaseElement): # type: ignore[misc]
         Initialize 'link' (Link metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param as_: Potential destination for a preload request (for rel="preload" and rel="modulepreload")
-            | Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
-        :param blocking: Whether the element is potentially render-blocking
-            | Unordered set of unique space-separated tokens*
-        :param color: Color to use when customizing a site's icon (for rel="mask-icon")
-            | CSS <color>
-        :param crossorigin: How the element handles crossorigin requests
-        :param disabled: Whether the link is disabled
-        :param fetchpriority: Sets the priority for fetches initiated by the element
-        :param href: Address of the hyperlink
-            | Valid non-empty URL potentially surrounded by spaces
-        :param hreflang: Language of the linked resource
-            | Valid BCP 47 language tag
-        :param imagesizes: Image sizes for different page layouts (for rel="preload")
-            | Valid source size list
-        :param imagesrcset: Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")
-            | Comma-separated list of image candidate strings
-        :param integrity: Integrity metadata used in Subresource Integrity checks [SRI]
-        :param media: Applicable media
-            | Valid media query list
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param rel: Relationship between the document containing the hyperlink and the destination resource
-            | Unordered set of unique space-separated tokens*
-        :param sizes: Sizes of the icons (for rel="icon")
-            | Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of sizes*
-        :param title: CSS style sheet set name
-        :param title: Title of the link
-        :param type: Hint for the type of the referenced resource
-            | Valid MIME type string
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `as_` :
+            Potential destination for a preload request (for rel="preload" and rel="modulepreload")  
+        
+            Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
+        `blocking` :
+            Whether the element is potentially render-blocking  
+        
+            Unordered set of unique space-separated tokens*
+        `color` :
+            Color to use when customizing a site's icon (for rel="mask-icon")  
+        
+            CSS <color>
+        `crossorigin` :
+            How the element handles crossorigin requests
+        `disabled` :
+            Whether the link is disabled
+        `fetchpriority` :
+            Sets the priority for fetches initiated by the element
+        `href` :
+            Address of the hyperlink  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `hreflang` :
+            Language of the linked resource  
+        
+            Valid BCP 47 language tag
+        `imagesizes` :
+            Image sizes for different page layouts (for rel="preload")  
+        
+            Valid source size list
+        `imagesrcset` :
+            Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")  
+        
+            Comma-separated list of image candidate strings
+        `integrity` :
+            Integrity metadata used in Subresource Integrity checks [SRI]
+        `media` :
+            Applicable media  
+        
+            Valid media query list
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `rel` :
+            Relationship between the document containing the hyperlink and the destination resource  
+        
+            Unordered set of unique space-separated tokens*
+        `sizes` :
+            Sizes of the icons (for rel="icon")  
+        
+            Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of sizes*
+        `title` :
+            CSS style sheet set name
+        `title` :
+            Title of the link
+        `type` :
+            Hint for the type of the referenced resource  
+        
+            Valid MIME type string
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "link",
@@ -10256,45 +12888,86 @@ class main(BaseElement):
         Initialize 'main' (Container for the dominant contents of the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "main",
@@ -10419,46 +13092,88 @@ class map(BaseElement):
         Initialize 'map' (Image map) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param name: Name of image map to reference from the usemap attribute
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `name` :
+            Name of image map to reference from the usemap attribute
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "map",
@@ -10584,45 +13299,86 @@ class mark(BaseElement):
         Initialize 'mark' (Highlight) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "mark",
@@ -10746,45 +13502,86 @@ class menu(BaseElement):
         Initialize 'menu' (Menu of commands) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "menu",
@@ -10913,51 +13710,98 @@ class meta(BaseElement):
         Initialize 'meta' (Text metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param charset: Character encoding declaration
-        :param content: Value of the element
-        :param http_equiv: Pragma directive
-        :param media: Applicable media
-            | Valid media query list
-        :param name: Metadata name
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `charset` :
+            Character encoding declaration
+        `content` :
+            Value of the element
+        `http_equiv` :
+            Pragma directive
+        `media` :
+            Applicable media  
+        
+            Valid media query list
+        `name` :
+            Metadata name
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "meta",
@@ -11097,51 +13941,98 @@ class meter(BaseElement):
         Initialize 'meter' (Gauge) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param high: Low limit of high range
-        :param low: High limit of low range
-        :param max: Upper bound of range
-        :param min: Lower bound of range
-        :param optimum: Optimum value in gauge
-        :param value: Current value of the element
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `high` :
+            Low limit of high range
+        `low` :
+            High limit of low range
+        `max` :
+            Upper bound of range
+        `min` :
+            Lower bound of range
+        `optimum` :
+            Optimum value in gauge
+        `value` :
+            Current value of the element
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "meter",
@@ -11277,45 +14168,86 @@ class nav(BaseElement):
         Initialize 'nav' (Section with navigational links) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "nav",
@@ -11439,45 +14371,86 @@ class noscript(BaseElement):
         Initialize 'noscript' (Fallback content for script) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "noscript",
@@ -11607,55 +14580,106 @@ class object(BaseElement):
         Initialize 'object' (Image, child navigable, or plugin) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param data: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param form: Associates the element with a form element
-            | ID*
-        :param height: Vertical dimension
-        :param name: Name of content navigable
-            | Valid navigable target name or keyword
-        :param type: Type of embedded resource
-            | Valid MIME type string
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `data` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `height` :
+            Vertical dimension
+        `name` :
+            Name of content navigable  
+        
+            Valid navigable target name or keyword
+        `type` :
+            Type of embedded resource  
+        
+            Valid MIME type string
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "object",
@@ -11794,48 +14818,92 @@ class ol(BaseElement):
         Initialize 'ol' (Ordered list) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param reversed: Number the list backwards
-        :param start: Starting value of the list
-        :param type: Kind of list marker
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `reversed` :
+            Number the list backwards
+        `start` :
+            Starting value of the list
+        `type` :
+            Kind of list marker
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "ol",
@@ -11967,47 +15035,90 @@ class optgroup(BaseElement):
         Initialize 'optgroup' (Group of options in a list box) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param disabled: Whether the form control is disabled
-        :param label: User-visible label
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `disabled` :
+            Whether the form control is disabled
+        `label` :
+            User-visible label
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "optgroup",
@@ -12139,49 +15250,94 @@ class option(BaseElement):
         Initialize 'option' (Option in a list box or combo box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param disabled: Whether the form control is disabled
-        :param label: User-visible label
-        :param selected: Whether the option is selected by default
-        :param value: Value to be used for form submission
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `disabled` :
+            Whether the form control is disabled
+        `label` :
+            User-visible label
+        `selected` :
+            Whether the option is selected by default
+        `value` :
+            Value to be used for form submission
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "option",
@@ -12316,50 +15472,96 @@ class output(BaseElement):
         Initialize 'output' (Calculated output value) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param for_: Specifies controls from which the output was calculated
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param form: Associates the element with a form element
-            | ID*
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `for_` :
+            Specifies controls from which the output was calculated  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "output",
@@ -12489,45 +15691,86 @@ class p(BaseElement):
         Initialize 'p' (Paragraph) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "p",
@@ -12651,45 +15894,86 @@ class picture(BaseElement):
         Initialize 'picture' (Image) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "picture",
@@ -12813,45 +16097,86 @@ class pre(BaseElement):
         Initialize 'pre' (Block of preformatted text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "pre",
@@ -12977,47 +16302,90 @@ class progress(BaseElement):
         Initialize 'progress' (Progress bar) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param max: Upper bound of range
-        :param value: Current value of the element
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `max` :
+            Upper bound of range
+        `value` :
+            Current value of the element
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "progress",
@@ -13146,47 +16514,90 @@ class q(BaseElement):
         Initialize 'q' (Quotation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param cite: Link to the source of the quotation or more information about the edit
-            | Valid URL potentially surrounded by spaces
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `cite` :
+            Link to the source of the quotation or more information about the edit  
+        
+            Valid URL potentially surrounded by spaces
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "q",
@@ -13312,45 +16723,86 @@ class rp(BaseElement):
         Initialize 'rp' (Parenthesis for ruby annotation text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "rp",
@@ -13474,45 +16926,86 @@ class rt(BaseElement):
         Initialize 'rt' (Ruby annotation text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "rt",
@@ -13636,45 +17129,86 @@ class ruby(BaseElement):
         Initialize 'ruby' (Ruby annotation(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "ruby",
@@ -13798,45 +17332,86 @@ class s(BaseElement):
         Initialize 's' (Inaccurate text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "s",
@@ -13960,45 +17535,86 @@ class samp(BaseElement):
         Initialize 'samp' (Computer output) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "samp",
@@ -14132,59 +17748,114 @@ class script(BaseElement):
         Initialize 'script' (Embedded script) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param async_: Execute script when available, without blocking while fetching
-        :param blocking: Whether the element is potentially render-blocking
-            | Unordered set of unique space-separated tokens*
-        :param crossorigin: How the element handles crossorigin requests
-        :param defer: Defer script execution
-        :param fetchpriority: Sets the priority for fetches initiated by the element
-        :param integrity: Integrity metadata used in Subresource Integrity checks [SRI]
-        :param nomodule: Prevents execution in user agents that support module scripts
-        :param referrerpolicy: Referrer policy for fetches initiated by the element
-            | Referrer policy
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param type: Type of script
-            | "module"; a valid MIME type string that is not a JavaScript MIME type essence match
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `async_` :
+            Execute script when available, without blocking while fetching
+        `blocking` :
+            Whether the element is potentially render-blocking  
+        
+            Unordered set of unique space-separated tokens*
+        `crossorigin` :
+            How the element handles crossorigin requests
+        `defer` :
+            Defer script execution
+        `fetchpriority` :
+            Sets the priority for fetches initiated by the element
+        `integrity` :
+            Integrity metadata used in Subresource Integrity checks [SRI]
+        `nomodule` :
+            Prevents execution in user agents that support module scripts
+        `referrerpolicy` :
+            Referrer policy for fetches initiated by the element  
+        
+            Referrer policy
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `type` :
+            Type of script  
+        
+            "module"; a valid MIME type string that is not a JavaScript MIME type essence match
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "script",
@@ -14328,45 +17999,86 @@ class search(BaseElement):
         Initialize 'search' (Container for search controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "search",
@@ -14490,45 +18202,86 @@ class section(BaseElement):
         Initialize 'section' (Generic document or application section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "section",
@@ -14659,55 +18412,106 @@ class select(BaseElement):
         Initialize 'select' (List box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param autocomplete: Hint for form autofill feature
-            | Autofill field name and related tokens*
-        :param disabled: Whether the form control is disabled
-        :param form: Associates the element with a form element
-            | ID*
-        :param multiple: Whether to allow multiple values
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param required: Whether the control is required for form submission
-        :param size: Size of the control
-            | Valid non-negative integer greater than zero
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `autocomplete` :
+            Hint for form autofill feature  
+        
+            Autofill field name and related tokens*
+        `disabled` :
+            Whether the form control is disabled
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `multiple` :
+            Whether to allow multiple values
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `required` :
+            Whether the control is required for form submission
+        `size` :
+            Size of the control  
+        
+            Valid non-negative integer greater than zero
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "select",
@@ -14846,46 +18650,88 @@ class slot(BaseElement):
         Initialize 'slot' (Shadow tree slot) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param name: Name of shadow tree slot
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `name` :
+            Name of shadow tree slot
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "slot",
@@ -15011,45 +18857,86 @@ class small(BaseElement):
         Initialize 'small' (Side comment) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "small",
@@ -15180,57 +19067,110 @@ class source(BaseElement):
         Initialize 'source' (Image source for img or media source for video or audio) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param height: Vertical dimension
-        :param media: Applicable media
-            | Valid media query list
-        :param sizes: Image sizes for different page layouts
-            | Valid source size list
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param srcset: Images to use in different situations, e.g., high-resolution displays, small monitors, etc.
-            | Comma-separated list of image candidate strings
-        :param type: Type of embedded resource
-            | Valid MIME type string
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `height` :
+            Vertical dimension
+        `media` :
+            Applicable media  
+        
+            Valid media query list
+        `sizes` :
+            Image sizes for different page layouts  
+        
+            Valid source size list
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `srcset` :
+            Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
+        
+            Comma-separated list of image candidate strings
+        `type` :
+            Type of embedded resource  
+        
+            Valid MIME type string
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "source",
@@ -15368,45 +19308,86 @@ class span(BaseElement):
         Initialize 'span' (Generic phrasing container) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "span",
@@ -15530,45 +19511,86 @@ class strong(BaseElement):
         Initialize 'strong' (Importance) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "strong",
@@ -15694,49 +19716,94 @@ class style(BaseElement): # type: ignore[misc]
         Initialize 'style' (Embedded styling information) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param blocking: Whether the element is potentially render-blocking
-            | Unordered set of unique space-separated tokens*
-        :param media: Applicable media
-            | Valid media query list
-        :param title: CSS style sheet set name
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `blocking` :
+            Whether the element is potentially render-blocking  
+        
+            Unordered set of unique space-separated tokens*
+        `media` :
+            Applicable media  
+        
+            Valid media query list
+        `title` :
+            CSS style sheet set name
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "style",
@@ -15864,45 +19931,86 @@ class sub(BaseElement):
         Initialize 'sub' (Subscript) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "sub",
@@ -16026,45 +20134,86 @@ class summary(BaseElement):
         Initialize 'summary' (Caption for details) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "summary",
@@ -16188,45 +20337,86 @@ class sup(BaseElement):
         Initialize 'sup' (Superscript) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "sup",
@@ -16350,45 +20540,86 @@ class svg(BaseElement):
         Initialize 'svg' (SVG root) element.  
         Documentation: None
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "svg",
@@ -16512,45 +20743,86 @@ class table(BaseElement):
         Initialize 'table' (Table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "table",
@@ -16674,45 +20946,86 @@ class tbody(BaseElement):
         Initialize 'tbody' (Group of rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "tbody",
@@ -16839,50 +21152,96 @@ class td(BaseElement):
         Initialize 'td' (Table cell) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param colspan: Number of columns that the cell is to span
-            | Valid non-negative integer greater than zero
-        :param headers: The header cells for this cell
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param rowspan: Number of rows that the cell is to span
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `colspan` :
+            Number of columns that the cell is to span  
+        
+            Valid non-negative integer greater than zero
+        `headers` :
+            The header cells for this cell  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `rowspan` :
+            Number of rows that the cell is to span
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "td",
@@ -17016,49 +21375,94 @@ class template(BaseElement):
         Initialize 'template' (Template) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param shadowrootclonable: Sets clonable on a declarative shadow root
-        :param shadowrootdelegatesfocus: Sets delegates focus on a declarative shadow root
-        :param shadowrootmode: Enables streaming declarative shadow roots
-        :param shadowrootserializable: Sets serializable on a declarative shadow root
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `shadowrootclonable` :
+            Sets clonable on a declarative shadow root
+        `shadowrootdelegatesfocus` :
+            Sets delegates focus on a declarative shadow root
+        `shadowrootmode` :
+            Enables streaming declarative shadow roots
+        `shadowrootserializable` :
+            Sets serializable on a declarative shadow root
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "template",
@@ -17203,62 +21607,120 @@ class textarea(BaseElement):
         Initialize 'textarea' (Multiline text controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param autocomplete: Hint for form autofill feature
-            | Autofill field name and related tokens*
-        :param cols: Maximum number of characters per line
-            | Valid non-negative integer greater than zero
-        :param dirname: Name of form control to use for sending the element's directionality in form submission
-        :param disabled: Whether the form control is disabled
-        :param form: Associates the element with a form element
-            | ID*
-        :param maxlength: Maximum length of value
-        :param minlength: Minimum length of value
-        :param name: Name of the element to use for form submission and in the form.elements API
-        :param placeholder: User-visible label to be placed within the form control
-        :param readonly: Whether to allow the value to be edited by the user
-        :param required: Whether the control is required for form submission
-        :param rows: Number of lines to show
-            | Valid non-negative integer greater than zero
-        :param wrap: How the value of the form control is to be wrapped for form submission
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `autocomplete` :
+            Hint for form autofill feature  
+        
+            Autofill field name and related tokens*
+        `cols` :
+            Maximum number of characters per line  
+        
+            Valid non-negative integer greater than zero
+        `dirname` :
+            Name of form control to use for sending the element's directionality in form submission
+        `disabled` :
+            Whether the form control is disabled
+        `form` :
+            Associates the element with a form element  
+        
+            ID*
+        `maxlength` :
+            Maximum length of value
+        `minlength` :
+            Minimum length of value
+        `name` :
+            Name of the element to use for form submission and in the form.elements API
+        `placeholder` :
+            User-visible label to be placed within the form control
+        `readonly` :
+            Whether to allow the value to be edited by the user
+        `required` :
+            Whether the control is required for form submission
+        `rows` :
+            Number of lines to show  
+        
+            Valid non-negative integer greater than zero
+        `wrap` :
+            How the value of the form control is to be wrapped for form submission
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "textarea",
@@ -17408,45 +21870,86 @@ class tfoot(BaseElement):
         Initialize 'tfoot' (Group of footer rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "tfoot",
@@ -17575,52 +22078,100 @@ class th(BaseElement):
         Initialize 'th' (Table header cell) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param abbr: Alternative label to use for the header cell when referencing the cell in other contexts
-        :param colspan: Number of columns that the cell is to span
-            | Valid non-negative integer greater than zero
-        :param headers: The header cells for this cell
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param rowspan: Number of rows that the cell is to span
-        :param scope: Specifies which cells the header cell applies to
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `abbr` :
+            Alternative label to use for the header cell when referencing the cell in other contexts
+        `colspan` :
+            Number of columns that the cell is to span  
+        
+            Valid non-negative integer greater than zero
+        `headers` :
+            The header cells for this cell  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `rowspan` :
+            Number of rows that the cell is to span
+        `scope` :
+            Specifies which cells the header cell applies to
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "th",
@@ -17754,45 +22305,86 @@ class thead(BaseElement):
         Initialize 'thead' (Group of heading rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "thead",
@@ -17917,47 +22509,90 @@ class time(BaseElement):
         Initialize 'time' (Machine-readable equivalent of date- or time-related data) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param datetime: Machine-readable value
-            | Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `datetime` :
+            Machine-readable value  
+        
+            Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "time",
@@ -18083,45 +22718,86 @@ class title(BaseElement):
         Initialize 'title' (Document title) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "title",
@@ -18245,45 +22921,86 @@ class tr(BaseElement):
         Initialize 'tr' (Table row) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "tr",
@@ -18412,52 +23129,100 @@ class track(BaseElement):
         Initialize 'track' (Timed text track) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param default: Enable the track if no other text track is more suitable
-        :param kind: The type of text track
-        :param label: User-visible label
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param srclang: Language of the text track
-            | Valid BCP 47 language tag
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `default` :
+            Enable the track if no other text track is more suitable
+        `kind` :
+            The type of text track
+        `label` :
+            User-visible label
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `srclang` :
+            Language of the text track  
+        
+            Valid BCP 47 language tag
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "track",
@@ -18591,45 +23356,86 @@ class u(BaseElement):
         Initialize 'u' (Unarticulated annotation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "u",
@@ -18753,45 +23559,86 @@ class ul(BaseElement):
         Initialize 'ul' (List) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "ul",
@@ -18915,45 +23762,86 @@ class var(BaseElement):
         Initialize 'var' (Variable) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "var",
@@ -19088,58 +23976,112 @@ class video(BaseElement):
         Initialize 'video' (Video player) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param autoplay: Hint that the media resource can be started automatically when the page is loaded
-        :param controls: Show user agent controls
-        :param crossorigin: How the element handles crossorigin requests
-        :param height: Vertical dimension
-        :param loop: Whether to loop the media resource
-        :param muted: Whether to mute the media resource by default
-        :param playsinline: Encourage the user agent to display video content within the element's playback area
-        :param poster: Poster frame to show prior to video playback
-            | Valid non-empty URL potentially surrounded by spaces
-        :param preload: Hints how much buffering the media resource will likely need
-        :param src: Address of the resource
-            | Valid non-empty URL potentially surrounded by spaces
-        :param width: Horizontal dimension
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `autoplay` :
+            Hint that the media resource can be started automatically when the page is loaded
+        `controls` :
+            Show user agent controls
+        `crossorigin` :
+            How the element handles crossorigin requests
+        `height` :
+            Vertical dimension
+        `loop` :
+            Whether to loop the media resource
+        `muted` :
+            Whether to mute the media resource by default
+        `playsinline` :
+            Encourage the user agent to display video content within the element's playback area
+        `poster` :
+            Poster frame to show prior to video playback  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `preload` :
+            Hints how much buffering the media resource will likely need
+        `src` :
+            Address of the resource  
+        
+            Valid non-empty URL potentially surrounded by spaces
+        `width` :
+            Horizontal dimension
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "video",
@@ -19285,45 +24227,86 @@ class wbr(BaseElement):
         Initialize 'wbr' (Line breaking opportunity) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
 
-        :param attrs: A list or dictionary of attributes for the element
-        :param id: The element's ID
-        :param class_: Classes to which the element belongs
-            | Set of space-separated tokens
-        :param accesskey: Keyboard shortcut to activate or focus element
-            | Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
-        :param autocapitalize: Recommended autocapitalization behavior (for supported input methods)
-        :param autocorrect: Recommended autocorrection behavior (for supported input methods)
-        :param autofocus: Automatically focus the element when the page is loaded
-        :param contenteditable: Whether the element is editable
-        :param dir: The text directionality of the element
-        :param draggable: Whether the element is draggable
-        :param enterkeyhint: Hint for selecting an enter key action
-        :param hidden: Whether the element is relevant
-        :param inert: Whether the element is inert.
-        :param inputmode: Hint for selecting an input modality
-        :param is_: Creates a customized built-in element
-            | Valid custom element name of a defined customized built-in element
-        :param itemid: Global identifier for a microdata item
-            | Valid URL potentially surrounded by spaces
-        :param itemprop: Property names of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
-        :param itemref: Referenced elements
-            | Unordered set of unique space-separated tokens consisting of IDs*
-        :param itemscope: Introduces a microdata item
-        :param itemtype: Item types of a microdata item
-            | Unordered set of unique space-separated tokens consisting of valid absolute URLs*
-        :param lang: Language of the element
-            | Valid BCP 47 language tag or the empty string
-        :param nonce: Cryptographic nonce used in Content Security Policy checks [CSP]
-        :param popover: Makes the element a popover element
-        :param slot: The element's desired slot
-        :param spellcheck: Whether the element is to have its spelling and grammar checked
-        :param style: Presentational and formatting instructions
-            | CSS declarations*
-        :param tabindex: Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        :param title: Advisory information for the element
-        :param translate: Whether the element is to be translated when the page is localized
-        :param writingsuggestions: Whether the element can offer writing suggestions or not.
+        Parameters
+        ----------
+        `attrs`: 
+            A list or dictionary of attributes for the element
+        `id` :
+            The element's ID
+        `class_` :
+            Classes to which the element belongs  
+        
+            Set of space-separated tokens
+        `accesskey` :
+            Keyboard shortcut to activate or focus element  
+        
+            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        `autocapitalize` :
+            Recommended autocapitalization behavior (for supported input methods)
+        `autocorrect` :
+            Recommended autocorrection behavior (for supported input methods)
+        `autofocus` :
+            Automatically focus the element when the page is loaded
+        `contenteditable` :
+            Whether the element is editable
+        `dir` :
+            The text directionality of the element
+        `draggable` :
+            Whether the element is draggable
+        `enterkeyhint` :
+            Hint for selecting an enter key action
+        `hidden` :
+            Whether the element is relevant
+        `inert` :
+            Whether the element is inert.
+        `inputmode` :
+            Hint for selecting an input modality
+        `is_` :
+            Creates a customized built-in element  
+        
+            Valid custom element name of a defined customized built-in element
+        `itemid` :
+            Global identifier for a microdata item  
+        
+            Valid URL potentially surrounded by spaces
+        `itemprop` :
+            Property names of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        `itemref` :
+            Referenced elements  
+        
+            Unordered set of unique space-separated tokens consisting of IDs*
+        `itemscope` :
+            Introduces a microdata item
+        `itemtype` :
+            Item types of a microdata item  
+        
+            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        `lang` :
+            Language of the element  
+        
+            Valid BCP 47 language tag or the empty string
+        `nonce` :
+            Cryptographic nonce used in Content Security Policy checks [CSP]
+        `popover` :
+            Makes the element a popover element
+        `slot` :
+            The element's desired slot
+        `spellcheck` :
+            Whether the element is to have its spelling and grammar checked
+        `style` :
+            Presentational and formatting instructions  
+        
+            CSS declarations*
+        `tabindex` :
+            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+        `title` :
+            Advisory information for the element
+        `translate` :
+            Whether the element is to be translated when the page is localized
+        `writingsuggestions` :
+            Whether the element can offer writing suggestions or not.
         """ #fmt: skip
         super().__init__(
             "wbr",

--- a/tools/spec_generator.py
+++ b/tools/spec_generator.py
@@ -349,10 +349,7 @@ hextracted = Hextract.hextract(spec_doc)
 document = {}
 
 for element, defn in hextracted.items():
-    document[element] = {
-        "spec": defn,
-        "mdn": None,
-    }
+    document[element] = {"spec": defn, "mdn": None}
 
 for element, defn in MDNSpec.parse().items():
     document[element]["mdn"] = defn


### PR DESCRIPTION
# 0.6.0
* Add livereload feature: 
    A websocket server to auto-reload the browser
    Automatic include of livereload-js through html_compose.HTML5Document 
    live_server daemon function which will automatically run your script and Python server daemon, as well as any build commands
    cross-platform file watcher based on Rust Notify
* Use numpy style docstring parameters with backticks because parameters with _ were being eaten by pylance. Parameter doc newlines should work in this format.
* Command-line script is a module for further extension as `html-compose` 
* Note in docstring that pretty printing can damage output due to the way HTML whitespace works. Development feature only.
