### PR TITLE
0.7.0

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.nodejs_23
+  ];
+}

--- a/src/html_compose/attributes/a_attrs.py
+++ b/src/html_compose/attributes/a_attrs.py
@@ -44,7 +44,7 @@ class AnchorAttrs:
         return BaseAttribute("hreflang", value)
 
     @staticmethod
-    def ping(value) -> BaseAttribute:
+    def ping(value: list) -> BaseAttribute:
         """
         "a" attribute: ping  
         URLs to ping  
@@ -68,7 +68,7 @@ class AnchorAttrs:
         return BaseAttribute("referrerpolicy", value)
 
     @staticmethod
-    def rel(value) -> BaseAttribute:
+    def rel(value: list) -> BaseAttribute:
         """
         "a" attribute: rel  
         Relationship between the location in the document containing the hyperlink and the destination resource  

--- a/src/html_compose/attributes/area_attrs.py
+++ b/src/html_compose/attributes/area_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class AreaAttrs:
@@ -56,7 +57,7 @@ class AreaAttrs:
         return BaseAttribute("href", value)
 
     @staticmethod
-    def ping(value) -> BaseAttribute:
+    def ping(value: list) -> BaseAttribute:
         """
         "area" attribute: ping  
         URLs to ping  
@@ -80,7 +81,7 @@ class AreaAttrs:
         return BaseAttribute("referrerpolicy", value)
 
     @staticmethod
-    def rel(value) -> BaseAttribute:
+    def rel(value: list) -> BaseAttribute:
         """
         "area" attribute: rel  
         Relationship between the location in the document containing the hyperlink and the destination resource  
@@ -92,7 +93,9 @@ class AreaAttrs:
         return BaseAttribute("rel", value)
 
     @staticmethod
-    def shape(value) -> BaseAttribute:
+    def shape(
+        value: Literal["circle", "default", "poly", "rect"],
+    ) -> BaseAttribute:
         """
         "area" attribute: shape  
         The kind of shape to be created in an image map  

--- a/src/html_compose/attributes/audio_attrs.py
+++ b/src/html_compose/attributes/audio_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class AudioAttrs:
@@ -32,7 +33,9 @@ class AudioAttrs:
         return BaseAttribute("controls", value)
 
     @staticmethod
-    def crossorigin(value) -> BaseAttribute:
+    def crossorigin(
+        value: Literal["anonymous", "use-credentials"],
+    ) -> BaseAttribute:
         """
         "audio" attribute: crossorigin  
         How the element handles crossorigin requests  
@@ -68,7 +71,7 @@ class AudioAttrs:
         return BaseAttribute("muted", value)
 
     @staticmethod
-    def preload(value) -> BaseAttribute:
+    def preload(value: Literal["none", "metadata", "auto"]) -> BaseAttribute:
         """
         "audio" attribute: preload  
         Hints how much buffering the media resource will likely need  

--- a/src/html_compose/attributes/bdo_attrs.py
+++ b/src/html_compose/attributes/bdo_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class BdoAttrs:
@@ -8,7 +9,7 @@ class BdoAttrs:
     """
 
     @staticmethod
-    def dir(value) -> BaseAttribute:
+    def dir(value: Literal["ltr", "rtl"]) -> BaseAttribute:
         """
         "bdo" attribute: dir  
         The text directionality of the element  

--- a/src/html_compose/attributes/button_attrs.py
+++ b/src/html_compose/attributes/button_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class ButtonAttrs:
@@ -44,7 +45,13 @@ class ButtonAttrs:
         return BaseAttribute("formaction", value)
 
     @staticmethod
-    def formenctype(value) -> BaseAttribute:
+    def formenctype(
+        value: Literal[
+            "application/x-www-form-urlencoded",
+            "multipart/form-data",
+            "text/plain",
+        ],
+    ) -> BaseAttribute:
         """
         "button" attribute: formenctype  
         Entry list encoding type to use for form submission  
@@ -56,7 +63,7 @@ class ButtonAttrs:
         return BaseAttribute("formenctype", value)
 
     @staticmethod
-    def formmethod(value) -> BaseAttribute:
+    def formmethod(value: Literal["GET", "POST", "dialog"]) -> BaseAttribute:
         """
         "button" attribute: formmethod  
         Variant to use for form submission  
@@ -116,7 +123,9 @@ class ButtonAttrs:
         return BaseAttribute("popovertarget", value)
 
     @staticmethod
-    def popovertargetaction(value) -> BaseAttribute:
+    def popovertargetaction(
+        value: Literal["toggle", "show", "hide"],
+    ) -> BaseAttribute:
         """
         "button" attribute: popovertargetaction  
         Indicates whether a targeted popover element is to be toggled, shown, or hidden  
@@ -128,7 +137,7 @@ class ButtonAttrs:
         return BaseAttribute("popovertargetaction", value)
 
     @staticmethod
-    def type(value) -> BaseAttribute:
+    def type(value: Literal["submit", "reset", "button"]) -> BaseAttribute:
         """
         "button" attribute: type  
         Type of button  

--- a/src/html_compose/attributes/form_attrs.py
+++ b/src/html_compose/attributes/form_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class FormAttrs:
@@ -32,7 +33,7 @@ class FormAttrs:
         return BaseAttribute("action", value)
 
     @staticmethod
-    def autocomplete(value) -> BaseAttribute:
+    def autocomplete(value: Literal["on", "off"]) -> BaseAttribute:
         """
         "form" attribute: autocomplete  
         Default setting for autofill feature for controls in the form  
@@ -44,7 +45,13 @@ class FormAttrs:
         return BaseAttribute("autocomplete", value)
 
     @staticmethod
-    def enctype(value) -> BaseAttribute:
+    def enctype(
+        value: Literal[
+            "application/x-www-form-urlencoded",
+            "multipart/form-data",
+            "text/plain",
+        ],
+    ) -> BaseAttribute:
         """
         "form" attribute: enctype  
         Entry list encoding type to use for form submission  
@@ -56,7 +63,7 @@ class FormAttrs:
         return BaseAttribute("enctype", value)
 
     @staticmethod
-    def method(value) -> BaseAttribute:
+    def method(value: Literal["GET", "POST", "dialog"]) -> BaseAttribute:
         """
         "form" attribute: method  
         Variant to use for form submission  

--- a/src/html_compose/attributes/global_attrs.py
+++ b/src/html_compose/attributes/global_attrs.py
@@ -9,7 +9,7 @@ class GlobalAttrs:
     """
 
     @staticmethod
-    def accesskey(value) -> BaseAttribute:
+    def accesskey(value: list) -> BaseAttribute:
         """
         "global" attribute: accesskey  
         Keyboard shortcut to activate or focus element  
@@ -59,7 +59,7 @@ class GlobalAttrs:
         return BaseAttribute("autofocus", value)
 
     @staticmethod
-    def class_(value) -> BaseAttribute:
+    def class_(value: list) -> BaseAttribute:
         """
         "global" attribute: class  
         Classes to which the element belongs  
@@ -208,7 +208,7 @@ class GlobalAttrs:
         return BaseAttribute("itemid", value)
 
     @staticmethod
-    def itemprop(value) -> BaseAttribute:
+    def itemprop(value: list) -> BaseAttribute:
         """
         "global" attribute: itemprop  
         Property names of a microdata item  
@@ -220,7 +220,7 @@ class GlobalAttrs:
         return BaseAttribute("itemprop", value)
 
     @staticmethod
-    def itemref(value) -> BaseAttribute:
+    def itemref(value: list) -> BaseAttribute:
         """
         "global" attribute: itemref  
         Referenced elements  
@@ -244,7 +244,7 @@ class GlobalAttrs:
         return BaseAttribute("itemscope", value)
 
     @staticmethod
-    def itemtype(value) -> BaseAttribute:
+    def itemtype(value: list) -> BaseAttribute:
         """
         "global" attribute: itemtype  
         Item types of a microdata item  

--- a/src/html_compose/attributes/iframe_attrs.py
+++ b/src/html_compose/attributes/iframe_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class IframeAttrs:
@@ -44,7 +45,7 @@ class IframeAttrs:
         return BaseAttribute("height", value)
 
     @staticmethod
-    def loading(value) -> BaseAttribute:
+    def loading(value: Literal["lazy", "eager"]) -> BaseAttribute:
         """
         "iframe" attribute: loading  
         Used when determining loading deferral  
@@ -80,7 +81,7 @@ class IframeAttrs:
         return BaseAttribute("referrerpolicy", value)
 
     @staticmethod
-    def sandbox(value) -> BaseAttribute:
+    def sandbox(value: list) -> BaseAttribute:
         """
         "iframe" attribute: sandbox  
         Security rules for nested content  

--- a/src/html_compose/attributes/img_attrs.py
+++ b/src/html_compose/attributes/img_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class ImgAttrs:
@@ -20,7 +21,9 @@ class ImgAttrs:
         return BaseAttribute("alt", value)
 
     @staticmethod
-    def crossorigin(value) -> BaseAttribute:
+    def crossorigin(
+        value: Literal["anonymous", "use-credentials"],
+    ) -> BaseAttribute:
         """
         "img" attribute: crossorigin  
         How the element handles crossorigin requests  
@@ -32,7 +35,7 @@ class ImgAttrs:
         return BaseAttribute("crossorigin", value)
 
     @staticmethod
-    def decoding(value) -> BaseAttribute:
+    def decoding(value: Literal["sync", "async", "auto"]) -> BaseAttribute:
         """
         "img" attribute: decoding  
         Decoding hint to use when processing this image for presentation  
@@ -44,7 +47,7 @@ class ImgAttrs:
         return BaseAttribute("decoding", value)
 
     @staticmethod
-    def fetchpriority(value) -> BaseAttribute:
+    def fetchpriority(value: Literal["auto", "high", "low"]) -> BaseAttribute:
         """
         "img" attribute: fetchpriority  
         Sets the priority for fetches initiated by the element  
@@ -80,7 +83,7 @@ class ImgAttrs:
         return BaseAttribute("ismap", value)
 
     @staticmethod
-    def loading(value) -> BaseAttribute:
+    def loading(value: Literal["lazy", "eager"]) -> BaseAttribute:
         """
         "img" attribute: loading  
         Used when determining loading deferral  

--- a/src/html_compose/attributes/input_attrs.py
+++ b/src/html_compose/attributes/input_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class InputAttrs:
@@ -68,7 +69,9 @@ class InputAttrs:
         return BaseAttribute("checked", value)
 
     @staticmethod
-    def colorspace(value) -> BaseAttribute:
+    def colorspace(
+        value: Literal["limited-srgb", "display-p3"],
+    ) -> BaseAttribute:
         """
         "input" attribute: colorspace  
         The color space of the serialized color  
@@ -128,7 +131,13 @@ class InputAttrs:
         return BaseAttribute("formaction", value)
 
     @staticmethod
-    def formenctype(value) -> BaseAttribute:
+    def formenctype(
+        value: Literal[
+            "application/x-www-form-urlencoded",
+            "multipart/form-data",
+            "text/plain",
+        ],
+    ) -> BaseAttribute:
         """
         "input" attribute: formenctype  
         Entry list encoding type to use for form submission  
@@ -140,7 +149,7 @@ class InputAttrs:
         return BaseAttribute("formenctype", value)
 
     @staticmethod
-    def formmethod(value) -> BaseAttribute:
+    def formmethod(value: Literal["GET", "POST", "dialog"]) -> BaseAttribute:
         """
         "input" attribute: formmethod  
         Variant to use for form submission  
@@ -308,7 +317,9 @@ class InputAttrs:
         return BaseAttribute("popovertarget", value)
 
     @staticmethod
-    def popovertargetaction(value) -> BaseAttribute:
+    def popovertargetaction(
+        value: Literal["toggle", "show", "hide"],
+    ) -> BaseAttribute:
         """
         "input" attribute: popovertargetaction  
         Indicates whether a targeted popover element is to be toggled, shown, or hidden  

--- a/src/html_compose/attributes/link_attrs.py
+++ b/src/html_compose/attributes/link_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class LinkAttrs:
@@ -20,7 +21,7 @@ class LinkAttrs:
         return BaseAttribute("as", value)
 
     @staticmethod
-    def blocking(value) -> BaseAttribute:
+    def blocking(value: list) -> BaseAttribute:
         """
         "link" attribute: blocking  
         Whether the element is potentially render-blocking  
@@ -44,7 +45,9 @@ class LinkAttrs:
         return BaseAttribute("color", value)
 
     @staticmethod
-    def crossorigin(value) -> BaseAttribute:
+    def crossorigin(
+        value: Literal["anonymous", "use-credentials"],
+    ) -> BaseAttribute:
         """
         "link" attribute: crossorigin  
         How the element handles crossorigin requests  
@@ -68,7 +71,7 @@ class LinkAttrs:
         return BaseAttribute("disabled", value)
 
     @staticmethod
-    def fetchpriority(value) -> BaseAttribute:
+    def fetchpriority(value: Literal["auto", "high", "low"]) -> BaseAttribute:
         """
         "link" attribute: fetchpriority  
         Sets the priority for fetches initiated by the element  
@@ -164,7 +167,7 @@ class LinkAttrs:
         return BaseAttribute("referrerpolicy", value)
 
     @staticmethod
-    def rel(value) -> BaseAttribute:
+    def rel(value: list) -> BaseAttribute:
         """
         "link" attribute: rel  
         Relationship between the document containing the hyperlink and the destination resource  
@@ -176,7 +179,7 @@ class LinkAttrs:
         return BaseAttribute("rel", value)
 
     @staticmethod
-    def sizes(value) -> BaseAttribute:
+    def sizes(value: list) -> BaseAttribute:
         """
         "link" attribute: sizes  
         Sizes of the icons (for rel="icon")  

--- a/src/html_compose/attributes/meta_attrs.py
+++ b/src/html_compose/attributes/meta_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class MetaAttrs:
@@ -8,7 +9,7 @@ class MetaAttrs:
     """
 
     @staticmethod
-    def charset(value) -> BaseAttribute:
+    def charset(value: Literal["utf-8"]) -> BaseAttribute:
         """
         "meta" attribute: charset  
         Character encoding declaration  
@@ -32,7 +33,15 @@ class MetaAttrs:
         return BaseAttribute("content", value)
 
     @staticmethod
-    def http_equiv(value) -> BaseAttribute:
+    def http_equiv(
+        value: Literal[
+            "content-type",
+            "default-style",
+            "refresh",
+            "x-ua-compatible",
+            "content-security-policy",
+        ],
+    ) -> BaseAttribute:
         """
         "meta" attribute: http-equiv  
         Pragma directive  

--- a/src/html_compose/attributes/ol_attrs.py
+++ b/src/html_compose/attributes/ol_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class OlAttrs:
@@ -32,7 +33,7 @@ class OlAttrs:
         return BaseAttribute("start", value)
 
     @staticmethod
-    def type(value) -> BaseAttribute:
+    def type(value: Literal["1", "a", "A", "i", "I"]) -> BaseAttribute:
         """
         "ol" attribute: type  
         Kind of list marker  

--- a/src/html_compose/attributes/output_attrs.py
+++ b/src/html_compose/attributes/output_attrs.py
@@ -8,7 +8,7 @@ class OutputAttrs:
     """
 
     @staticmethod
-    def for_(value) -> BaseAttribute:
+    def for_(value: list) -> BaseAttribute:
         """
         "output" attribute: for  
         Specifies controls from which the output was calculated  

--- a/src/html_compose/attributes/script_attrs.py
+++ b/src/html_compose/attributes/script_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class ScriptAttrs:
@@ -20,7 +21,7 @@ class ScriptAttrs:
         return BaseAttribute("async", value)
 
     @staticmethod
-    def blocking(value) -> BaseAttribute:
+    def blocking(value: list) -> BaseAttribute:
         """
         "script" attribute: blocking  
         Whether the element is potentially render-blocking  
@@ -32,7 +33,9 @@ class ScriptAttrs:
         return BaseAttribute("blocking", value)
 
     @staticmethod
-    def crossorigin(value) -> BaseAttribute:
+    def crossorigin(
+        value: Literal["anonymous", "use-credentials"],
+    ) -> BaseAttribute:
         """
         "script" attribute: crossorigin  
         How the element handles crossorigin requests  
@@ -56,7 +59,7 @@ class ScriptAttrs:
         return BaseAttribute("defer", value)
 
     @staticmethod
-    def fetchpriority(value) -> BaseAttribute:
+    def fetchpriority(value: Literal["auto", "high", "low"]) -> BaseAttribute:
         """
         "script" attribute: fetchpriority  
         Sets the priority for fetches initiated by the element  

--- a/src/html_compose/attributes/style_attrs.py
+++ b/src/html_compose/attributes/style_attrs.py
@@ -8,7 +8,7 @@ class StyleAttrs:
     """
 
     @staticmethod
-    def blocking(value) -> BaseAttribute:
+    def blocking(value: list) -> BaseAttribute:
         """
         "style" attribute: blocking  
         Whether the element is potentially render-blocking  

--- a/src/html_compose/attributes/td_attrs.py
+++ b/src/html_compose/attributes/td_attrs.py
@@ -20,7 +20,7 @@ class TdAttrs:
         return BaseAttribute("colspan", value)
 
     @staticmethod
-    def headers(value) -> BaseAttribute:
+    def headers(value: list) -> BaseAttribute:
         """
         "td" attribute: headers  
         The header cells for this cell  

--- a/src/html_compose/attributes/template_attrs.py
+++ b/src/html_compose/attributes/template_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class TemplateAttrs:
@@ -32,7 +33,7 @@ class TemplateAttrs:
         return BaseAttribute("shadowrootdelegatesfocus", value)
 
     @staticmethod
-    def shadowrootmode(value) -> BaseAttribute:
+    def shadowrootmode(value: Literal["open", "closed"]) -> BaseAttribute:
         """
         "template" attribute: shadowrootmode  
         Enables streaming declarative shadow roots  

--- a/src/html_compose/attributes/textarea_attrs.py
+++ b/src/html_compose/attributes/textarea_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class TextareaAttrs:
@@ -152,7 +153,7 @@ class TextareaAttrs:
         return BaseAttribute("rows", value)
 
     @staticmethod
-    def wrap(value) -> BaseAttribute:
+    def wrap(value: Literal["soft", "hard"]) -> BaseAttribute:
         """
         "textarea" attribute: wrap  
         How the value of the form control is to be wrapped for form submission  

--- a/src/html_compose/attributes/th_attrs.py
+++ b/src/html_compose/attributes/th_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class ThAttrs:
@@ -32,7 +33,7 @@ class ThAttrs:
         return BaseAttribute("colspan", value)
 
     @staticmethod
-    def headers(value) -> BaseAttribute:
+    def headers(value: list) -> BaseAttribute:
         """
         "th" attribute: headers  
         The header cells for this cell  
@@ -56,7 +57,9 @@ class ThAttrs:
         return BaseAttribute("rowspan", value)
 
     @staticmethod
-    def scope(value) -> BaseAttribute:
+    def scope(
+        value: Literal["row", "col", "rowgroup", "colgroup"],
+    ) -> BaseAttribute:
         """
         "th" attribute: scope  
         Specifies which cells the header cell applies to  

--- a/src/html_compose/attributes/track_attrs.py
+++ b/src/html_compose/attributes/track_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class TrackAttrs:
@@ -20,7 +21,11 @@ class TrackAttrs:
         return BaseAttribute("default", value)
 
     @staticmethod
-    def kind(value) -> BaseAttribute:
+    def kind(
+        value: Literal[
+            "subtitles", "captions", "descriptions", "chapters", "metadata"
+        ],
+    ) -> BaseAttribute:
         """
         "track" attribute: kind  
         The type of text track  

--- a/src/html_compose/attributes/video_attrs.py
+++ b/src/html_compose/attributes/video_attrs.py
@@ -1,4 +1,5 @@
 from . import BaseAttribute
+from typing import Literal
 
 
 class VideoAttrs:
@@ -32,7 +33,9 @@ class VideoAttrs:
         return BaseAttribute("controls", value)
 
     @staticmethod
-    def crossorigin(value) -> BaseAttribute:
+    def crossorigin(
+        value: Literal["anonymous", "use-credentials"],
+    ) -> BaseAttribute:
         """
         "video" attribute: crossorigin  
         How the element handles crossorigin requests  
@@ -104,7 +107,7 @@ class VideoAttrs:
         return BaseAttribute("poster", value)
 
     @staticmethod
-    def preload(value) -> BaseAttribute:
+    def preload(value: Literal["none", "metadata", "auto"]) -> BaseAttribute:
         """
         "video" attribute: preload  
         Hints how much buffering the media resource will likely need  

--- a/src/html_compose/elements.py
+++ b/src/html_compose/elements.py
@@ -83,16 +83,16 @@ class a(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         download: Optional[str] = None,
         href: Optional[str] = None,
         hreflang: Optional[str] = None,
-        ping: Optional[str] = None,
+        ping: Optional[Union[str, list]] = None,
         referrerpolicy: Optional[str] = None,
-        rel: Optional[str] = None,
+        rel: Optional[Union[str, list]] = None,
         target: Optional[str] = None,
         type: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -137,10 +137,10 @@ class a(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -166,9 +166,7 @@ class a(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `download` :
             Whether to download the resource instead of navigating to it, and its filename if so
         `href` :
@@ -180,17 +178,13 @@ class a(BaseElement):
         
             Valid BCP 47 language tag
         `ping` :
-            URLs to ping  
-        
-            Set of space-separated tokens consisting of valid non-empty URLs
+            URLs to ping
         `referrerpolicy` :
             Referrer policy for fetches initiated by the element  
         
             Referrer policy
         `rel` :
-            Relationship between the location in the document containing the hyperlink and the destination resource  
-        
-            Unordered set of unique space-separated tokens*
+            Relationship between the location in the document containing the hyperlink and the destination resource
         `target` :
             Navigable for hyperlink navigation  
         
@@ -200,9 +194,7 @@ class a(BaseElement):
         
             Valid MIME type string
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -232,19 +224,13 @@ class a(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -377,8 +363,8 @@ class abbr(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -423,10 +409,10 @@ class abbr(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -452,13 +438,9 @@ class abbr(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -488,19 +470,13 @@ class abbr(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -617,8 +593,8 @@ class address(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -663,10 +639,10 @@ class address(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -692,13 +668,9 @@ class address(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -728,19 +700,13 @@ class address(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -857,19 +823,19 @@ class area(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         alt: Optional[str] = None,
         coords: Optional[str] = None,
         download: Optional[str] = None,
         href: Optional[str] = None,
-        ping: Optional[str] = None,
+        ping: Optional[Union[str, list]] = None,
         referrerpolicy: Optional[str] = None,
-        rel: Optional[str] = None,
+        rel: Optional[Union[str, list]] = None,
         shape: Optional[
             Union[str, Literal["circle", "default", "poly", "rect"]]
         ] = None,
         target: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -914,10 +880,10 @@ class area(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -943,9 +909,7 @@ class area(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `alt` :
             Replacement text for use when images are not available
         `coords` :
@@ -959,17 +923,13 @@ class area(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `ping` :
-            URLs to ping  
-        
-            Set of space-separated tokens consisting of valid non-empty URLs
+            URLs to ping
         `referrerpolicy` :
             Referrer policy for fetches initiated by the element  
         
             Referrer policy
         `rel` :
-            Relationship between the location in the document containing the hyperlink and the destination resource  
-        
-            Unordered set of unique space-separated tokens*
+            Relationship between the location in the document containing the hyperlink and the destination resource
         `shape` :
             The kind of shape to be created in an image map
         `target` :
@@ -977,9 +937,7 @@ class area(BaseElement):
         
             Valid navigable target name or keyword
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -1009,19 +967,13 @@ class area(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -1156,8 +1108,8 @@ class article(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -1202,10 +1154,10 @@ class article(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -1231,13 +1183,9 @@ class article(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -1267,19 +1215,13 @@ class article(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -1396,8 +1338,8 @@ class aside(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -1442,10 +1384,10 @@ class aside(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -1471,13 +1413,9 @@ class aside(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -1507,19 +1445,13 @@ class aside(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -1636,7 +1568,7 @@ class audio(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         autoplay: Optional[Union[str, bool]] = None,
         controls: Optional[Union[str, bool]] = None,
         crossorigin: Optional[
@@ -1648,7 +1580,7 @@ class audio(BaseElement):
             Union[str, Literal["none", "metadata", "auto"]]
         ] = None,
         src: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -1693,10 +1625,10 @@ class audio(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -1722,9 +1654,7 @@ class audio(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `autoplay` :
             Hint that the media resource can be started automatically when the page is loaded
         `controls` :
@@ -1742,9 +1672,7 @@ class audio(BaseElement):
         
             Valid non-empty URL potentially surrounded by spaces
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -1774,19 +1702,13 @@ class audio(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -1917,8 +1839,8 @@ class b(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -1963,10 +1885,10 @@ class b(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -1992,13 +1914,9 @@ class b(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -2028,19 +1946,13 @@ class b(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -2157,10 +2069,10 @@ class base(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         href: Optional[str] = None,
         target: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -2205,10 +2117,10 @@ class base(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -2234,9 +2146,7 @@ class base(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `href` :
             Document base URL  
         
@@ -2246,9 +2156,7 @@ class base(BaseElement):
         
             Valid navigable target name or keyword
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -2278,19 +2186,13 @@ class base(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -2411,8 +2313,8 @@ class bdi(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -2457,10 +2359,10 @@ class bdi(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -2486,13 +2388,9 @@ class bdi(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -2522,19 +2420,13 @@ class bdi(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -2651,8 +2543,8 @@ class bdo(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -2697,10 +2589,10 @@ class bdo(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -2726,13 +2618,9 @@ class bdo(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -2762,19 +2650,13 @@ class bdo(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -2891,9 +2773,9 @@ class blockquote(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         cite: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -2938,10 +2820,10 @@ class blockquote(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -2967,17 +2849,13 @@ class blockquote(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `cite` :
             Link to the source of the quotation or more information about the edit  
         
             Valid URL potentially surrounded by spaces
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -3007,19 +2885,13 @@ class blockquote(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -3138,8 +3010,8 @@ class body(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -3184,10 +3056,10 @@ class body(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -3213,13 +3085,9 @@ class body(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -3249,19 +3117,13 @@ class body(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -3378,8 +3240,8 @@ class br(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -3424,10 +3286,10 @@ class br(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -3453,13 +3315,9 @@ class br(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -3489,19 +3347,13 @@ class br(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -3618,7 +3470,7 @@ class button(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         disabled: Optional[Union[str, bool]] = None,
         form: Optional[str] = None,
         formaction: Optional[str] = None,
@@ -3644,7 +3496,7 @@ class button(BaseElement):
         ] = None,
         type: Optional[Union[str, Literal["submit", "reset", "button"]]] = None,
         value: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -3689,10 +3541,10 @@ class button(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -3718,9 +3570,7 @@ class button(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `disabled` :
             Whether the form control is disabled
         `form` :
@@ -3754,9 +3604,7 @@ class button(BaseElement):
         `value` :
             Value to be used for form submission
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -3786,19 +3634,13 @@ class button(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -3939,10 +3781,10 @@ class canvas(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         height: Optional[Union[str, int]] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -3987,10 +3829,10 @@ class canvas(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -4016,17 +3858,13 @@ class canvas(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `height` :
             Vertical dimension
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -4056,19 +3894,13 @@ class canvas(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -4189,8 +4021,8 @@ class caption(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -4235,10 +4067,10 @@ class caption(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -4264,13 +4096,9 @@ class caption(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -4300,19 +4128,13 @@ class caption(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -4429,8 +4251,8 @@ class cite(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -4475,10 +4297,10 @@ class cite(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -4504,13 +4326,9 @@ class cite(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -4540,19 +4358,13 @@ class cite(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -4669,8 +4481,8 @@ class code(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -4715,10 +4527,10 @@ class code(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -4744,13 +4556,9 @@ class code(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -4780,19 +4588,13 @@ class code(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -4909,9 +4711,9 @@ class col(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         span: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -4956,10 +4758,10 @@ class col(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -4985,17 +4787,13 @@ class col(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `span` :
             Number of columns spanned by the element  
         
             Valid non-negative integer greater than zero
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -5025,19 +4823,13 @@ class col(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -5156,9 +4948,9 @@ class colgroup(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         span: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -5203,10 +4995,10 @@ class colgroup(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -5232,17 +5024,13 @@ class colgroup(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `span` :
             Number of columns spanned by the element  
         
             Valid non-negative integer greater than zero
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -5272,19 +5060,13 @@ class colgroup(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -5403,9 +5185,9 @@ class data(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         value: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -5450,10 +5232,10 @@ class data(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -5479,15 +5261,11 @@ class data(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `value` :
             Machine-readable value
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -5517,19 +5295,13 @@ class data(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -5648,8 +5420,8 @@ class datalist(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -5694,10 +5466,10 @@ class datalist(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -5723,13 +5495,9 @@ class datalist(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -5759,19 +5527,13 @@ class datalist(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -5888,8 +5650,8 @@ class dd(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -5934,10 +5696,10 @@ class dd(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -5963,13 +5725,9 @@ class dd(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -5999,19 +5757,13 @@ class dd(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -6128,10 +5880,10 @@ class del_(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         cite: Optional[str] = None,
         datetime: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -6176,10 +5928,10 @@ class del_(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -6205,9 +5957,7 @@ class del_(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `cite` :
             Link to the source of the quotation or more information about the edit  
         
@@ -6217,9 +5967,7 @@ class del_(BaseElement):
         
             Valid date string with optional time
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -6249,19 +5997,13 @@ class del_(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -6382,10 +6124,10 @@ class details(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         name: Optional[str] = None,
         open: Optional[Union[str, bool]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -6430,10 +6172,10 @@ class details(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -6459,17 +6201,13 @@ class details(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `name` :
             Name of group of mutually-exclusive details elements
         `open` :
             Whether the details are visible
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -6499,19 +6237,13 @@ class details(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -6632,8 +6364,8 @@ class dfn(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -6678,10 +6410,10 @@ class dfn(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -6707,13 +6439,9 @@ class dfn(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -6743,19 +6471,13 @@ class dfn(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -6872,9 +6594,9 @@ class dialog(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         open: Optional[Union[str, bool]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -6919,10 +6641,10 @@ class dialog(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -6948,15 +6670,11 @@ class dialog(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `open` :
             Whether the dialog box is showing
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -6986,19 +6704,13 @@ class dialog(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -7117,8 +6829,8 @@ class div(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -7163,10 +6875,10 @@ class div(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -7192,13 +6904,9 @@ class div(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -7228,19 +6936,13 @@ class div(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -7357,8 +7059,8 @@ class dl(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -7403,10 +7105,10 @@ class dl(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -7432,13 +7134,9 @@ class dl(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -7468,19 +7166,13 @@ class dl(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -7597,8 +7289,8 @@ class dt(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -7643,10 +7335,10 @@ class dt(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -7672,13 +7364,9 @@ class dt(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -7708,19 +7396,13 @@ class dt(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -7837,8 +7519,8 @@ class em(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -7883,10 +7565,10 @@ class em(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -7912,13 +7594,9 @@ class em(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -7948,19 +7626,13 @@ class em(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -8077,12 +7749,12 @@ class embed(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         height: Optional[Union[str, int]] = None,
         src: Optional[str] = None,
         type: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -8127,10 +7799,10 @@ class embed(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -8156,9 +7828,7 @@ class embed(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `height` :
             Vertical dimension
         `src` :
@@ -8172,9 +7842,7 @@ class embed(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -8204,19 +7872,13 @@ class embed(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -8341,11 +8003,11 @@ class fieldset(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         disabled: Optional[Union[str, bool]] = None,
         form: Optional[str] = None,
         name: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -8390,10 +8052,10 @@ class fieldset(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -8419,9 +8081,7 @@ class fieldset(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `disabled` :
             Whether the descendant form controls, except any inside legend, are disabled
         `form` :
@@ -8431,9 +8091,7 @@ class fieldset(BaseElement):
         `name` :
             Name of the element to use for form submission and in the form.elements API
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -8463,19 +8121,13 @@ class fieldset(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -8598,8 +8250,8 @@ class figcaption(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -8644,10 +8296,10 @@ class figcaption(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -8673,13 +8325,9 @@ class figcaption(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -8709,19 +8357,13 @@ class figcaption(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -8838,8 +8480,8 @@ class figure(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -8884,10 +8526,10 @@ class figure(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -8913,13 +8555,9 @@ class figure(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -8949,19 +8587,13 @@ class figure(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -9078,8 +8710,8 @@ class footer(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -9124,10 +8756,10 @@ class footer(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -9153,13 +8785,9 @@ class footer(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -9189,19 +8817,13 @@ class footer(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -9318,7 +8940,7 @@ class form(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         accept_charset: Optional[str] = None,
         action: Optional[str] = None,
         autocomplete: Optional[Union[str, Literal["on", "off"]]] = None,
@@ -9336,7 +8958,7 @@ class form(BaseElement):
         name: Optional[str] = None,
         novalidate: Optional[Union[str, bool]] = None,
         target: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -9381,10 +9003,10 @@ class form(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -9410,9 +9032,7 @@ class form(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accept_charset` :
             Character encodings to use for form submission  
         
@@ -9436,9 +9056,7 @@ class form(BaseElement):
         
             Valid navigable target name or keyword
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -9468,19 +9086,13 @@ class form(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -9613,8 +9225,8 @@ class h1(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -9659,10 +9271,10 @@ class h1(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -9688,13 +9300,9 @@ class h1(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -9724,19 +9332,13 @@ class h1(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -9853,8 +9455,8 @@ class h2(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -9899,10 +9501,10 @@ class h2(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -9928,13 +9530,9 @@ class h2(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -9964,19 +9562,13 @@ class h2(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -10093,8 +9685,8 @@ class h3(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -10139,10 +9731,10 @@ class h3(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -10168,13 +9760,9 @@ class h3(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -10204,19 +9792,13 @@ class h3(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -10333,8 +9915,8 @@ class h4(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -10379,10 +9961,10 @@ class h4(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -10408,13 +9990,9 @@ class h4(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -10444,19 +10022,13 @@ class h4(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -10573,8 +10145,8 @@ class h5(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -10619,10 +10191,10 @@ class h5(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -10648,13 +10220,9 @@ class h5(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -10684,19 +10252,13 @@ class h5(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -10813,8 +10375,8 @@ class h6(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -10859,10 +10421,10 @@ class h6(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -10888,13 +10450,9 @@ class h6(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -10924,19 +10482,13 @@ class h6(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -11053,8 +10605,8 @@ class head(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -11099,10 +10651,10 @@ class head(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -11128,13 +10680,9 @@ class head(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -11164,19 +10712,13 @@ class head(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -11293,8 +10835,8 @@ class header(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -11339,10 +10881,10 @@ class header(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -11368,13 +10910,9 @@ class header(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -11404,19 +10942,13 @@ class header(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -11533,8 +11065,8 @@ class hgroup(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -11579,10 +11111,10 @@ class hgroup(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -11608,13 +11140,9 @@ class hgroup(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -11644,19 +11172,13 @@ class hgroup(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -11773,8 +11295,8 @@ class hr(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -11819,10 +11341,10 @@ class hr(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -11848,13 +11370,9 @@ class hr(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -11884,19 +11402,13 @@ class hr(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -12013,8 +11525,8 @@ class html(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -12059,10 +11571,10 @@ class html(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -12088,13 +11600,9 @@ class html(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -12124,19 +11632,13 @@ class html(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -12253,8 +11755,8 @@ class i(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -12299,10 +11801,10 @@ class i(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -12328,13 +11830,9 @@ class i(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -12364,19 +11862,13 @@ class i(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -12493,18 +11985,18 @@ class iframe(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         allow: Optional[str] = None,
         allowfullscreen: Optional[Union[str, bool]] = None,
         height: Optional[Union[str, int]] = None,
         loading: Optional[Union[str, Literal["lazy", "eager"]]] = None,
         name: Optional[str] = None,
         referrerpolicy: Optional[str] = None,
-        sandbox: Optional[str] = None,
+        sandbox: Optional[Union[str, list]] = None,
         src: Optional[str] = None,
         srcdoc: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -12549,10 +12041,10 @@ class iframe(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -12578,9 +12070,7 @@ class iframe(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `allow` :
             Permissions policy to be applied to the iframe's contents  
         
@@ -12600,9 +12090,7 @@ class iframe(BaseElement):
         
             Referrer policy
         `sandbox` :
-            Security rules for nested content  
-        
-            Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of "allow-downloads" "allow-forms" "allow-modals" "allow-orientation-lock" "allow-pointer-lock" "allow-popups" "allow-popups-to-escape-sandbox" "allow-presentation" "allow-same-origin" "allow-scripts" "allow-top-navigation" "allow-top-navigation-by-user-activation" "allow-top-navigation-to-custom-protocols"
+            Security rules for nested content
         `src` :
             Address of the resource  
         
@@ -12614,9 +12102,7 @@ class iframe(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -12646,19 +12132,13 @@ class iframe(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -12795,7 +12275,7 @@ class img(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         alt: Optional[str] = None,
         crossorigin: Optional[
             Union[str, Literal["anonymous", "use-credentials"]]
@@ -12813,7 +12293,7 @@ class img(BaseElement):
         srcset: Optional[str] = None,
         usemap: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -12858,10 +12338,10 @@ class img(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -12887,9 +12367,7 @@ class img(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `alt` :
             Replacement text for use when images are not available
         `crossorigin` :
@@ -12927,9 +12405,7 @@ class img(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -12959,19 +12435,13 @@ class img(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -13114,7 +12584,7 @@ class input(BaseElement):  # type: ignore[misc]
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         accept: Optional[str] = None,
         alpha: Optional[Union[str, bool]] = None,
         alt: Optional[str] = None,
@@ -13165,7 +12635,7 @@ class input(BaseElement):  # type: ignore[misc]
         type: Optional[str] = None,
         value: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -13210,10 +12680,10 @@ class input(BaseElement):  # type: ignore[misc]
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -13238,9 +12708,7 @@ class input(BaseElement):  # type: ignore[misc]
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accept` :
             Hint for expected file type in file upload controls  
         
@@ -13340,9 +12808,7 @@ class input(BaseElement):  # type: ignore[misc]
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -13372,19 +12838,13 @@ class input(BaseElement):  # type: ignore[misc]
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -13567,10 +13027,10 @@ class ins(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         cite: Optional[str] = None,
         datetime: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -13615,10 +13075,10 @@ class ins(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -13644,9 +13104,7 @@ class ins(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `cite` :
             Link to the source of the quotation or more information about the edit  
         
@@ -13656,9 +13114,7 @@ class ins(BaseElement):
         
             Valid date string with optional time
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -13688,19 +13144,13 @@ class ins(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -13821,8 +13271,8 @@ class kbd(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -13867,10 +13317,10 @@ class kbd(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -13896,13 +13346,9 @@ class kbd(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -13932,19 +13378,13 @@ class kbd(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -14061,9 +13501,9 @@ class label(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         for_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -14108,10 +13548,10 @@ class label(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -14137,17 +13577,13 @@ class label(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `for_` :
             Associate the label with form control  
         
             ID*
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -14177,19 +13613,13 @@ class label(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -14308,8 +13738,8 @@ class legend(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -14354,10 +13784,10 @@ class legend(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -14383,13 +13813,9 @@ class legend(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -14419,19 +13845,13 @@ class legend(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -14548,9 +13968,9 @@ class li(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         value: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -14595,10 +14015,10 @@ class li(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -14624,15 +14044,11 @@ class li(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `value` :
             Ordinal value of the list item
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -14662,19 +14078,13 @@ class li(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -14793,9 +14203,9 @@ class link(BaseElement):  # type: ignore[misc]
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         as_: Optional[str] = None,
-        blocking: Optional[str] = None,
+        blocking: Optional[Union[str, list]] = None,
         color: Optional[str] = None,
         crossorigin: Optional[
             Union[str, Literal["anonymous", "use-credentials"]]
@@ -14811,11 +14221,11 @@ class link(BaseElement):  # type: ignore[misc]
         integrity: Optional[str] = None,
         media: Optional[str] = None,
         referrerpolicy: Optional[str] = None,
-        rel: Optional[str] = None,
-        sizes: Optional[str] = None,
+        rel: Optional[Union[str, list]] = None,
+        sizes: Optional[Union[str, list]] = None,
         title: Optional[str] = None,
         type: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -14860,10 +14270,10 @@ class link(BaseElement):  # type: ignore[misc]
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -14888,17 +14298,13 @@ class link(BaseElement):  # type: ignore[misc]
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `as_` :
             Potential destination for a preload request (for rel="preload" and rel="modulepreload")  
         
             Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
         `blocking` :
-            Whether the element is potentially render-blocking  
-        
-            Unordered set of unique space-separated tokens*
+            Whether the element is potentially render-blocking
         `color` :
             Color to use when customizing a site's icon (for rel="mask-icon")  
         
@@ -14936,13 +14342,9 @@ class link(BaseElement):  # type: ignore[misc]
         
             Referrer policy
         `rel` :
-            Relationship between the document containing the hyperlink and the destination resource  
-        
-            Unordered set of unique space-separated tokens*
+            Relationship between the document containing the hyperlink and the destination resource
         `sizes` :
-            Sizes of the icons (for rel="icon")  
-        
-            Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of sizes*
+            Sizes of the icons (for rel="icon")
         `title` :
             CSS style sheet set name
         `title` :
@@ -14952,9 +14354,7 @@ class link(BaseElement):  # type: ignore[misc]
         
             Valid MIME type string
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -14984,19 +14384,13 @@ class link(BaseElement):  # type: ignore[misc]
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -15143,8 +14537,8 @@ class main(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -15189,10 +14583,10 @@ class main(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -15218,13 +14612,9 @@ class main(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -15254,19 +14644,13 @@ class main(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -15383,9 +14767,9 @@ class map(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         name: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -15430,10 +14814,10 @@ class map(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -15459,15 +14843,11 @@ class map(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `name` :
             Name of image map to reference from the usemap attribute
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -15497,19 +14877,13 @@ class map(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -15628,8 +15002,8 @@ class mark(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -15674,10 +15048,10 @@ class mark(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -15703,13 +15077,9 @@ class mark(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -15739,19 +15109,13 @@ class mark(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -15868,8 +15232,8 @@ class menu(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -15914,10 +15278,10 @@ class menu(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -15943,13 +15307,9 @@ class menu(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -15979,19 +15339,13 @@ class menu(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -16108,7 +15462,7 @@ class meta(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         charset: Optional[Union[str, Literal["utf-8"]]] = None,
         content: Optional[str] = None,
         http_equiv: Optional[
@@ -16125,7 +15479,7 @@ class meta(BaseElement):
         ] = None,
         media: Optional[str] = None,
         name: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -16170,10 +15524,10 @@ class meta(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -16199,9 +15553,7 @@ class meta(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `charset` :
             Character encoding declaration
         `content` :
@@ -16215,9 +15567,7 @@ class meta(BaseElement):
         `name` :
             Metadata name
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -16247,19 +15597,13 @@ class meta(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -16386,14 +15730,14 @@ class meter(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         high: Optional[Union[str, float]] = None,
         low: Optional[Union[str, float]] = None,
         max: Optional[Union[str, float]] = None,
         min: Optional[Union[str, float]] = None,
         optimum: Optional[Union[str, float]] = None,
         value: Optional[Union[str, float]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -16438,10 +15782,10 @@ class meter(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -16467,9 +15811,7 @@ class meter(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `high` :
             Low limit of high range
         `low` :
@@ -16483,9 +15825,7 @@ class meter(BaseElement):
         `value` :
             Current value of the element
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -16515,19 +15855,13 @@ class meter(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -16656,8 +15990,8 @@ class nav(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -16702,10 +16036,10 @@ class nav(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -16731,13 +16065,9 @@ class nav(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -16767,19 +16097,13 @@ class nav(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -16896,8 +16220,8 @@ class noscript(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -16942,10 +16266,10 @@ class noscript(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -16971,13 +16295,9 @@ class noscript(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -17007,19 +16327,13 @@ class noscript(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -17136,14 +16450,14 @@ class object(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         data: Optional[str] = None,
         form: Optional[str] = None,
         height: Optional[Union[str, int]] = None,
         name: Optional[str] = None,
         type: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -17188,10 +16502,10 @@ class object(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -17217,9 +16531,7 @@ class object(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `data` :
             Address of the resource  
         
@@ -17241,9 +16553,7 @@ class object(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -17273,19 +16583,13 @@ class object(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -17414,11 +16718,11 @@ class ol(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         reversed: Optional[Union[str, bool]] = None,
         start: Optional[Union[str, int]] = None,
         type: Optional[Union[str, Literal["1", "a", "A", "i", "I"]]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -17463,10 +16767,10 @@ class ol(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -17492,9 +16796,7 @@ class ol(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `reversed` :
             Number the list backwards
         `start` :
@@ -17502,9 +16804,7 @@ class ol(BaseElement):
         `type` :
             Kind of list marker
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -17534,19 +16834,13 @@ class ol(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -17669,10 +16963,10 @@ class optgroup(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         disabled: Optional[Union[str, bool]] = None,
         label: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -17717,10 +17011,10 @@ class optgroup(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -17746,17 +17040,13 @@ class optgroup(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `disabled` :
             Whether the form control is disabled
         `label` :
             User-visible label
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -17786,19 +17076,13 @@ class optgroup(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -17919,12 +17203,12 @@ class option(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         disabled: Optional[Union[str, bool]] = None,
         label: Optional[str] = None,
         selected: Optional[Union[str, bool]] = None,
         value: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -17969,10 +17253,10 @@ class option(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -17998,9 +17282,7 @@ class option(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `disabled` :
             Whether the form control is disabled
         `label` :
@@ -18010,9 +17292,7 @@ class option(BaseElement):
         `value` :
             Value to be used for form submission
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -18042,19 +17322,13 @@ class option(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -18179,11 +17453,11 @@ class output(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        for_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        for_: Optional[Union[str, list]] = None,
         form: Optional[str] = None,
         name: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -18228,10 +17502,10 @@ class output(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -18257,13 +17531,9 @@ class output(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `for_` :
-            Specifies controls from which the output was calculated  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Specifies controls from which the output was calculated
         `form` :
             Associates the element with a form element  
         
@@ -18271,9 +17541,7 @@ class output(BaseElement):
         `name` :
             Name of the element to use for form submission and in the form.elements API
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -18303,19 +17571,13 @@ class output(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -18438,8 +17700,8 @@ class p(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -18484,10 +17746,10 @@ class p(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -18513,13 +17775,9 @@ class p(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -18549,19 +17807,13 @@ class p(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -18678,8 +17930,8 @@ class picture(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -18724,10 +17976,10 @@ class picture(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -18753,13 +18005,9 @@ class picture(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -18789,19 +18037,13 @@ class picture(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -18918,8 +18160,8 @@ class pre(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -18964,10 +18206,10 @@ class pre(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -18993,13 +18235,9 @@ class pre(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -19029,19 +18267,13 @@ class pre(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -19158,10 +18390,10 @@ class progress(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         max: Optional[Union[str, float]] = None,
         value: Optional[Union[str, float]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -19206,10 +18438,10 @@ class progress(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -19235,17 +18467,13 @@ class progress(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `max` :
             Upper bound of range
         `value` :
             Current value of the element
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -19275,19 +18503,13 @@ class progress(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -19408,9 +18630,9 @@ class q(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         cite: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -19455,10 +18677,10 @@ class q(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -19484,17 +18706,13 @@ class q(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `cite` :
             Link to the source of the quotation or more information about the edit  
         
             Valid URL potentially surrounded by spaces
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -19524,19 +18742,13 @@ class q(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -19655,8 +18867,8 @@ class rp(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -19701,10 +18913,10 @@ class rp(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -19730,13 +18942,9 @@ class rp(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -19766,19 +18974,13 @@ class rp(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -19895,8 +19097,8 @@ class rt(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -19941,10 +19143,10 @@ class rt(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -19970,13 +19172,9 @@ class rt(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -20006,19 +19204,13 @@ class rt(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -20135,8 +19327,8 @@ class ruby(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -20181,10 +19373,10 @@ class ruby(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -20210,13 +19402,9 @@ class ruby(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -20246,19 +19434,13 @@ class ruby(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -20375,8 +19557,8 @@ class s(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -20421,10 +19603,10 @@ class s(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -20450,13 +19632,9 @@ class s(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -20486,19 +19664,13 @@ class s(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -20615,8 +19787,8 @@ class samp(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -20661,10 +19833,10 @@ class samp(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -20690,13 +19862,9 @@ class samp(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -20726,19 +19894,13 @@ class samp(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -20855,9 +20017,9 @@ class script(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         async_: Optional[Union[str, bool]] = None,
-        blocking: Optional[str] = None,
+        blocking: Optional[Union[str, list]] = None,
         crossorigin: Optional[
             Union[str, Literal["anonymous", "use-credentials"]]
         ] = None,
@@ -20870,7 +20032,7 @@ class script(BaseElement):
         referrerpolicy: Optional[str] = None,
         src: Optional[str] = None,
         type: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -20915,10 +20077,10 @@ class script(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -20944,15 +20106,11 @@ class script(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `async_` :
             Execute script when available, without blocking while fetching
         `blocking` :
-            Whether the element is potentially render-blocking  
-        
-            Unordered set of unique space-separated tokens*
+            Whether the element is potentially render-blocking
         `crossorigin` :
             How the element handles crossorigin requests
         `defer` :
@@ -20976,9 +20134,7 @@ class script(BaseElement):
         
             "module"; a valid MIME type string that is not a JavaScript MIME type essence match
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -21008,19 +20164,13 @@ class script(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -21157,8 +20307,8 @@ class search(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -21203,10 +20353,10 @@ class search(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -21232,13 +20382,9 @@ class search(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -21268,19 +20414,13 @@ class search(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -21397,8 +20537,8 @@ class section(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -21443,10 +20583,10 @@ class section(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -21472,13 +20612,9 @@ class section(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -21508,19 +20644,13 @@ class section(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -21637,7 +20767,7 @@ class select(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         autocomplete: Optional[str] = None,
         disabled: Optional[Union[str, bool]] = None,
         form: Optional[str] = None,
@@ -21645,7 +20775,7 @@ class select(BaseElement):
         name: Optional[str] = None,
         required: Optional[Union[str, bool]] = None,
         size: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -21690,10 +20820,10 @@ class select(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -21719,9 +20849,7 @@ class select(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `autocomplete` :
             Hint for form autofill feature  
         
@@ -21743,9 +20871,7 @@ class select(BaseElement):
         
             Valid non-negative integer greater than zero
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -21775,19 +20901,13 @@ class select(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -21918,9 +21038,9 @@ class slot(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         name: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -21965,10 +21085,10 @@ class slot(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -21994,15 +21114,11 @@ class slot(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `name` :
             Name of shadow tree slot
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -22032,19 +21148,13 @@ class slot(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -22163,8 +21273,8 @@ class small(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -22209,10 +21319,10 @@ class small(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -22238,13 +21348,9 @@ class small(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -22274,19 +21380,13 @@ class small(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -22403,7 +21503,7 @@ class source(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         height: Optional[Union[str, int]] = None,
         media: Optional[str] = None,
         sizes: Optional[str] = None,
@@ -22411,7 +21511,7 @@ class source(BaseElement):
         srcset: Optional[str] = None,
         type: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -22456,10 +21556,10 @@ class source(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -22485,9 +21585,7 @@ class source(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `height` :
             Vertical dimension
         `media` :
@@ -22513,9 +21611,7 @@ class source(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -22545,19 +21641,13 @@ class source(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -22688,8 +21778,8 @@ class span(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -22734,10 +21824,10 @@ class span(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -22763,13 +21853,9 @@ class span(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -22799,19 +21885,13 @@ class span(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -22928,8 +22008,8 @@ class strong(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -22974,10 +22054,10 @@ class strong(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -23003,13 +22083,9 @@ class strong(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -23039,19 +22115,13 @@ class strong(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -23168,11 +22238,11 @@ class style(BaseElement):  # type: ignore[misc]
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        blocking: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        blocking: Optional[Union[str, list]] = None,
         media: Optional[str] = None,
         title: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -23217,10 +22287,10 @@ class style(BaseElement):  # type: ignore[misc]
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -23245,13 +22315,9 @@ class style(BaseElement):  # type: ignore[misc]
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `blocking` :
-            Whether the element is potentially render-blocking  
-        
-            Unordered set of unique space-separated tokens*
+            Whether the element is potentially render-blocking
         `media` :
             Applicable media  
         
@@ -23259,9 +22325,7 @@ class style(BaseElement):  # type: ignore[misc]
         `title` :
             CSS style sheet set name
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -23291,19 +22355,13 @@ class style(BaseElement):  # type: ignore[misc]
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -23422,8 +22480,8 @@ class sub(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -23468,10 +22526,10 @@ class sub(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -23497,13 +22555,9 @@ class sub(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -23533,19 +22587,13 @@ class sub(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -23662,8 +22710,8 @@ class summary(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -23708,10 +22756,10 @@ class summary(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -23737,13 +22785,9 @@ class summary(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -23773,19 +22817,13 @@ class summary(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -23902,8 +22940,8 @@ class sup(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -23948,10 +22986,10 @@ class sup(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -23977,13 +23015,9 @@ class sup(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -24013,19 +23047,13 @@ class sup(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -24142,8 +23170,8 @@ class svg(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -24188,10 +23216,10 @@ class svg(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -24217,13 +23245,9 @@ class svg(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -24253,19 +23277,13 @@ class svg(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -24382,8 +23400,8 @@ class table(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -24428,10 +23446,10 @@ class table(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -24457,13 +23475,9 @@ class table(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -24493,19 +23507,13 @@ class table(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -24622,8 +23630,8 @@ class tbody(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -24668,10 +23676,10 @@ class tbody(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -24697,13 +23705,9 @@ class tbody(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -24733,19 +23737,13 @@ class tbody(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -24862,11 +23860,11 @@ class td(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         colspan: Optional[str] = None,
-        headers: Optional[str] = None,
+        headers: Optional[Union[str, list]] = None,
         rowspan: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -24911,10 +23909,10 @@ class td(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -24940,23 +23938,17 @@ class td(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `colspan` :
             Number of columns that the cell is to span  
         
             Valid non-negative integer greater than zero
         `headers` :
-            The header cells for this cell  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            The header cells for this cell
         `rowspan` :
             Number of rows that the cell is to span
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -24986,19 +23978,13 @@ class td(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -25121,12 +24107,12 @@ class template(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         shadowrootclonable: Optional[Union[str, bool]] = None,
         shadowrootdelegatesfocus: Optional[Union[str, bool]] = None,
         shadowrootmode: Optional[Union[str, Literal["open", "closed"]]] = None,
         shadowrootserializable: Optional[Union[str, bool]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -25171,10 +24157,10 @@ class template(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -25200,9 +24186,7 @@ class template(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `shadowrootclonable` :
             Sets clonable on a declarative shadow root
         `shadowrootdelegatesfocus` :
@@ -25212,9 +24196,7 @@ class template(BaseElement):
         `shadowrootserializable` :
             Sets serializable on a declarative shadow root
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -25244,19 +24226,13 @@ class template(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -25388,7 +24364,7 @@ class textarea(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         autocomplete: Optional[str] = None,
         cols: Optional[str] = None,
         dirname: Optional[str] = None,
@@ -25402,7 +24378,7 @@ class textarea(BaseElement):
         required: Optional[Union[str, bool]] = None,
         rows: Optional[str] = None,
         wrap: Optional[Union[str, Literal["soft", "hard"]]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -25447,10 +24423,10 @@ class textarea(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -25476,9 +24452,7 @@ class textarea(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `autocomplete` :
             Hint for form autofill feature  
         
@@ -25514,9 +24488,7 @@ class textarea(BaseElement):
         `wrap` :
             How the value of the form control is to be wrapped for form submission
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -25546,19 +24518,13 @@ class textarea(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -25701,8 +24667,8 @@ class tfoot(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -25747,10 +24713,10 @@ class tfoot(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -25776,13 +24742,9 @@ class tfoot(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -25812,19 +24774,13 @@ class tfoot(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -25941,15 +24897,15 @@ class th(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         abbr: Optional[str] = None,
         colspan: Optional[str] = None,
-        headers: Optional[str] = None,
+        headers: Optional[Union[str, list]] = None,
         rowspan: Optional[Union[str, int]] = None,
         scope: Optional[
             Union[str, Literal["row", "col", "rowgroup", "colgroup"]]
         ] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -25994,10 +24950,10 @@ class th(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -26023,9 +24979,7 @@ class th(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `abbr` :
             Alternative label to use for the header cell when referencing the cell in other contexts
         `colspan` :
@@ -26033,17 +24987,13 @@ class th(BaseElement):
         
             Valid non-negative integer greater than zero
         `headers` :
-            The header cells for this cell  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            The header cells for this cell
         `rowspan` :
             Number of rows that the cell is to span
         `scope` :
             Specifies which cells the header cell applies to
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -26073,19 +25023,13 @@ class th(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -26212,8 +25156,8 @@ class thead(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -26258,10 +25202,10 @@ class thead(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -26287,13 +25231,9 @@ class thead(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -26323,19 +25263,13 @@ class thead(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -26452,9 +25386,9 @@ class time(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         datetime: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -26499,10 +25433,10 @@ class time(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -26528,17 +25462,13 @@ class time(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `datetime` :
             Machine-readable value  
         
             Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -26568,19 +25498,13 @@ class time(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -26699,8 +25623,8 @@ class title(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -26745,10 +25669,10 @@ class title(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -26774,13 +25698,9 @@ class title(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -26810,19 +25730,13 @@ class title(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -26939,8 +25853,8 @@ class tr(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -26985,10 +25899,10 @@ class tr(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -27014,13 +25928,9 @@ class tr(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -27050,19 +25960,13 @@ class tr(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -27179,7 +26083,7 @@ class track(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         default: Optional[Union[str, bool]] = None,
         kind: Optional[
             Union[
@@ -27196,7 +26100,7 @@ class track(BaseElement):
         label: Optional[str] = None,
         src: Optional[str] = None,
         srclang: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -27241,10 +26145,10 @@ class track(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -27270,9 +26174,7 @@ class track(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `default` :
             Enable the track if no other text track is more suitable
         `kind` :
@@ -27288,9 +26190,7 @@ class track(BaseElement):
         
             Valid BCP 47 language tag
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -27320,19 +26220,13 @@ class track(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -27459,8 +26353,8 @@ class u(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -27505,10 +26399,10 @@ class u(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -27534,13 +26428,9 @@ class u(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -27570,19 +26460,13 @@ class u(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -27699,8 +26583,8 @@ class ul(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -27745,10 +26629,10 @@ class ul(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -27774,13 +26658,9 @@ class ul(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -27810,19 +26690,13 @@ class ul(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -27939,8 +26813,8 @@ class var(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -27985,10 +26859,10 @@ class var(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -28014,13 +26888,9 @@ class var(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -28050,19 +26920,13 @@ class var(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -28179,7 +27043,7 @@ class video(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         autoplay: Optional[Union[str, bool]] = None,
         controls: Optional[Union[str, bool]] = None,
         crossorigin: Optional[
@@ -28195,7 +27059,7 @@ class video(BaseElement):
         ] = None,
         src: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -28240,10 +27104,10 @@ class video(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -28269,9 +27133,7 @@ class video(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `autoplay` :
             Hint that the media resource can be started automatically when the page is loaded
         `controls` :
@@ -28299,9 +27161,7 @@ class video(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -28331,19 +27191,13 @@ class video(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -28482,8 +27336,8 @@ class wbr(BaseElement):
             Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
         ] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[
             Union[
                 str,
@@ -28528,10 +27382,10 @@ class wbr(BaseElement):
         ] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal["auto", "manual"]]] = None,
@@ -28557,13 +27411,9 @@ class wbr(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -28593,19 +27443,13 @@ class wbr(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -195,3 +195,10 @@ def test_float_precision():
 def test_list_attribute():
     el = div({"class": ["a", "b", "c"]})
     assert el.render() == '<div class="a b c"></div>'
+
+
+def test_rel_array():
+    # ensure the list type arg doesnt violate type checks and builds
+    # correctly
+    el = a(rel=["noopener", "noreferrer"])
+    assert el.render() == '<a rel="noopener noreferrer"></a>'

--- a/tools/generated/a_attrs.py
+++ b/tools/generated/a_attrs.py
@@ -50,7 +50,7 @@ class AnchorAttrs:
 
 
     @staticmethod
-    def ping(value) -> BaseAttribute:
+    def ping(value: list) -> BaseAttribute:
         """
         "a" attribute: ping  
         URLs to ping  
@@ -78,7 +78,7 @@ class AnchorAttrs:
 
 
     @staticmethod
-    def rel(value) -> BaseAttribute:
+    def rel(value: list) -> BaseAttribute:
         """
         "a" attribute: rel  
         Relationship between the location in the document containing the hyperlink and the destination resource  

--- a/tools/generated/area_attrs.py
+++ b/tools/generated/area_attrs.py
@@ -64,7 +64,7 @@ class AreaAttrs:
 
 
     @staticmethod
-    def ping(value) -> BaseAttribute:
+    def ping(value: list) -> BaseAttribute:
         """
         "area" attribute: ping  
         URLs to ping  
@@ -92,7 +92,7 @@ class AreaAttrs:
 
 
     @staticmethod
-    def rel(value) -> BaseAttribute:
+    def rel(value: list) -> BaseAttribute:
         """
         "area" attribute: rel  
         Relationship between the location in the document containing the hyperlink and the destination resource  
@@ -106,7 +106,7 @@ class AreaAttrs:
 
 
     @staticmethod
-    def shape(value) -> BaseAttribute:
+    def shape(value: Literal['circle', 'default', 'poly', 'rect']) -> BaseAttribute:
         """
         "area" attribute: shape  
         The kind of shape to be created in an image map  

--- a/tools/generated/audio_attrs.py
+++ b/tools/generated/audio_attrs.py
@@ -36,7 +36,7 @@ class AudioAttrs:
 
 
     @staticmethod
-    def crossorigin(value) -> BaseAttribute:
+    def crossorigin(value: Literal['anonymous', 'use-credentials']) -> BaseAttribute:
         """
         "audio" attribute: crossorigin  
         How the element handles crossorigin requests  
@@ -78,7 +78,7 @@ class AudioAttrs:
 
 
     @staticmethod
-    def preload(value) -> BaseAttribute:
+    def preload(value: Literal['none', 'metadata', 'auto']) -> BaseAttribute:
         """
         "audio" attribute: preload  
         Hints how much buffering the media resource will likely need  

--- a/tools/generated/bdo_attrs.py
+++ b/tools/generated/bdo_attrs.py
@@ -8,7 +8,7 @@ class BdoAttrs:
     """ 
     
     @staticmethod
-    def dir(value) -> BaseAttribute:
+    def dir(value: Literal['ltr', 'rtl']) -> BaseAttribute:
         """
         "bdo" attribute: dir  
         The text directionality of the element  

--- a/tools/generated/button_attrs.py
+++ b/tools/generated/button_attrs.py
@@ -50,7 +50,7 @@ class ButtonAttrs:
 
 
     @staticmethod
-    def formenctype(value) -> BaseAttribute:
+    def formenctype(value: Literal['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']) -> BaseAttribute:
         """
         "button" attribute: formenctype  
         Entry list encoding type to use for form submission  
@@ -64,7 +64,7 @@ class ButtonAttrs:
 
 
     @staticmethod
-    def formmethod(value) -> BaseAttribute:
+    def formmethod(value: Literal['GET', 'POST', 'dialog']) -> BaseAttribute:
         """
         "button" attribute: formmethod  
         Variant to use for form submission  
@@ -134,7 +134,7 @@ class ButtonAttrs:
 
 
     @staticmethod
-    def popovertargetaction(value) -> BaseAttribute:
+    def popovertargetaction(value: Literal['toggle', 'show', 'hide']) -> BaseAttribute:
         """
         "button" attribute: popovertargetaction  
         Indicates whether a targeted popover element is to be toggled, shown, or hidden  
@@ -148,7 +148,7 @@ class ButtonAttrs:
 
 
     @staticmethod
-    def type(value) -> BaseAttribute:
+    def type(value: Literal['submit', 'reset', 'button']) -> BaseAttribute:
         """
         "button" attribute: type  
         Type of button  

--- a/tools/generated/elements.py
+++ b/tools/generated/elements.py
@@ -28,16 +28,16 @@ class a(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         download: Optional[str] = None,
         href: Optional[str] = None,
         hreflang: Optional[str] = None,
-        ping: Optional[str] = None,
+        ping: Optional[Union[str, list]] = None,
         referrerpolicy: Optional[str] = None,
-        rel: Optional[str] = None,
+        rel: Optional[Union[str, list]] = None,
         target: Optional[str] = None,
         type: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -50,10 +50,10 @@ class a(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -77,9 +77,7 @@ class a(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `download` :
             Whether to download the resource instead of navigating to it, and its filename if so
         `href` :
@@ -91,17 +89,13 @@ class a(BaseElement):
         
             Valid BCP 47 language tag
         `ping` :
-            URLs to ping  
-        
-            Set of space-separated tokens consisting of valid non-empty URLs
+            URLs to ping
         `referrerpolicy` :
             Referrer policy for fetches initiated by the element  
         
             Referrer policy
         `rel` :
-            Relationship between the location in the document containing the hyperlink and the destination resource  
-        
-            Unordered set of unique space-separated tokens*
+            Relationship between the location in the document containing the hyperlink and the destination resource
         `target` :
             Navigable for hyperlink navigation  
         
@@ -111,9 +105,7 @@ class a(BaseElement):
         
             Valid MIME type string
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -143,19 +135,13 @@ class a(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -285,8 +271,8 @@ class abbr(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -299,10 +285,10 @@ class abbr(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -326,13 +312,9 @@ class abbr(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -362,19 +344,13 @@ class abbr(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -488,8 +464,8 @@ class address(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -502,10 +478,10 @@ class address(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -529,13 +505,9 @@ class address(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -565,19 +537,13 @@ class address(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -691,17 +657,17 @@ class area(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         alt: Optional[str] = None,
         coords: Optional[str] = None,
         download: Optional[str] = None,
         href: Optional[str] = None,
-        ping: Optional[str] = None,
+        ping: Optional[Union[str, list]] = None,
         referrerpolicy: Optional[str] = None,
-        rel: Optional[str] = None,
+        rel: Optional[Union[str, list]] = None,
         shape: Optional[Union[str, Literal['circle', 'default', 'poly', 'rect']]] = None,
         target: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -714,10 +680,10 @@ class area(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -741,9 +707,7 @@ class area(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `alt` :
             Replacement text for use when images are not available
         `coords` :
@@ -757,17 +721,13 @@ class area(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `ping` :
-            URLs to ping  
-        
-            Set of space-separated tokens consisting of valid non-empty URLs
+            URLs to ping
         `referrerpolicy` :
             Referrer policy for fetches initiated by the element  
         
             Referrer policy
         `rel` :
-            Relationship between the location in the document containing the hyperlink and the destination resource  
-        
-            Unordered set of unique space-separated tokens*
+            Relationship between the location in the document containing the hyperlink and the destination resource
         `shape` :
             The kind of shape to be created in an image map
         `target` :
@@ -775,9 +735,7 @@ class area(BaseElement):
         
             Valid navigable target name or keyword
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -807,19 +765,13 @@ class area(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -951,8 +903,8 @@ class article(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -965,10 +917,10 @@ class article(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -992,13 +944,9 @@ class article(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -1028,19 +976,13 @@ class article(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -1154,8 +1096,8 @@ class aside(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -1168,10 +1110,10 @@ class aside(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -1195,13 +1137,9 @@ class aside(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -1231,19 +1169,13 @@ class aside(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -1357,7 +1289,7 @@ class audio(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         autoplay: Optional[Union[str, bool]] = None,
         controls: Optional[Union[str, bool]] = None,
         crossorigin: Optional[Union[str, Literal['anonymous', 'use-credentials']]] = None,
@@ -1365,7 +1297,7 @@ class audio(BaseElement):
         muted: Optional[Union[str, bool]] = None,
         preload: Optional[Union[str, Literal['none', 'metadata', 'auto']]] = None,
         src: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -1378,10 +1310,10 @@ class audio(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -1405,9 +1337,7 @@ class audio(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `autoplay` :
             Hint that the media resource can be started automatically when the page is loaded
         `controls` :
@@ -1425,9 +1355,7 @@ class audio(BaseElement):
         
             Valid non-empty URL potentially surrounded by spaces
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -1457,19 +1385,13 @@ class audio(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -1597,8 +1519,8 @@ class b(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -1611,10 +1533,10 @@ class b(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -1638,13 +1560,9 @@ class b(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -1674,19 +1592,13 @@ class b(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -1800,10 +1712,10 @@ class base(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         href: Optional[str] = None,
         target: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -1816,10 +1728,10 @@ class base(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -1843,9 +1755,7 @@ class base(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `href` :
             Document base URL  
         
@@ -1855,9 +1765,7 @@ class base(BaseElement):
         
             Valid navigable target name or keyword
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -1887,19 +1795,13 @@ class base(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -2017,8 +1919,8 @@ class bdi(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -2031,10 +1933,10 @@ class bdi(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -2058,13 +1960,9 @@ class bdi(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -2094,19 +1992,13 @@ class bdi(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -2220,8 +2112,8 @@ class bdo(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -2234,10 +2126,10 @@ class bdo(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -2261,13 +2153,9 @@ class bdo(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -2297,19 +2185,13 @@ class bdo(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -2423,9 +2305,9 @@ class blockquote(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         cite: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -2438,10 +2320,10 @@ class blockquote(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -2465,17 +2347,13 @@ class blockquote(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `cite` :
             Link to the source of the quotation or more information about the edit  
         
             Valid URL potentially surrounded by spaces
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -2505,19 +2383,13 @@ class blockquote(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -2633,8 +2505,8 @@ class body(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -2647,10 +2519,10 @@ class body(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -2674,13 +2546,9 @@ class body(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -2710,19 +2578,13 @@ class body(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -2836,8 +2698,8 @@ class br(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -2850,10 +2712,10 @@ class br(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -2877,13 +2739,9 @@ class br(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -2913,19 +2771,13 @@ class br(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -3039,7 +2891,7 @@ class button(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         disabled: Optional[Union[str, bool]] = None,
         form: Optional[str] = None,
         formaction: Optional[str] = None,
@@ -3052,7 +2904,7 @@ class button(BaseElement):
         popovertargetaction: Optional[Union[str, Literal['toggle', 'show', 'hide']]] = None,
         type: Optional[Union[str, Literal['submit', 'reset', 'button']]] = None,
         value: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -3065,10 +2917,10 @@ class button(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -3092,9 +2944,7 @@ class button(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `disabled` :
             Whether the form control is disabled
         `form` :
@@ -3128,9 +2978,7 @@ class button(BaseElement):
         `value` :
             Value to be used for form submission
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -3160,19 +3008,13 @@ class button(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -3310,10 +3152,10 @@ class canvas(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         height: Optional[Union[str, int]] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -3326,10 +3168,10 @@ class canvas(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -3353,17 +3195,13 @@ class canvas(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `height` :
             Vertical dimension
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -3393,19 +3231,13 @@ class canvas(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -3523,8 +3355,8 @@ class caption(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -3537,10 +3369,10 @@ class caption(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -3564,13 +3396,9 @@ class caption(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -3600,19 +3428,13 @@ class caption(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -3726,8 +3548,8 @@ class cite(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -3740,10 +3562,10 @@ class cite(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -3767,13 +3589,9 @@ class cite(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -3803,19 +3621,13 @@ class cite(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -3929,8 +3741,8 @@ class code(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -3943,10 +3755,10 @@ class code(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -3970,13 +3782,9 @@ class code(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -4006,19 +3814,13 @@ class code(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -4132,9 +3934,9 @@ class col(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         span: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -4147,10 +3949,10 @@ class col(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -4174,17 +3976,13 @@ class col(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `span` :
             Number of columns spanned by the element  
         
             Valid non-negative integer greater than zero
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -4214,19 +4012,13 @@ class col(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -4342,9 +4134,9 @@ class colgroup(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         span: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -4357,10 +4149,10 @@ class colgroup(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -4384,17 +4176,13 @@ class colgroup(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `span` :
             Number of columns spanned by the element  
         
             Valid non-negative integer greater than zero
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -4424,19 +4212,13 @@ class colgroup(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -4552,9 +4334,9 @@ class data(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         value: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -4567,10 +4349,10 @@ class data(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -4594,15 +4376,11 @@ class data(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `value` :
             Machine-readable value
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -4632,19 +4410,13 @@ class data(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -4760,8 +4532,8 @@ class datalist(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -4774,10 +4546,10 @@ class datalist(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -4801,13 +4573,9 @@ class datalist(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -4837,19 +4605,13 @@ class datalist(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -4963,8 +4725,8 @@ class dd(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -4977,10 +4739,10 @@ class dd(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -5004,13 +4766,9 @@ class dd(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -5040,19 +4798,13 @@ class dd(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -5166,10 +4918,10 @@ class del_(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         cite: Optional[str] = None,
         datetime: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -5182,10 +4934,10 @@ class del_(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -5209,9 +4961,7 @@ class del_(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `cite` :
             Link to the source of the quotation or more information about the edit  
         
@@ -5221,9 +4971,7 @@ class del_(BaseElement):
         
             Valid date string with optional time
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -5253,19 +5001,13 @@ class del_(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -5383,10 +5125,10 @@ class details(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         name: Optional[str] = None,
         open: Optional[Union[str, bool]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -5399,10 +5141,10 @@ class details(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -5426,17 +5168,13 @@ class details(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `name` :
             Name of group of mutually-exclusive details elements
         `open` :
             Whether the details are visible
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -5466,19 +5204,13 @@ class details(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -5596,8 +5328,8 @@ class dfn(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -5610,10 +5342,10 @@ class dfn(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -5637,13 +5369,9 @@ class dfn(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -5673,19 +5401,13 @@ class dfn(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -5799,9 +5521,9 @@ class dialog(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         open: Optional[Union[str, bool]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -5814,10 +5536,10 @@ class dialog(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -5841,15 +5563,11 @@ class dialog(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `open` :
             Whether the dialog box is showing
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -5879,19 +5597,13 @@ class dialog(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -6007,8 +5719,8 @@ class div(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -6021,10 +5733,10 @@ class div(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -6048,13 +5760,9 @@ class div(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -6084,19 +5792,13 @@ class div(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -6210,8 +5912,8 @@ class dl(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -6224,10 +5926,10 @@ class dl(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -6251,13 +5953,9 @@ class dl(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -6287,19 +5985,13 @@ class dl(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -6413,8 +6105,8 @@ class dt(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -6427,10 +6119,10 @@ class dt(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -6454,13 +6146,9 @@ class dt(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -6490,19 +6178,13 @@ class dt(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -6616,8 +6298,8 @@ class em(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -6630,10 +6312,10 @@ class em(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -6657,13 +6339,9 @@ class em(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -6693,19 +6371,13 @@ class em(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -6819,12 +6491,12 @@ class embed(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         height: Optional[Union[str, int]] = None,
         src: Optional[str] = None,
         type: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -6837,10 +6509,10 @@ class embed(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -6864,9 +6536,7 @@ class embed(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `height` :
             Vertical dimension
         `src` :
@@ -6880,9 +6550,7 @@ class embed(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -6912,19 +6580,13 @@ class embed(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -7046,11 +6708,11 @@ class fieldset(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         disabled: Optional[Union[str, bool]] = None,
         form: Optional[str] = None,
         name: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -7063,10 +6725,10 @@ class fieldset(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -7090,9 +6752,7 @@ class fieldset(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `disabled` :
             Whether the descendant form controls, except any inside legend, are disabled
         `form` :
@@ -7102,9 +6762,7 @@ class fieldset(BaseElement):
         `name` :
             Name of the element to use for form submission and in the form.elements API
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -7134,19 +6792,13 @@ class fieldset(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -7266,8 +6918,8 @@ class figcaption(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -7280,10 +6932,10 @@ class figcaption(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -7307,13 +6959,9 @@ class figcaption(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -7343,19 +6991,13 @@ class figcaption(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -7469,8 +7111,8 @@ class figure(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -7483,10 +7125,10 @@ class figure(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -7510,13 +7152,9 @@ class figure(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -7546,19 +7184,13 @@ class figure(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -7672,8 +7304,8 @@ class footer(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -7686,10 +7318,10 @@ class footer(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -7713,13 +7345,9 @@ class footer(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -7749,19 +7377,13 @@ class footer(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -7875,7 +7497,7 @@ class form(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         accept_charset: Optional[str] = None,
         action: Optional[str] = None,
         autocomplete: Optional[Union[str, Literal['on', 'off']]] = None,
@@ -7884,7 +7506,7 @@ class form(BaseElement):
         name: Optional[str] = None,
         novalidate: Optional[Union[str, bool]] = None,
         target: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -7897,10 +7519,10 @@ class form(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -7924,9 +7546,7 @@ class form(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accept_charset` :
             Character encodings to use for form submission  
         
@@ -7950,9 +7570,7 @@ class form(BaseElement):
         
             Valid navigable target name or keyword
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -7982,19 +7600,13 @@ class form(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -8124,8 +7736,8 @@ class h1(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -8138,10 +7750,10 @@ class h1(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -8165,13 +7777,9 @@ class h1(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -8201,19 +7809,13 @@ class h1(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -8327,8 +7929,8 @@ class h2(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -8341,10 +7943,10 @@ class h2(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -8368,13 +7970,9 @@ class h2(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -8404,19 +8002,13 @@ class h2(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -8530,8 +8122,8 @@ class h3(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -8544,10 +8136,10 @@ class h3(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -8571,13 +8163,9 @@ class h3(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -8607,19 +8195,13 @@ class h3(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -8733,8 +8315,8 @@ class h4(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -8747,10 +8329,10 @@ class h4(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -8774,13 +8356,9 @@ class h4(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -8810,19 +8388,13 @@ class h4(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -8936,8 +8508,8 @@ class h5(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -8950,10 +8522,10 @@ class h5(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -8977,13 +8549,9 @@ class h5(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -9013,19 +8581,13 @@ class h5(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -9139,8 +8701,8 @@ class h6(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -9153,10 +8715,10 @@ class h6(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -9180,13 +8742,9 @@ class h6(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -9216,19 +8774,13 @@ class h6(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -9342,8 +8894,8 @@ class head(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -9356,10 +8908,10 @@ class head(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -9383,13 +8935,9 @@ class head(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -9419,19 +8967,13 @@ class head(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -9545,8 +9087,8 @@ class header(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -9559,10 +9101,10 @@ class header(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -9586,13 +9128,9 @@ class header(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -9622,19 +9160,13 @@ class header(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -9748,8 +9280,8 @@ class hgroup(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -9762,10 +9294,10 @@ class hgroup(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -9789,13 +9321,9 @@ class hgroup(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -9825,19 +9353,13 @@ class hgroup(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -9951,8 +9473,8 @@ class hr(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -9965,10 +9487,10 @@ class hr(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -9992,13 +9514,9 @@ class hr(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -10028,19 +9546,13 @@ class hr(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -10154,8 +9666,8 @@ class html(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -10168,10 +9680,10 @@ class html(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -10195,13 +9707,9 @@ class html(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -10231,19 +9739,13 @@ class html(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -10357,8 +9859,8 @@ class i(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -10371,10 +9873,10 @@ class i(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -10398,13 +9900,9 @@ class i(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -10434,19 +9932,13 @@ class i(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -10560,18 +10052,18 @@ class iframe(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         allow: Optional[str] = None,
         allowfullscreen: Optional[Union[str, bool]] = None,
         height: Optional[Union[str, int]] = None,
         loading: Optional[Union[str, Literal['lazy', 'eager']]] = None,
         name: Optional[str] = None,
         referrerpolicy: Optional[str] = None,
-        sandbox: Optional[str] = None,
+        sandbox: Optional[Union[str, list]] = None,
         src: Optional[str] = None,
         srcdoc: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -10584,10 +10076,10 @@ class iframe(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -10611,9 +10103,7 @@ class iframe(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `allow` :
             Permissions policy to be applied to the iframe's contents  
         
@@ -10633,9 +10123,7 @@ class iframe(BaseElement):
         
             Referrer policy
         `sandbox` :
-            Security rules for nested content  
-        
-            Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of "allow-downloads" "allow-forms" "allow-modals" "allow-orientation-lock" "allow-pointer-lock" "allow-popups" "allow-popups-to-escape-sandbox" "allow-presentation" "allow-same-origin" "allow-scripts" "allow-top-navigation" "allow-top-navigation-by-user-activation" "allow-top-navigation-to-custom-protocols"
+            Security rules for nested content
         `src` :
             Address of the resource  
         
@@ -10647,9 +10135,7 @@ class iframe(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -10679,19 +10165,13 @@ class iframe(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -10825,7 +10305,7 @@ class img(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         alt: Optional[str] = None,
         crossorigin: Optional[Union[str, Literal['anonymous', 'use-credentials']]] = None,
         decoding: Optional[Union[str, Literal['sync', 'async', 'auto']]] = None,
@@ -10839,7 +10319,7 @@ class img(BaseElement):
         srcset: Optional[str] = None,
         usemap: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -10852,10 +10332,10 @@ class img(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -10879,9 +10359,7 @@ class img(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `alt` :
             Replacement text for use when images are not available
         `crossorigin` :
@@ -10919,9 +10397,7 @@ class img(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -10951,19 +10427,13 @@ class img(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -11103,7 +10573,7 @@ class input(BaseElement): # type: ignore[misc]
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         accept: Optional[str] = None,
         alpha: Optional[Union[str, bool]] = None,
         alt: Optional[str] = None,
@@ -11139,7 +10609,7 @@ class input(BaseElement): # type: ignore[misc]
         type: Optional[str] = None,
         value: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -11152,10 +10622,10 @@ class input(BaseElement): # type: ignore[misc]
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -11178,9 +10648,7 @@ class input(BaseElement): # type: ignore[misc]
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accept` :
             Hint for expected file type in file upload controls  
         
@@ -11280,9 +10748,7 @@ class input(BaseElement): # type: ignore[misc]
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -11312,19 +10778,13 @@ class input(BaseElement): # type: ignore[misc]
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -11504,10 +10964,10 @@ class ins(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         cite: Optional[str] = None,
         datetime: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -11520,10 +10980,10 @@ class ins(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -11547,9 +11007,7 @@ class ins(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `cite` :
             Link to the source of the quotation or more information about the edit  
         
@@ -11559,9 +11017,7 @@ class ins(BaseElement):
         
             Valid date string with optional time
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -11591,19 +11047,13 @@ class ins(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -11721,8 +11171,8 @@ class kbd(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -11735,10 +11185,10 @@ class kbd(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -11762,13 +11212,9 @@ class kbd(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -11798,19 +11244,13 @@ class kbd(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -11924,9 +11364,9 @@ class label(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         for_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -11939,10 +11379,10 @@ class label(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -11966,17 +11406,13 @@ class label(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `for_` :
             Associate the label with form control  
         
             ID*
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -12006,19 +11442,13 @@ class label(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -12134,8 +11564,8 @@ class legend(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -12148,10 +11578,10 @@ class legend(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -12175,13 +11605,9 @@ class legend(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -12211,19 +11637,13 @@ class legend(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -12337,9 +11757,9 @@ class li(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         value: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -12352,10 +11772,10 @@ class li(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -12379,15 +11799,11 @@ class li(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `value` :
             Ordinal value of the list item
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -12417,19 +11833,13 @@ class li(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -12545,9 +11955,9 @@ class link(BaseElement): # type: ignore[misc]
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         as_: Optional[str] = None,
-        blocking: Optional[str] = None,
+        blocking: Optional[Union[str, list]] = None,
         color: Optional[str] = None,
         crossorigin: Optional[Union[str, Literal['anonymous', 'use-credentials']]] = None,
         disabled: Optional[Union[str, bool]] = None,
@@ -12559,11 +11969,11 @@ class link(BaseElement): # type: ignore[misc]
         integrity: Optional[str] = None,
         media: Optional[str] = None,
         referrerpolicy: Optional[str] = None,
-        rel: Optional[str] = None,
-        sizes: Optional[str] = None,
+        rel: Optional[Union[str, list]] = None,
+        sizes: Optional[Union[str, list]] = None,
         title: Optional[str] = None,
         type: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -12576,10 +11986,10 @@ class link(BaseElement): # type: ignore[misc]
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -12602,17 +12012,13 @@ class link(BaseElement): # type: ignore[misc]
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `as_` :
             Potential destination for a preload request (for rel="preload" and rel="modulepreload")  
         
             Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
         `blocking` :
-            Whether the element is potentially render-blocking  
-        
-            Unordered set of unique space-separated tokens*
+            Whether the element is potentially render-blocking
         `color` :
             Color to use when customizing a site's icon (for rel="mask-icon")  
         
@@ -12650,13 +12056,9 @@ class link(BaseElement): # type: ignore[misc]
         
             Referrer policy
         `rel` :
-            Relationship between the document containing the hyperlink and the destination resource  
-        
-            Unordered set of unique space-separated tokens*
+            Relationship between the document containing the hyperlink and the destination resource
         `sizes` :
-            Sizes of the icons (for rel="icon")  
-        
-            Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of sizes*
+            Sizes of the icons (for rel="icon")
         `title` :
             CSS style sheet set name
         `title` :
@@ -12666,9 +12068,7 @@ class link(BaseElement): # type: ignore[misc]
         
             Valid MIME type string
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -12698,19 +12098,13 @@ class link(BaseElement): # type: ignore[misc]
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -12854,8 +12248,8 @@ class main(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -12868,10 +12262,10 @@ class main(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -12895,13 +12289,9 @@ class main(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -12931,19 +12321,13 @@ class main(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -13057,9 +12441,9 @@ class map(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         name: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -13072,10 +12456,10 @@ class map(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -13099,15 +12483,11 @@ class map(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `name` :
             Name of image map to reference from the usemap attribute
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -13137,19 +12517,13 @@ class map(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -13265,8 +12639,8 @@ class mark(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -13279,10 +12653,10 @@ class mark(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -13306,13 +12680,9 @@ class mark(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -13342,19 +12712,13 @@ class mark(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -13468,8 +12832,8 @@ class menu(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -13482,10 +12846,10 @@ class menu(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -13509,13 +12873,9 @@ class menu(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -13545,19 +12905,13 @@ class menu(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -13671,13 +13025,13 @@ class meta(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         charset: Optional[Union[str, Literal['utf-8']]] = None,
         content: Optional[str] = None,
         http_equiv: Optional[Union[str, Literal['content-type', 'default-style', 'refresh', 'x-ua-compatible', 'content-security-policy']]] = None,
         media: Optional[str] = None,
         name: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -13690,10 +13044,10 @@ class meta(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -13717,9 +13071,7 @@ class meta(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `charset` :
             Character encoding declaration
         `content` :
@@ -13733,9 +13085,7 @@ class meta(BaseElement):
         `name` :
             Metadata name
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -13765,19 +13115,13 @@ class meta(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -13901,14 +13245,14 @@ class meter(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         high: Optional[Union[str, float]] = None,
         low: Optional[Union[str, float]] = None,
         max: Optional[Union[str, float]] = None,
         min: Optional[Union[str, float]] = None,
         optimum: Optional[Union[str, float]] = None,
         value: Optional[Union[str, float]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -13921,10 +13265,10 @@ class meter(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -13948,9 +13292,7 @@ class meter(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `high` :
             Low limit of high range
         `low` :
@@ -13964,9 +13306,7 @@ class meter(BaseElement):
         `value` :
             Current value of the element
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -13996,19 +13336,13 @@ class meter(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -14134,8 +13468,8 @@ class nav(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -14148,10 +13482,10 @@ class nav(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -14175,13 +13509,9 @@ class nav(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -14211,19 +13541,13 @@ class nav(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -14337,8 +13661,8 @@ class noscript(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -14351,10 +13675,10 @@ class noscript(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -14378,13 +13702,9 @@ class noscript(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -14414,19 +13734,13 @@ class noscript(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -14540,14 +13854,14 @@ class object(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         data: Optional[str] = None,
         form: Optional[str] = None,
         height: Optional[Union[str, int]] = None,
         name: Optional[str] = None,
         type: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -14560,10 +13874,10 @@ class object(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -14587,9 +13901,7 @@ class object(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `data` :
             Address of the resource  
         
@@ -14611,9 +13923,7 @@ class object(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -14643,19 +13953,13 @@ class object(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -14781,11 +14085,11 @@ class ol(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         reversed: Optional[Union[str, bool]] = None,
         start: Optional[Union[str, int]] = None,
         type: Optional[Union[str, Literal['1', 'a', 'A', 'i', 'I']]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -14798,10 +14102,10 @@ class ol(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -14825,9 +14129,7 @@ class ol(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `reversed` :
             Number the list backwards
         `start` :
@@ -14835,9 +14137,7 @@ class ol(BaseElement):
         `type` :
             Kind of list marker
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -14867,19 +14167,13 @@ class ol(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -14999,10 +14293,10 @@ class optgroup(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         disabled: Optional[Union[str, bool]] = None,
         label: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -15015,10 +14309,10 @@ class optgroup(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -15042,17 +14336,13 @@ class optgroup(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `disabled` :
             Whether the form control is disabled
         `label` :
             User-visible label
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -15082,19 +14372,13 @@ class optgroup(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -15212,12 +14496,12 @@ class option(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         disabled: Optional[Union[str, bool]] = None,
         label: Optional[str] = None,
         selected: Optional[Union[str, bool]] = None,
         value: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -15230,10 +14514,10 @@ class option(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -15257,9 +14541,7 @@ class option(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `disabled` :
             Whether the form control is disabled
         `label` :
@@ -15269,9 +14551,7 @@ class option(BaseElement):
         `value` :
             Value to be used for form submission
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -15301,19 +14581,13 @@ class option(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -15435,11 +14709,11 @@ class output(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        for_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        for_: Optional[Union[str, list]] = None,
         form: Optional[str] = None,
         name: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -15452,10 +14726,10 @@ class output(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -15479,13 +14753,9 @@ class output(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `for_` :
-            Specifies controls from which the output was calculated  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Specifies controls from which the output was calculated
         `form` :
             Associates the element with a form element  
         
@@ -15493,9 +14763,7 @@ class output(BaseElement):
         `name` :
             Name of the element to use for form submission and in the form.elements API
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -15525,19 +14793,13 @@ class output(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -15657,8 +14919,8 @@ class p(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -15671,10 +14933,10 @@ class p(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -15698,13 +14960,9 @@ class p(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -15734,19 +14992,13 @@ class p(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -15860,8 +15112,8 @@ class picture(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -15874,10 +15126,10 @@ class picture(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -15901,13 +15153,9 @@ class picture(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -15937,19 +15185,13 @@ class picture(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -16063,8 +15305,8 @@ class pre(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -16077,10 +15319,10 @@ class pre(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -16104,13 +15346,9 @@ class pre(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -16140,19 +15378,13 @@ class pre(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -16266,10 +15498,10 @@ class progress(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         max: Optional[Union[str, float]] = None,
         value: Optional[Union[str, float]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -16282,10 +15514,10 @@ class progress(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -16309,17 +15541,13 @@ class progress(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `max` :
             Upper bound of range
         `value` :
             Current value of the element
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -16349,19 +15577,13 @@ class progress(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -16479,9 +15701,9 @@ class q(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         cite: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -16494,10 +15716,10 @@ class q(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -16521,17 +15743,13 @@ class q(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `cite` :
             Link to the source of the quotation or more information about the edit  
         
             Valid URL potentially surrounded by spaces
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -16561,19 +15779,13 @@ class q(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -16689,8 +15901,8 @@ class rp(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -16703,10 +15915,10 @@ class rp(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -16730,13 +15942,9 @@ class rp(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -16766,19 +15974,13 @@ class rp(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -16892,8 +16094,8 @@ class rt(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -16906,10 +16108,10 @@ class rt(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -16933,13 +16135,9 @@ class rt(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -16969,19 +16167,13 @@ class rt(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -17095,8 +16287,8 @@ class ruby(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -17109,10 +16301,10 @@ class ruby(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -17136,13 +16328,9 @@ class ruby(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -17172,19 +16360,13 @@ class ruby(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -17298,8 +16480,8 @@ class s(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -17312,10 +16494,10 @@ class s(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -17339,13 +16521,9 @@ class s(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -17375,19 +16553,13 @@ class s(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -17501,8 +16673,8 @@ class samp(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -17515,10 +16687,10 @@ class samp(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -17542,13 +16714,9 @@ class samp(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -17578,19 +16746,13 @@ class samp(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -17704,9 +16866,9 @@ class script(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         async_: Optional[Union[str, bool]] = None,
-        blocking: Optional[str] = None,
+        blocking: Optional[Union[str, list]] = None,
         crossorigin: Optional[Union[str, Literal['anonymous', 'use-credentials']]] = None,
         defer: Optional[Union[str, bool]] = None,
         fetchpriority: Optional[Union[str, Literal['auto', 'high', 'low']]] = None,
@@ -17715,7 +16877,7 @@ class script(BaseElement):
         referrerpolicy: Optional[str] = None,
         src: Optional[str] = None,
         type: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -17728,10 +16890,10 @@ class script(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -17755,15 +16917,11 @@ class script(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `async_` :
             Execute script when available, without blocking while fetching
         `blocking` :
-            Whether the element is potentially render-blocking  
-        
-            Unordered set of unique space-separated tokens*
+            Whether the element is potentially render-blocking
         `crossorigin` :
             How the element handles crossorigin requests
         `defer` :
@@ -17787,9 +16945,7 @@ class script(BaseElement):
         
             "module"; a valid MIME type string that is not a JavaScript MIME type essence match
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -17819,19 +16975,13 @@ class script(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -17965,8 +17115,8 @@ class search(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -17979,10 +17129,10 @@ class search(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -18006,13 +17156,9 @@ class search(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -18042,19 +17188,13 @@ class search(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -18168,8 +17308,8 @@ class section(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -18182,10 +17322,10 @@ class section(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -18209,13 +17349,9 @@ class section(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -18245,19 +17381,13 @@ class section(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -18371,7 +17501,7 @@ class select(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         autocomplete: Optional[str] = None,
         disabled: Optional[Union[str, bool]] = None,
         form: Optional[str] = None,
@@ -18379,7 +17509,7 @@ class select(BaseElement):
         name: Optional[str] = None,
         required: Optional[Union[str, bool]] = None,
         size: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -18392,10 +17522,10 @@ class select(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -18419,9 +17549,7 @@ class select(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `autocomplete` :
             Hint for form autofill feature  
         
@@ -18443,9 +17571,7 @@ class select(BaseElement):
         
             Valid non-negative integer greater than zero
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -18475,19 +17601,13 @@ class select(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -18615,9 +17735,9 @@ class slot(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         name: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -18630,10 +17750,10 @@ class slot(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -18657,15 +17777,11 @@ class slot(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `name` :
             Name of shadow tree slot
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -18695,19 +17811,13 @@ class slot(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -18823,8 +17933,8 @@ class small(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -18837,10 +17947,10 @@ class small(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -18864,13 +17974,9 @@ class small(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -18900,19 +18006,13 @@ class small(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -19026,7 +18126,7 @@ class source(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         height: Optional[Union[str, int]] = None,
         media: Optional[str] = None,
         sizes: Optional[str] = None,
@@ -19034,7 +18134,7 @@ class source(BaseElement):
         srcset: Optional[str] = None,
         type: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -19047,10 +18147,10 @@ class source(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -19074,9 +18174,7 @@ class source(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `height` :
             Vertical dimension
         `media` :
@@ -19102,9 +18200,7 @@ class source(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -19134,19 +18230,13 @@ class source(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -19274,8 +18364,8 @@ class span(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -19288,10 +18378,10 @@ class span(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -19315,13 +18405,9 @@ class span(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -19351,19 +18437,13 @@ class span(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -19477,8 +18557,8 @@ class strong(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -19491,10 +18571,10 @@ class strong(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -19518,13 +18598,9 @@ class strong(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -19554,19 +18630,13 @@ class strong(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -19680,11 +18750,11 @@ class style(BaseElement): # type: ignore[misc]
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        blocking: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        blocking: Optional[Union[str, list]] = None,
         media: Optional[str] = None,
         title: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -19697,10 +18767,10 @@ class style(BaseElement): # type: ignore[misc]
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -19723,13 +18793,9 @@ class style(BaseElement): # type: ignore[misc]
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `blocking` :
-            Whether the element is potentially render-blocking  
-        
-            Unordered set of unique space-separated tokens*
+            Whether the element is potentially render-blocking
         `media` :
             Applicable media  
         
@@ -19737,9 +18803,7 @@ class style(BaseElement): # type: ignore[misc]
         `title` :
             CSS style sheet set name
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -19769,19 +18833,13 @@ class style(BaseElement): # type: ignore[misc]
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -19897,8 +18955,8 @@ class sub(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -19911,10 +18969,10 @@ class sub(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -19938,13 +18996,9 @@ class sub(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -19974,19 +19028,13 @@ class sub(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -20100,8 +19148,8 @@ class summary(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -20114,10 +19162,10 @@ class summary(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -20141,13 +19189,9 @@ class summary(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -20177,19 +19221,13 @@ class summary(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -20303,8 +19341,8 @@ class sup(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -20317,10 +19355,10 @@ class sup(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -20344,13 +19382,9 @@ class sup(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -20380,19 +19414,13 @@ class sup(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -20506,8 +19534,8 @@ class svg(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -20520,10 +19548,10 @@ class svg(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -20547,13 +19575,9 @@ class svg(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -20583,19 +19607,13 @@ class svg(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -20709,8 +19727,8 @@ class table(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -20723,10 +19741,10 @@ class table(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -20750,13 +19768,9 @@ class table(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -20786,19 +19800,13 @@ class table(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -20912,8 +19920,8 @@ class tbody(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -20926,10 +19934,10 @@ class tbody(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -20953,13 +19961,9 @@ class tbody(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -20989,19 +19993,13 @@ class tbody(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -21115,11 +20113,11 @@ class td(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         colspan: Optional[str] = None,
-        headers: Optional[str] = None,
+        headers: Optional[Union[str, list]] = None,
         rowspan: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -21132,10 +20130,10 @@ class td(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -21159,23 +20157,17 @@ class td(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `colspan` :
             Number of columns that the cell is to span  
         
             Valid non-negative integer greater than zero
         `headers` :
-            The header cells for this cell  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            The header cells for this cell
         `rowspan` :
             Number of rows that the cell is to span
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -21205,19 +20197,13 @@ class td(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -21337,12 +20323,12 @@ class template(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         shadowrootclonable: Optional[Union[str, bool]] = None,
         shadowrootdelegatesfocus: Optional[Union[str, bool]] = None,
         shadowrootmode: Optional[Union[str, Literal['open', 'closed']]] = None,
         shadowrootserializable: Optional[Union[str, bool]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -21355,10 +20341,10 @@ class template(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -21382,9 +20368,7 @@ class template(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `shadowrootclonable` :
             Sets clonable on a declarative shadow root
         `shadowrootdelegatesfocus` :
@@ -21394,9 +20378,7 @@ class template(BaseElement):
         `shadowrootserializable` :
             Sets serializable on a declarative shadow root
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -21426,19 +20408,13 @@ class template(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -21560,7 +20536,7 @@ class textarea(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         autocomplete: Optional[str] = None,
         cols: Optional[str] = None,
         dirname: Optional[str] = None,
@@ -21574,7 +20550,7 @@ class textarea(BaseElement):
         required: Optional[Union[str, bool]] = None,
         rows: Optional[str] = None,
         wrap: Optional[Union[str, Literal['soft', 'hard']]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -21587,10 +20563,10 @@ class textarea(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -21614,9 +20590,7 @@ class textarea(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `autocomplete` :
             Hint for form autofill feature  
         
@@ -21652,9 +20626,7 @@ class textarea(BaseElement):
         `wrap` :
             How the value of the form control is to be wrapped for form submission
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -21684,19 +20656,13 @@ class textarea(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -21836,8 +20802,8 @@ class tfoot(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -21850,10 +20816,10 @@ class tfoot(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -21877,13 +20843,9 @@ class tfoot(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -21913,19 +20875,13 @@ class tfoot(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -22039,13 +20995,13 @@ class th(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         abbr: Optional[str] = None,
         colspan: Optional[str] = None,
-        headers: Optional[str] = None,
+        headers: Optional[Union[str, list]] = None,
         rowspan: Optional[Union[str, int]] = None,
         scope: Optional[Union[str, Literal['row', 'col', 'rowgroup', 'colgroup']]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -22058,10 +21014,10 @@ class th(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -22085,9 +21041,7 @@ class th(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `abbr` :
             Alternative label to use for the header cell when referencing the cell in other contexts
         `colspan` :
@@ -22095,17 +21049,13 @@ class th(BaseElement):
         
             Valid non-negative integer greater than zero
         `headers` :
-            The header cells for this cell  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            The header cells for this cell
         `rowspan` :
             Number of rows that the cell is to span
         `scope` :
             Specifies which cells the header cell applies to
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -22135,19 +21085,13 @@ class th(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -22271,8 +21215,8 @@ class thead(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -22285,10 +21229,10 @@ class thead(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -22312,13 +21256,9 @@ class thead(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -22348,19 +21288,13 @@ class thead(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -22474,9 +21408,9 @@ class time(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         datetime: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -22489,10 +21423,10 @@ class time(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -22516,17 +21450,13 @@ class time(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `datetime` :
             Machine-readable value  
         
             Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -22556,19 +21486,13 @@ class time(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -22684,8 +21608,8 @@ class title(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -22698,10 +21622,10 @@ class title(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -22725,13 +21649,9 @@ class title(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -22761,19 +21681,13 @@ class title(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -22887,8 +21801,8 @@ class tr(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -22901,10 +21815,10 @@ class tr(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -22928,13 +21842,9 @@ class tr(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -22964,19 +21874,13 @@ class tr(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -23090,13 +21994,13 @@ class track(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         default: Optional[Union[str, bool]] = None,
         kind: Optional[Union[str, Literal['subtitles', 'captions', 'descriptions', 'chapters', 'metadata']]] = None,
         label: Optional[str] = None,
         src: Optional[str] = None,
         srclang: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -23109,10 +22013,10 @@ class track(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -23136,9 +22040,7 @@ class track(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `default` :
             Enable the track if no other text track is more suitable
         `kind` :
@@ -23154,9 +22056,7 @@ class track(BaseElement):
         
             Valid BCP 47 language tag
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -23186,19 +22086,13 @@ class track(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -23322,8 +22216,8 @@ class u(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -23336,10 +22230,10 @@ class u(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -23363,13 +22257,9 @@ class u(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -23399,19 +22289,13 @@ class u(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -23525,8 +22409,8 @@ class ul(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -23539,10 +22423,10 @@ class ul(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -23566,13 +22450,9 @@ class ul(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -23602,19 +22482,13 @@ class ul(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -23728,8 +22602,8 @@ class var(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -23742,10 +22616,10 @@ class var(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -23769,13 +22643,9 @@ class var(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -23805,19 +22675,13 @@ class var(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -23931,7 +22795,7 @@ class video(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
         autoplay: Optional[Union[str, bool]] = None,
         controls: Optional[Union[str, bool]] = None,
         crossorigin: Optional[Union[str, Literal['anonymous', 'use-credentials']]] = None,
@@ -23943,7 +22807,7 @@ class video(BaseElement):
         preload: Optional[Union[str, Literal['none', 'metadata', 'auto']]] = None,
         src: Optional[str] = None,
         width: Optional[Union[str, int]] = None,
-        accesskey: Optional[str] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -23956,10 +22820,10 @@ class video(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -23983,9 +22847,7 @@ class video(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `autoplay` :
             Hint that the media resource can be started automatically when the page is loaded
         `controls` :
@@ -24013,9 +22875,7 @@ class video(BaseElement):
         `width` :
             Horizontal dimension
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -24045,19 +22905,13 @@ class video(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         
@@ -24193,8 +23047,8 @@ class wbr(BaseElement):
         self,
         attrs: Optional[Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]] = None,
         id: Optional[str] = None,
-        class_: Optional[str] = None,
-        accesskey: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        accesskey: Optional[Union[str, list]] = None,
         autocapitalize: Optional[Union[str, Literal['on', 'off', 'none', 'sentences', 'words', 'characters']]] = None,
         autocorrect: Optional[Union[str, Literal['on', 'off']]] = None,
         autofocus: Optional[Union[str, bool]] = None,
@@ -24207,10 +23061,10 @@ class wbr(BaseElement):
         inputmode: Optional[Union[str, Literal['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']]] = None,
         is_: Optional[str] = None,
         itemid: Optional[str] = None,
-        itemprop: Optional[str] = None,
-        itemref: Optional[str] = None,
+        itemprop: Optional[Union[str, list]] = None,
+        itemref: Optional[Union[str, list]] = None,
         itemscope: Optional[Union[str, bool]] = None,
-        itemtype: Optional[str] = None,
+        itemtype: Optional[Union[str, list]] = None,
         lang: Optional[str] = None,
         nonce: Optional[str] = None,
         popover: Optional[Union[str, Literal['auto', 'manual']]] = None,
@@ -24234,13 +23088,9 @@ class wbr(BaseElement):
         `id` :
             The element's ID
         `class_` :
-            Classes to which the element belongs  
-        
-            Set of space-separated tokens
+            Classes to which the element belongs
         `accesskey` :
-            Keyboard shortcut to activate or focus element  
-        
-            Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+            Keyboard shortcut to activate or focus element
         `autocapitalize` :
             Recommended autocapitalization behavior (for supported input methods)
         `autocorrect` :
@@ -24270,19 +23120,13 @@ class wbr(BaseElement):
         
             Valid URL potentially surrounded by spaces
         `itemprop` :
-            Property names of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+            Property names of a microdata item
         `itemref` :
-            Referenced elements  
-        
-            Unordered set of unique space-separated tokens consisting of IDs*
+            Referenced elements
         `itemscope` :
             Introduces a microdata item
         `itemtype` :
-            Item types of a microdata item  
-        
-            Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+            Item types of a microdata item
         `lang` :
             Language of the element  
         

--- a/tools/generated/form_attrs.py
+++ b/tools/generated/form_attrs.py
@@ -36,7 +36,7 @@ class FormAttrs:
 
 
     @staticmethod
-    def autocomplete(value) -> BaseAttribute:
+    def autocomplete(value: Literal['on', 'off']) -> BaseAttribute:
         """
         "form" attribute: autocomplete  
         Default setting for autofill feature for controls in the form  
@@ -50,7 +50,7 @@ class FormAttrs:
 
 
     @staticmethod
-    def enctype(value) -> BaseAttribute:
+    def enctype(value: Literal['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']) -> BaseAttribute:
         """
         "form" attribute: enctype  
         Entry list encoding type to use for form submission  
@@ -64,7 +64,7 @@ class FormAttrs:
 
 
     @staticmethod
-    def method(value) -> BaseAttribute:
+    def method(value: Literal['GET', 'POST', 'dialog']) -> BaseAttribute:
         """
         "form" attribute: method  
         Variant to use for form submission  

--- a/tools/generated/global_attrs.py
+++ b/tools/generated/global_attrs.py
@@ -8,7 +8,7 @@ class GlobalAttrs:
     """ 
     
     @staticmethod
-    def accesskey(value) -> BaseAttribute:
+    def accesskey(value: list) -> BaseAttribute:
         """
         "global" attribute: accesskey  
         Keyboard shortcut to activate or focus element  
@@ -64,7 +64,7 @@ class GlobalAttrs:
 
 
     @staticmethod
-    def class_(value) -> BaseAttribute:
+    def class_(value: list) -> BaseAttribute:
         """
         "global" attribute: class  
         Classes to which the element belongs  
@@ -218,7 +218,7 @@ class GlobalAttrs:
 
 
     @staticmethod
-    def itemprop(value) -> BaseAttribute:
+    def itemprop(value: list) -> BaseAttribute:
         """
         "global" attribute: itemprop  
         Property names of a microdata item  
@@ -232,7 +232,7 @@ class GlobalAttrs:
 
 
     @staticmethod
-    def itemref(value) -> BaseAttribute:
+    def itemref(value: list) -> BaseAttribute:
         """
         "global" attribute: itemref  
         Referenced elements  
@@ -260,7 +260,7 @@ class GlobalAttrs:
 
 
     @staticmethod
-    def itemtype(value) -> BaseAttribute:
+    def itemtype(value: list) -> BaseAttribute:
         """
         "global" attribute: itemtype  
         Item types of a microdata item  

--- a/tools/generated/iframe_attrs.py
+++ b/tools/generated/iframe_attrs.py
@@ -50,7 +50,7 @@ class IframeAttrs:
 
 
     @staticmethod
-    def loading(value) -> BaseAttribute:
+    def loading(value: Literal['lazy', 'eager']) -> BaseAttribute:
         """
         "iframe" attribute: loading  
         Used when determining loading deferral  
@@ -92,7 +92,7 @@ class IframeAttrs:
 
 
     @staticmethod
-    def sandbox(value) -> BaseAttribute:
+    def sandbox(value: list) -> BaseAttribute:
         """
         "iframe" attribute: sandbox  
         Security rules for nested content  

--- a/tools/generated/img_attrs.py
+++ b/tools/generated/img_attrs.py
@@ -22,7 +22,7 @@ class ImgAttrs:
 
 
     @staticmethod
-    def crossorigin(value) -> BaseAttribute:
+    def crossorigin(value: Literal['anonymous', 'use-credentials']) -> BaseAttribute:
         """
         "img" attribute: crossorigin  
         How the element handles crossorigin requests  
@@ -36,7 +36,7 @@ class ImgAttrs:
 
 
     @staticmethod
-    def decoding(value) -> BaseAttribute:
+    def decoding(value: Literal['sync', 'async', 'auto']) -> BaseAttribute:
         """
         "img" attribute: decoding  
         Decoding hint to use when processing this image for presentation  
@@ -50,7 +50,7 @@ class ImgAttrs:
 
 
     @staticmethod
-    def fetchpriority(value) -> BaseAttribute:
+    def fetchpriority(value: Literal['auto', 'high', 'low']) -> BaseAttribute:
         """
         "img" attribute: fetchpriority  
         Sets the priority for fetches initiated by the element  
@@ -92,7 +92,7 @@ class ImgAttrs:
 
 
     @staticmethod
-    def loading(value) -> BaseAttribute:
+    def loading(value: Literal['lazy', 'eager']) -> BaseAttribute:
         """
         "img" attribute: loading  
         Used when determining loading deferral  

--- a/tools/generated/input_attrs.py
+++ b/tools/generated/input_attrs.py
@@ -78,7 +78,7 @@ class InputAttrs:
 
 
     @staticmethod
-    def colorspace(value) -> BaseAttribute:
+    def colorspace(value: Literal['limited-srgb', 'display-p3']) -> BaseAttribute:
         """
         "input" attribute: colorspace  
         The color space of the serialized color  
@@ -148,7 +148,7 @@ class InputAttrs:
 
 
     @staticmethod
-    def formenctype(value) -> BaseAttribute:
+    def formenctype(value: Literal['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']) -> BaseAttribute:
         """
         "input" attribute: formenctype  
         Entry list encoding type to use for form submission  
@@ -162,7 +162,7 @@ class InputAttrs:
 
 
     @staticmethod
-    def formmethod(value) -> BaseAttribute:
+    def formmethod(value: Literal['GET', 'POST', 'dialog']) -> BaseAttribute:
         """
         "input" attribute: formmethod  
         Variant to use for form submission  
@@ -358,7 +358,7 @@ class InputAttrs:
 
 
     @staticmethod
-    def popovertargetaction(value) -> BaseAttribute:
+    def popovertargetaction(value: Literal['toggle', 'show', 'hide']) -> BaseAttribute:
         """
         "input" attribute: popovertargetaction  
         Indicates whether a targeted popover element is to be toggled, shown, or hidden  

--- a/tools/generated/link_attrs.py
+++ b/tools/generated/link_attrs.py
@@ -22,7 +22,7 @@ class LinkAttrs:
 
 
     @staticmethod
-    def blocking(value) -> BaseAttribute:
+    def blocking(value: list) -> BaseAttribute:
         """
         "link" attribute: blocking  
         Whether the element is potentially render-blocking  
@@ -50,7 +50,7 @@ class LinkAttrs:
 
 
     @staticmethod
-    def crossorigin(value) -> BaseAttribute:
+    def crossorigin(value: Literal['anonymous', 'use-credentials']) -> BaseAttribute:
         """
         "link" attribute: crossorigin  
         How the element handles crossorigin requests  
@@ -78,7 +78,7 @@ class LinkAttrs:
 
 
     @staticmethod
-    def fetchpriority(value) -> BaseAttribute:
+    def fetchpriority(value: Literal['auto', 'high', 'low']) -> BaseAttribute:
         """
         "link" attribute: fetchpriority  
         Sets the priority for fetches initiated by the element  
@@ -190,7 +190,7 @@ class LinkAttrs:
 
 
     @staticmethod
-    def rel(value) -> BaseAttribute:
+    def rel(value: list) -> BaseAttribute:
         """
         "link" attribute: rel  
         Relationship between the document containing the hyperlink and the destination resource  
@@ -204,7 +204,7 @@ class LinkAttrs:
 
 
     @staticmethod
-    def sizes(value) -> BaseAttribute:
+    def sizes(value: list) -> BaseAttribute:
         """
         "link" attribute: sizes  
         Sizes of the icons (for rel="icon")  

--- a/tools/generated/meta_attrs.py
+++ b/tools/generated/meta_attrs.py
@@ -8,7 +8,7 @@ class MetaAttrs:
     """ 
     
     @staticmethod
-    def charset(value) -> BaseAttribute:
+    def charset(value: Literal['utf-8']) -> BaseAttribute:
         """
         "meta" attribute: charset  
         Character encoding declaration  
@@ -36,7 +36,7 @@ class MetaAttrs:
 
 
     @staticmethod
-    def http_equiv(value) -> BaseAttribute:
+    def http_equiv(value: Literal['content-type', 'default-style', 'refresh', 'x-ua-compatible', 'content-security-policy']) -> BaseAttribute:
         """
         "meta" attribute: http-equiv  
         Pragma directive  

--- a/tools/generated/ol_attrs.py
+++ b/tools/generated/ol_attrs.py
@@ -36,7 +36,7 @@ class OlAttrs:
 
 
     @staticmethod
-    def type(value) -> BaseAttribute:
+    def type(value: Literal['1', 'a', 'A', 'i', 'I']) -> BaseAttribute:
         """
         "ol" attribute: type  
         Kind of list marker  

--- a/tools/generated/output_attrs.py
+++ b/tools/generated/output_attrs.py
@@ -8,7 +8,7 @@ class OutputAttrs:
     """ 
     
     @staticmethod
-    def for_(value) -> BaseAttribute:
+    def for_(value: list) -> BaseAttribute:
         """
         "output" attribute: for  
         Specifies controls from which the output was calculated  

--- a/tools/generated/script_attrs.py
+++ b/tools/generated/script_attrs.py
@@ -22,7 +22,7 @@ class ScriptAttrs:
 
 
     @staticmethod
-    def blocking(value) -> BaseAttribute:
+    def blocking(value: list) -> BaseAttribute:
         """
         "script" attribute: blocking  
         Whether the element is potentially render-blocking  
@@ -36,7 +36,7 @@ class ScriptAttrs:
 
 
     @staticmethod
-    def crossorigin(value) -> BaseAttribute:
+    def crossorigin(value: Literal['anonymous', 'use-credentials']) -> BaseAttribute:
         """
         "script" attribute: crossorigin  
         How the element handles crossorigin requests  
@@ -64,7 +64,7 @@ class ScriptAttrs:
 
 
     @staticmethod
-    def fetchpriority(value) -> BaseAttribute:
+    def fetchpriority(value: Literal['auto', 'high', 'low']) -> BaseAttribute:
         """
         "script" attribute: fetchpriority  
         Sets the priority for fetches initiated by the element  

--- a/tools/generated/style_attrs.py
+++ b/tools/generated/style_attrs.py
@@ -8,7 +8,7 @@ class StyleAttrs:
     """ 
     
     @staticmethod
-    def blocking(value) -> BaseAttribute:
+    def blocking(value: list) -> BaseAttribute:
         """
         "style" attribute: blocking  
         Whether the element is potentially render-blocking  

--- a/tools/generated/td_attrs.py
+++ b/tools/generated/td_attrs.py
@@ -22,7 +22,7 @@ class TdAttrs:
 
 
     @staticmethod
-    def headers(value) -> BaseAttribute:
+    def headers(value: list) -> BaseAttribute:
         """
         "td" attribute: headers  
         The header cells for this cell  

--- a/tools/generated/template_attrs.py
+++ b/tools/generated/template_attrs.py
@@ -36,7 +36,7 @@ class TemplateAttrs:
 
 
     @staticmethod
-    def shadowrootmode(value) -> BaseAttribute:
+    def shadowrootmode(value: Literal['open', 'closed']) -> BaseAttribute:
         """
         "template" attribute: shadowrootmode  
         Enables streaming declarative shadow roots  

--- a/tools/generated/textarea_attrs.py
+++ b/tools/generated/textarea_attrs.py
@@ -176,7 +176,7 @@ class TextareaAttrs:
 
 
     @staticmethod
-    def wrap(value) -> BaseAttribute:
+    def wrap(value: Literal['soft', 'hard']) -> BaseAttribute:
         """
         "textarea" attribute: wrap  
         How the value of the form control is to be wrapped for form submission  

--- a/tools/generated/th_attrs.py
+++ b/tools/generated/th_attrs.py
@@ -36,7 +36,7 @@ class ThAttrs:
 
 
     @staticmethod
-    def headers(value) -> BaseAttribute:
+    def headers(value: list) -> BaseAttribute:
         """
         "th" attribute: headers  
         The header cells for this cell  
@@ -64,7 +64,7 @@ class ThAttrs:
 
 
     @staticmethod
-    def scope(value) -> BaseAttribute:
+    def scope(value: Literal['row', 'col', 'rowgroup', 'colgroup']) -> BaseAttribute:
         """
         "th" attribute: scope  
         Specifies which cells the header cell applies to  

--- a/tools/generated/track_attrs.py
+++ b/tools/generated/track_attrs.py
@@ -22,7 +22,7 @@ class TrackAttrs:
 
 
     @staticmethod
-    def kind(value) -> BaseAttribute:
+    def kind(value: Literal['subtitles', 'captions', 'descriptions', 'chapters', 'metadata']) -> BaseAttribute:
         """
         "track" attribute: kind  
         The type of text track  

--- a/tools/generated/video_attrs.py
+++ b/tools/generated/video_attrs.py
@@ -36,7 +36,7 @@ class VideoAttrs:
 
 
     @staticmethod
-    def crossorigin(value) -> BaseAttribute:
+    def crossorigin(value: Literal['anonymous', 'use-credentials']) -> BaseAttribute:
         """
         "video" attribute: crossorigin  
         How the element handles crossorigin requests  
@@ -120,7 +120,7 @@ class VideoAttrs:
 
 
     @staticmethod
-    def preload(value) -> BaseAttribute:
+    def preload(value: Literal['none', 'metadata', 'auto']) -> BaseAttribute:
         """
         "video" attribute: preload  
         Hints how much buffering the media resource will likely need  

--- a/tools/generator_common.py
+++ b/tools/generator_common.py
@@ -24,7 +24,7 @@ def ReadAttr(attr_spec) -> AttrDefinition:
 
 
 def value_hint_to_python_type(value):
-    if isinstance(value, list):
+    if isinstance(value, list) or value.startswith("[") and value.endswith("]"):
         # Since the list looks like ["a", "b", "c"]
         # this works
         return f"Literal{value}"
@@ -36,6 +36,8 @@ def value_hint_to_python_type(value):
         return "int"
     if value.startswith("Valid floating-point number"):
         return "float"
+    if "space-separated tokens" in value:
+        return "list"
     return None
 
 


### PR DESCRIPTION
# 0.7.0
* Improved type hint generation for lists and literals
* Add -n / --noimport <optional module name> to `html-compose convert` which will will output, if --noimport ht is used, `ht.div` instead of importing each class
