### PR TITLE
0.8.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,19 @@
+# 0.8.0
+* Add custom element generator CustomElement.create or create_element
+  * BaseElement now takes id/class_ params because this justifies their existence
+* html translator will now output an array if an array is given
+* Improve import statement output in translator
+* Translator will generate custom elements for elements it does not recognize.
+  - One reason this was added is that html_compose has no intention of implementing
+    deprecated HTML elements, but it previously breaks when trying to reproduce
+    them.
+* Fix translator inappropriately stripping leading whitespace
+* WatchConds can optionally not reload the server via server_reload param
+
+# 0.7.0
+* Improved type hint generation for lists and literals
+* Add -n / --noimport <optional module name> to `html-compose convert` which will will output, if --noimport ht is used, `ht.div` instead of importing each class
+
 # 0.6.3
 * Minor repo polish
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "html-compose"
-version = "0.7.1"
+version = "0.8.0"
 description = "Composable HTML generation in python"
 authors = [
     { name = "jealouscloud", email = "github@noaha.org" }

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -80,7 +80,7 @@ traitlets==5.14.3
 types-beautifulsoup4==4.12.0.20250204
 types-html5lib==1.1.11.20241018
     # via types-beautifulsoup4
-typing-extensions==4.12.2
+typing-extensions==4.14.1
     # via anyio
     # via ipython
     # via mypy

--- a/src/html_compose/__init__.py
+++ b/src/html_compose/__init__.py
@@ -54,6 +54,7 @@ def doctype(dtype: str = "html"):
 
 
 from .base_element import BaseElement
+from .custom_element import CustomElement
 from .document import HTML5Document
 
 # ruff: noqa: F401, E402

--- a/src/html_compose/__init__.py
+++ b/src/html_compose/__init__.py
@@ -55,6 +55,9 @@ def doctype(dtype: str = "html"):
 
 from .base_element import BaseElement
 from .custom_element import CustomElement
+
+create_element = CustomElement.create
+
 from .document import HTML5Document
 
 # ruff: noqa: F401, E402

--- a/src/html_compose/base_element.py
+++ b/src/html_compose/base_element.py
@@ -63,8 +63,6 @@ class BaseElement(ElementBase):
         Args:
             name (str): The name of the element.
             void_element (bool): Indicates if the element is a void element. Defaults to False.
-            id (str): The ID of the element. Defaults to None.
-            class_: The class of the element. Defaults to None.
             attrs: A list of attributes for the element.
                 It can also be a dictionary of key,value strings.
                 Defaults to None.

--- a/src/html_compose/cli.py
+++ b/src/html_compose/cli.py
@@ -25,7 +25,23 @@ def from_html(args):
 
     if is_stdin:
         print("---\n")
-    print(translate_html.translate(html_content, args.noimport))
+
+    tresult = translate_html.translate(html_content, args.noimport)
+
+    if tresult is None:
+        print("Failed to translate HTML content")
+        return
+
+    if tresult.import_statement:
+        print(tresult.import_statement, "\n")
+
+    if tresult.custom_elements:
+        print("\n".join(tresult.custom_elements))
+
+    if len(tresult.elements) > 1:
+        print(tresult.as_array())
+    elif len(tresult.elements) == 1:
+        print(tresult.elements[0])
 
 
 def parse_html_translate(parser):

--- a/src/html_compose/custom_element.py
+++ b/src/html_compose/custom_element.py
@@ -18,13 +18,27 @@ class CustomElement(BaseElement):
         class_: Optional[Union[str, list]] = None,
         children: Optional[list] = None,
     ):
+        """
+        Initialize a custom HTML element
+
+        Args:
+            attrs: A list of attributes for the element.
+                It can also be a dictionary of key,value strings.
+                Defaults to None.
+            id (str): The ID of the element. Defaults to None.
+            class_: The class of the element. Defaults to None.
+            children: A list of child elements. Defaults to None.
+        """
         tag = self.__class__.tag
         if tag == "UNSET":
             raise ValueError(
                 "CustomElement must be created with a tag name using the create() method."
             )
         super().__init__(
-            self.__class__.tag, self.__class__.is_void, attrs, children
+            self.__class__.tag,
+            void_element=self.__class__.is_void,
+            attrs=attrs,
+            children=children,
         )
         if not (id is None or id is False):
             self._process_attr("id", id)

--- a/src/html_compose/custom_element.py
+++ b/src/html_compose/custom_element.py
@@ -1,0 +1,49 @@
+from typing import Optional, Union
+
+from .attributes import BaseAttribute, GlobalAttrs
+from .base_element import BaseElement
+from .util_funcs import safe_name
+
+
+class CustomElement(BaseElement):
+    tag = "UNSET"
+    is_void = False
+
+    def __init__(
+        self,
+        attrs: Optional[
+            Union[dict[str, Union[str, dict, list]], list[BaseAttribute]]
+        ] = None,
+        id: Optional[str] = None,
+        class_: Optional[Union[str, list]] = None,
+        children: Optional[list] = None,
+    ):
+        tag = self.__class__.tag
+        if tag == "UNSET":
+            raise ValueError(
+                "CustomElement must be created with a tag name using the create() method."
+            )
+        super().__init__(
+            self.__class__.tag, self.__class__.is_void, attrs, children
+        )
+        if not (id is None or id is False):
+            self._process_attr("id", id)
+        if not (class_ is None or class_ is False):
+            self._process_attr("class", class_)
+
+    class hint(GlobalAttrs):
+        pass
+
+    _ = hint
+
+    @staticmethod
+    def create(tag: str, void_element: bool = False) -> type["CustomElement"]:
+        """
+        Create a new element class with the given tag and void_element flag.
+        This method is a factory for creating new element classes.
+        """
+        return type(
+            safe_name(tag),
+            (CustomElement,),
+            {"tag": tag, "is_void": void_element},
+        )

--- a/src/html_compose/elements.py
+++ b/src/html_compose/elements.py
@@ -66,6 +66,9 @@ class a(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a  
     """  # fmt: skip
 
+    tag = "a"
+    categories = ["flow", "phrasing*", "interactive", "palpable"]
+
     class hint(GlobalAttrs, AnchorAttrs):
         """
         Type hints for "a" attrs  
@@ -346,6 +349,9 @@ class abbr(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr  
     """  # fmt: skip
 
+    tag = "abbr"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "abbr" attrs  
@@ -576,6 +582,9 @@ class address(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address  
     """  # fmt: skip
 
+    tag = "address"
+    categories = ["flow", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "address" attrs  
@@ -805,6 +814,9 @@ class area(BaseElement):
     Interface: HTMLAreaElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area  
     """  # fmt: skip
+
+    tag = "area"
+    categories = ["flow", "phrasing"]
 
     class hint(GlobalAttrs, AreaAttrs):
         """
@@ -1091,6 +1103,9 @@ class article(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article  
     """  # fmt: skip
 
+    tag = "article"
+    categories = ["flow", "sectioning", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "article" attrs  
@@ -1321,6 +1336,9 @@ class aside(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside  
     """  # fmt: skip
 
+    tag = "aside"
+    categories = ["flow", "sectioning", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "aside" attrs  
@@ -1550,6 +1568,9 @@ class audio(BaseElement):
     Interface: HTMLAudioElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio  
     """  # fmt: skip
+
+    tag = "audio"
+    categories = ["flow", "phrasing", "embedded", "interactive", "palpable*"]
 
     class hint(GlobalAttrs, AudioAttrs):
         """
@@ -1822,6 +1843,9 @@ class b(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b  
     """  # fmt: skip
 
+    tag = "b"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "b" attrs  
@@ -2051,6 +2075,9 @@ class base(BaseElement):
     Interface: HTMLBaseElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base  
     """  # fmt: skip
+
+    tag = "base"
+    categories = ["metadata"]
 
     class hint(GlobalAttrs, BaseAttrs):
         """
@@ -2296,6 +2323,9 @@ class bdi(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi  
     """  # fmt: skip
 
+    tag = "bdi"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "bdi" attrs  
@@ -2526,6 +2556,9 @@ class bdo(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo  
     """  # fmt: skip
 
+    tag = "bdo"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "bdo" attrs  
@@ -2755,6 +2788,9 @@ class blockquote(BaseElement):
     Interface: HTMLQuoteElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote  
     """  # fmt: skip
+
+    tag = "blockquote"
+    categories = ["flow", "palpable"]
 
     class hint(GlobalAttrs, BlockquoteAttrs):
         """
@@ -2993,6 +3029,9 @@ class body(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body  
     """  # fmt: skip
 
+    tag = "body"
+    categories = ["none"]
+
     class hint(GlobalAttrs, BodyAttrs):
         """
         Type hints for "body" attrs  
@@ -3223,6 +3262,9 @@ class br(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br  
     """  # fmt: skip
 
+    tag = "br"
+    categories = ["flow", "phrasing"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "br" attrs  
@@ -3452,6 +3494,18 @@ class button(BaseElement):
     Interface: HTMLButtonElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button  
     """  # fmt: skip
+
+    tag = "button"
+    categories = [
+        "flow",
+        "phrasing",
+        "interactive",
+        "listed",
+        "labelable",
+        "submittable",
+        "form-associated",
+        "palpable",
+    ]
 
     class hint(GlobalAttrs, ButtonAttrs):
         """
@@ -3764,6 +3818,9 @@ class canvas(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas  
     """  # fmt: skip
 
+    tag = "canvas"
+    categories = ["flow", "phrasing", "embedded", "palpable"]
+
     class hint(GlobalAttrs, CanvasAttrs):
         """
         Type hints for "canvas" attrs  
@@ -4004,6 +4061,9 @@ class caption(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption  
     """  # fmt: skip
 
+    tag = "caption"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "caption" attrs  
@@ -4233,6 +4293,9 @@ class cite(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite  
     """  # fmt: skip
+
+    tag = "cite"
+    categories = ["flow", "phrasing", "palpable"]
 
     class hint(GlobalAttrs):
         """
@@ -4464,6 +4527,9 @@ class code(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code  
     """  # fmt: skip
 
+    tag = "code"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "code" attrs  
@@ -4693,6 +4759,9 @@ class col(BaseElement):
     Interface: HTMLTableColElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col  
     """  # fmt: skip
+
+    tag = "col"
+    categories = ["none"]
 
     class hint(GlobalAttrs, ColAttrs):
         """
@@ -4931,6 +5000,9 @@ class colgroup(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup  
     """  # fmt: skip
 
+    tag = "colgroup"
+    categories = ["none"]
+
     class hint(GlobalAttrs, ColgroupAttrs):
         """
         Type hints for "colgroup" attrs  
@@ -5168,6 +5240,9 @@ class data(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data  
     """  # fmt: skip
 
+    tag = "data"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs, DataAttrs):
         """
         Type hints for "data" attrs  
@@ -5403,6 +5478,9 @@ class datalist(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist  
     """  # fmt: skip
 
+    tag = "datalist"
+    categories = ["flow", "phrasing"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "datalist" attrs  
@@ -5633,6 +5711,9 @@ class dd(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd  
     """  # fmt: skip
 
+    tag = "dd"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "dd" attrs  
@@ -5862,6 +5943,9 @@ class del_(BaseElement):
     Interface: HTMLModElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del  
     """  # fmt: skip
+
+    tag = "del"
+    categories = ["flow", "phrasing*", "palpable"]
 
     class hint(GlobalAttrs, DelAttrs):
         """
@@ -6107,6 +6191,9 @@ class details(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details  
     """  # fmt: skip
 
+    tag = "details"
+    categories = ["flow", "interactive", "palpable"]
+
     class hint(GlobalAttrs, DetailsAttrs):
         """
         Type hints for "details" attrs  
@@ -6347,6 +6434,9 @@ class dfn(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn  
     """  # fmt: skip
 
+    tag = "dfn"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "dfn" attrs  
@@ -6576,6 +6666,9 @@ class dialog(BaseElement):
     Interface: HTMLDialogElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog  
     """  # fmt: skip
+
+    tag = "dialog"
+    categories = ["flow"]
 
     class hint(GlobalAttrs, DialogAttrs):
         """
@@ -6812,6 +6905,9 @@ class div(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div  
     """  # fmt: skip
 
+    tag = "div"
+    categories = ["flow", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "div" attrs  
@@ -7041,6 +7137,9 @@ class dl(BaseElement):
     Interface: HTMLDListElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl  
     """  # fmt: skip
+
+    tag = "dl"
+    categories = ["flow", "palpable"]
 
     class hint(GlobalAttrs):
         """
@@ -7272,6 +7371,9 @@ class dt(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt  
     """  # fmt: skip
 
+    tag = "dt"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "dt" attrs  
@@ -7502,6 +7604,9 @@ class em(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em  
     """  # fmt: skip
 
+    tag = "em"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "em" attrs  
@@ -7731,6 +7836,9 @@ class embed(BaseElement):
     Interface: HTMLEmbedElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed  
     """  # fmt: skip
+
+    tag = "embed"
+    categories = ["flow", "phrasing", "embedded", "interactive", "palpable"]
 
     class hint(GlobalAttrs, EmbedAttrs):
         """
@@ -7986,6 +8094,9 @@ class fieldset(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset  
     """  # fmt: skip
 
+    tag = "fieldset"
+    categories = ["flow", "listed", "form-associated", "palpable"]
+
     class hint(GlobalAttrs, FieldsetAttrs):
         """
         Type hints for "fieldset" attrs  
@@ -8233,6 +8344,9 @@ class figcaption(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption  
     """  # fmt: skip
 
+    tag = "figcaption"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "figcaption" attrs  
@@ -8462,6 +8576,9 @@ class figure(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure  
     """  # fmt: skip
+
+    tag = "figure"
+    categories = ["flow", "palpable"]
 
     class hint(GlobalAttrs):
         """
@@ -8693,6 +8810,9 @@ class footer(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer  
     """  # fmt: skip
 
+    tag = "footer"
+    categories = ["flow", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "footer" attrs  
@@ -8922,6 +9042,9 @@ class form(BaseElement):
     Interface: HTMLFormElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form  
     """  # fmt: skip
+
+    tag = "form"
+    categories = ["flow", "palpable"]
 
     class hint(GlobalAttrs, FormAttrs):
         """
@@ -9208,6 +9331,9 @@ class h1(BaseElement):
     Documentation: None  
     """  # fmt: skip
 
+    tag = "h1"
+    categories = ["flow", "heading", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "h1" attrs  
@@ -9437,6 +9563,9 @@ class h2(BaseElement):
     Interface: HTMLHeadingElement  
     Documentation: None  
     """  # fmt: skip
+
+    tag = "h2"
+    categories = ["flow", "heading", "palpable"]
 
     class hint(GlobalAttrs):
         """
@@ -9668,6 +9797,9 @@ class h3(BaseElement):
     Documentation: None  
     """  # fmt: skip
 
+    tag = "h3"
+    categories = ["flow", "heading", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "h3" attrs  
@@ -9897,6 +10029,9 @@ class h4(BaseElement):
     Interface: HTMLHeadingElement  
     Documentation: None  
     """  # fmt: skip
+
+    tag = "h4"
+    categories = ["flow", "heading", "palpable"]
 
     class hint(GlobalAttrs):
         """
@@ -10128,6 +10263,9 @@ class h5(BaseElement):
     Documentation: None  
     """  # fmt: skip
 
+    tag = "h5"
+    categories = ["flow", "heading", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "h5" attrs  
@@ -10357,6 +10495,9 @@ class h6(BaseElement):
     Interface: HTMLHeadingElement  
     Documentation: None  
     """  # fmt: skip
+
+    tag = "h6"
+    categories = ["flow", "heading", "palpable"]
 
     class hint(GlobalAttrs):
         """
@@ -10588,6 +10729,9 @@ class head(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head  
     """  # fmt: skip
 
+    tag = "head"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "head" attrs  
@@ -10817,6 +10961,9 @@ class header(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header  
     """  # fmt: skip
+
+    tag = "header"
+    categories = ["flow", "palpable"]
 
     class hint(GlobalAttrs):
         """
@@ -11048,6 +11195,9 @@ class hgroup(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup  
     """  # fmt: skip
 
+    tag = "hgroup"
+    categories = ["flow", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "hgroup" attrs  
@@ -11277,6 +11427,9 @@ class hr(BaseElement):
     Interface: HTMLHRElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr  
     """  # fmt: skip
+
+    tag = "hr"
+    categories = ["flow"]
 
     class hint(GlobalAttrs):
         """
@@ -11508,6 +11661,9 @@ class html(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html  
     """  # fmt: skip
 
+    tag = "html"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "html" attrs  
@@ -11738,6 +11894,9 @@ class i(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i  
     """  # fmt: skip
 
+    tag = "i"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "i" attrs  
@@ -11967,6 +12126,9 @@ class iframe(BaseElement):
     Interface: HTMLIFrameElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe  
     """  # fmt: skip
+
+    tag = "iframe"
+    categories = ["flow", "phrasing", "embedded", "interactive", "palpable"]
 
     class hint(GlobalAttrs, IframeAttrs):
         """
@@ -12257,6 +12419,16 @@ class img(BaseElement):
     Interface: HTMLImageElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img  
     """  # fmt: skip
+
+    tag = "img"
+    categories = [
+        "flow",
+        "phrasing",
+        "embedded",
+        "interactive*",
+        "form-associated",
+        "palpable",
+    ]
 
     class hint(GlobalAttrs, ImgAttrs):
         """
@@ -12566,6 +12738,19 @@ class input(BaseElement):  # type: ignore[misc]
     Interface: HTMLInputElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input  
     """  # fmt: skip
+
+    tag = "input"
+    categories = [
+        "flow",
+        "phrasing",
+        "interactive*",
+        "listed",
+        "labelable",
+        "submittable",
+        "resettable",
+        "form-associated",
+        "palpable*",
+    ]
 
     class hint(GlobalAttrs, InputAttrs):
         """
@@ -13010,6 +13195,9 @@ class ins(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins  
     """  # fmt: skip
 
+    tag = "ins"
+    categories = ["flow", "phrasing*", "palpable"]
+
     class hint(GlobalAttrs, InsAttrs):
         """
         Type hints for "ins" attrs  
@@ -13254,6 +13442,9 @@ class kbd(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd  
     """  # fmt: skip
 
+    tag = "kbd"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "kbd" attrs  
@@ -13483,6 +13674,9 @@ class label(BaseElement):
     Interface: HTMLLabelElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label  
     """  # fmt: skip
+
+    tag = "label"
+    categories = ["flow", "phrasing", "interactive", "palpable"]
 
     class hint(GlobalAttrs, LabelAttrs):
         """
@@ -13721,6 +13915,9 @@ class legend(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend  
     """  # fmt: skip
 
+    tag = "legend"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "legend" attrs  
@@ -13950,6 +14147,9 @@ class li(BaseElement):
     Interface: HTMLLIElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li  
     """  # fmt: skip
+
+    tag = "li"
+    categories = ["none"]
 
     class hint(GlobalAttrs, LiAttrs):
         """
@@ -14185,6 +14385,9 @@ class link(BaseElement):  # type: ignore[misc]
     Interface: HTMLLinkElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link  
     """  # fmt: skip
+
+    tag = "link"
+    categories = ["metadata", "flow*", "phrasing*"]
 
     class hint(GlobalAttrs, LinkAttrs):
         """
@@ -14520,6 +14723,9 @@ class main(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main  
     """  # fmt: skip
 
+    tag = "main"
+    categories = ["flow", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "main" attrs  
@@ -14749,6 +14955,9 @@ class map(BaseElement):
     Interface: HTMLMapElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map  
     """  # fmt: skip
+
+    tag = "map"
+    categories = ["flow", "phrasing*", "palpable"]
 
     class hint(GlobalAttrs, MapAttrs):
         """
@@ -14985,6 +15194,9 @@ class mark(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark  
     """  # fmt: skip
 
+    tag = "mark"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "mark" attrs  
@@ -15215,6 +15427,9 @@ class menu(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu  
     """  # fmt: skip
 
+    tag = "menu"
+    categories = ["flow", "palpable*"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "menu" attrs  
@@ -15444,6 +15659,9 @@ class meta(BaseElement):
     Interface: HTMLMetaElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta  
     """  # fmt: skip
+
+    tag = "meta"
+    categories = ["metadata", "flow*", "phrasing*"]
 
     class hint(GlobalAttrs, MetaAttrs):
         """
@@ -15713,6 +15931,9 @@ class meter(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter  
     """  # fmt: skip
 
+    tag = "meter"
+    categories = ["flow", "phrasing", "labelable", "palpable"]
+
     class hint(GlobalAttrs, MeterAttrs):
         """
         Type hints for "meter" attrs  
@@ -15973,6 +16194,9 @@ class nav(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav  
     """  # fmt: skip
 
+    tag = "nav"
+    categories = ["flow", "sectioning", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "nav" attrs  
@@ -16203,6 +16427,9 @@ class noscript(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript  
     """  # fmt: skip
 
+    tag = "noscript"
+    categories = ["metadata", "flow", "phrasing"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "noscript" attrs  
@@ -16432,6 +16659,17 @@ class object(BaseElement):
     Interface: HTMLObjectElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object  
     """  # fmt: skip
+
+    tag = "object"
+    categories = [
+        "flow",
+        "phrasing",
+        "embedded",
+        "interactive*",
+        "listed",
+        "form-associated",
+        "palpable",
+    ]
 
     class hint(GlobalAttrs, ObjectAttrs):
         """
@@ -16701,6 +16939,9 @@ class ol(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol  
     """  # fmt: skip
 
+    tag = "ol"
+    categories = ["flow", "palpable*"]
+
     class hint(GlobalAttrs, OlAttrs):
         """
         Type hints for "ol" attrs  
@@ -16946,6 +17187,9 @@ class optgroup(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup  
     """  # fmt: skip
 
+    tag = "optgroup"
+    categories = ["none"]
+
     class hint(GlobalAttrs, OptgroupAttrs):
         """
         Type hints for "optgroup" attrs  
@@ -17185,6 +17429,9 @@ class option(BaseElement):
     Interface: HTMLOptionElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option  
     """  # fmt: skip
+
+    tag = "option"
+    categories = ["none"]
 
     class hint(GlobalAttrs, OptionAttrs):
         """
@@ -17436,6 +17683,17 @@ class output(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output  
     """  # fmt: skip
 
+    tag = "output"
+    categories = [
+        "flow",
+        "phrasing",
+        "listed",
+        "labelable",
+        "resettable",
+        "form-associated",
+        "palpable",
+    ]
+
     class hint(GlobalAttrs, OutputAttrs):
         """
         Type hints for "output" attrs  
@@ -17683,6 +17941,9 @@ class p(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p  
     """  # fmt: skip
 
+    tag = "p"
+    categories = ["flow", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "p" attrs  
@@ -17912,6 +18173,9 @@ class picture(BaseElement):
     Interface: HTMLPictureElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture  
     """  # fmt: skip
+
+    tag = "picture"
+    categories = ["flow", "phrasing", "embedded", "palpable"]
 
     class hint(GlobalAttrs):
         """
@@ -18143,6 +18407,9 @@ class pre(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre  
     """  # fmt: skip
 
+    tag = "pre"
+    categories = ["flow", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "pre" attrs  
@@ -18372,6 +18639,9 @@ class progress(BaseElement):
     Interface: HTMLProgressElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress  
     """  # fmt: skip
+
+    tag = "progress"
+    categories = ["flow", "phrasing", "labelable", "palpable"]
 
     class hint(GlobalAttrs, ProgressAttrs):
         """
@@ -18613,6 +18883,9 @@ class q(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q  
     """  # fmt: skip
 
+    tag = "q"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs, QAttrs):
         """
         Type hints for "q" attrs  
@@ -18850,6 +19123,9 @@ class rp(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp  
     """  # fmt: skip
 
+    tag = "rp"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "rp" attrs  
@@ -19079,6 +19355,9 @@ class rt(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt  
     """  # fmt: skip
+
+    tag = "rt"
+    categories = ["none"]
 
     class hint(GlobalAttrs):
         """
@@ -19310,6 +19589,9 @@ class ruby(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby  
     """  # fmt: skip
 
+    tag = "ruby"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "ruby" attrs  
@@ -19539,6 +19821,9 @@ class s(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s  
     """  # fmt: skip
+
+    tag = "s"
+    categories = ["flow", "phrasing", "palpable"]
 
     class hint(GlobalAttrs):
         """
@@ -19770,6 +20055,9 @@ class samp(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp  
     """  # fmt: skip
 
+    tag = "samp"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "samp" attrs  
@@ -19999,6 +20287,9 @@ class script(BaseElement):
     Interface: HTMLScriptElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script  
     """  # fmt: skip
+
+    tag = "script"
+    categories = ["metadata", "flow", "phrasing", "script-supporting"]
 
     class hint(GlobalAttrs, ScriptAttrs):
         """
@@ -20290,6 +20581,9 @@ class search(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search  
     """  # fmt: skip
 
+    tag = "search"
+    categories = ["flow", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "search" attrs  
@@ -20520,6 +20814,9 @@ class section(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section  
     """  # fmt: skip
 
+    tag = "section"
+    categories = ["flow", "sectioning", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "section" attrs  
@@ -20749,6 +21046,19 @@ class select(BaseElement):
     Interface: HTMLSelectElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select  
     """  # fmt: skip
+
+    tag = "select"
+    categories = [
+        "flow",
+        "phrasing",
+        "interactive",
+        "listed",
+        "labelable",
+        "submittable",
+        "resettable",
+        "form-associated",
+        "palpable",
+    ]
 
     class hint(GlobalAttrs, SelectAttrs):
         """
@@ -21021,6 +21331,9 @@ class slot(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot  
     """  # fmt: skip
 
+    tag = "slot"
+    categories = ["flow", "phrasing"]
+
     class hint(GlobalAttrs, SlotAttrs):
         """
         Type hints for "slot" attrs  
@@ -21256,6 +21569,9 @@ class small(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small  
     """  # fmt: skip
 
+    tag = "small"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "small" attrs  
@@ -21485,6 +21801,9 @@ class source(BaseElement):
     Interface: HTMLSourceElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source  
     """  # fmt: skip
+
+    tag = "source"
+    categories = ["none"]
 
     class hint(GlobalAttrs, SourceAttrs):
         """
@@ -21761,6 +22080,9 @@ class span(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span  
     """  # fmt: skip
 
+    tag = "span"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "span" attrs  
@@ -21991,6 +22313,9 @@ class strong(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong  
     """  # fmt: skip
 
+    tag = "strong"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "strong" attrs  
@@ -22220,6 +22545,9 @@ class style(BaseElement):  # type: ignore[misc]
     Interface: HTMLStyleElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style  
     """  # fmt: skip
+
+    tag = "style"
+    categories = ["metadata"]
 
     class hint(GlobalAttrs, StyleAttrs):
         """
@@ -22463,6 +22791,9 @@ class sub(BaseElement):
     Documentation: None  
     """  # fmt: skip
 
+    tag = "sub"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "sub" attrs  
@@ -22692,6 +23023,9 @@ class summary(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary  
     """  # fmt: skip
+
+    tag = "summary"
+    categories = ["none"]
 
     class hint(GlobalAttrs):
         """
@@ -22923,6 +23257,9 @@ class sup(BaseElement):
     Documentation: None  
     """  # fmt: skip
 
+    tag = "sup"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "sup" attrs  
@@ -23152,6 +23489,9 @@ class svg(BaseElement):
     Interface: SVGSVGElement  
     Documentation: None  
     """  # fmt: skip
+
+    tag = "svg"
+    categories = ["flow", "phrasing", "embedded", "palpable"]
 
     class hint(GlobalAttrs):
         """
@@ -23383,6 +23723,9 @@ class table(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table  
     """  # fmt: skip
 
+    tag = "table"
+    categories = ["flow", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "table" attrs  
@@ -23613,6 +23956,9 @@ class tbody(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody  
     """  # fmt: skip
 
+    tag = "tbody"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "tbody" attrs  
@@ -23842,6 +24188,9 @@ class td(BaseElement):
     Interface: HTMLTableCellElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td  
     """  # fmt: skip
+
+    tag = "td"
+    categories = ["none"]
 
     class hint(GlobalAttrs, TdAttrs):
         """
@@ -24089,6 +24438,9 @@ class template(BaseElement):
     Interface: HTMLTemplateElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template  
     """  # fmt: skip
+
+    tag = "template"
+    categories = ["metadata", "flow", "phrasing", "script-supporting"]
 
     class hint(GlobalAttrs, TemplateAttrs):
         """
@@ -24346,6 +24698,19 @@ class textarea(BaseElement):
     Interface: HTMLTextAreaElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea  
     """  # fmt: skip
+
+    tag = "textarea"
+    categories = [
+        "flow",
+        "phrasing",
+        "interactive",
+        "listed",
+        "labelable",
+        "submittable",
+        "resettable",
+        "form-associated",
+        "palpable",
+    ]
 
     class hint(GlobalAttrs, TextareaAttrs):
         """
@@ -24650,6 +25015,9 @@ class tfoot(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot  
     """  # fmt: skip
 
+    tag = "tfoot"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "tfoot" attrs  
@@ -24879,6 +25247,9 @@ class th(BaseElement):
     Interface: HTMLTableCellElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th  
     """  # fmt: skip
+
+    tag = "th"
+    categories = ["interactive*"]
 
     class hint(GlobalAttrs, ThAttrs):
         """
@@ -25139,6 +25510,9 @@ class thead(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead  
     """  # fmt: skip
 
+    tag = "thead"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "thead" attrs  
@@ -25368,6 +25742,9 @@ class time(BaseElement):
     Interface: HTMLTimeElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time  
     """  # fmt: skip
+
+    tag = "time"
+    categories = ["flow", "phrasing", "palpable"]
 
     class hint(GlobalAttrs, TimeAttrs):
         """
@@ -25606,6 +25983,9 @@ class title(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title  
     """  # fmt: skip
 
+    tag = "title"
+    categories = ["metadata"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "title" attrs  
@@ -25836,6 +26216,9 @@ class tr(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr  
     """  # fmt: skip
 
+    tag = "tr"
+    categories = ["none"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "tr" attrs  
@@ -26065,6 +26448,9 @@ class track(BaseElement):
     Interface: HTMLTrackElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track  
     """  # fmt: skip
+
+    tag = "track"
+    categories = ["none"]
 
     class hint(GlobalAttrs, TrackAttrs):
         """
@@ -26336,6 +26722,9 @@ class u(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u  
     """  # fmt: skip
 
+    tag = "u"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "u" attrs  
@@ -26565,6 +26954,9 @@ class ul(BaseElement):
     Interface: HTMLUListElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul  
     """  # fmt: skip
+
+    tag = "ul"
+    categories = ["flow", "palpable*"]
 
     class hint(GlobalAttrs):
         """
@@ -26796,6 +27188,9 @@ class var(BaseElement):
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var  
     """  # fmt: skip
 
+    tag = "var"
+    categories = ["flow", "phrasing", "palpable"]
+
     class hint(GlobalAttrs):
         """
         Type hints for "var" attrs  
@@ -27025,6 +27420,9 @@ class video(BaseElement):
     Interface: HTMLVideoElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video  
     """  # fmt: skip
+
+    tag = "video"
+    categories = ["flow", "phrasing", "embedded", "interactive", "palpable"]
 
     class hint(GlobalAttrs, VideoAttrs):
         """
@@ -27318,6 +27716,9 @@ class wbr(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr  
     """  # fmt: skip
+
+    tag = "wbr"
+    categories = ["flow", "phrasing"]
 
     class hint(GlobalAttrs):
         """

--- a/src/html_compose/live/live_server.py
+++ b/src/html_compose/live/live_server.py
@@ -130,7 +130,8 @@ def live_server(
                     print(
                         f"Reloading daemon after {daemon_task.delay} seconds..."
                     )
-                    tr.add_task(daemon_task)
+                    if any([c.server_reload for c in conds_hit]):
+                        tr.add_task(daemon_task)
                     tr.add_task(browser_update_task)
             sleep(loop_delay)
     except KeyboardInterrupt:

--- a/src/html_compose/live/watcher.py
+++ b/src/html_compose/live/watcher.py
@@ -392,9 +392,9 @@ class Watcher:
                 )
                 continue
 
-            assert isinstance(
-                result, set
-            ), f"Unexpected result type: {type(result)}"
+            assert isinstance(result, set), (
+                f"Unexpected result type: {type(result)}"
+            )
 
             result_tuples: set[tuple[int, str]] = result
             for watch_id, path in result_tuples:

--- a/src/html_compose/live/watcher.py
+++ b/src/html_compose/live/watcher.py
@@ -145,6 +145,7 @@ class WatchCond:
         action: Optional[Union[ShellCommand, Callable]],
         ignore_glob: Optional[Union[str, list[str]]] = None,
         delay: float = 0,
+        server_reload: bool = True,
         no_reload: bool = False,
     ):
         """
@@ -170,6 +171,7 @@ class WatchCond:
             self.ignore_glob = [ignore_glob]
         else:
             self.ignore_glob = ignore_glob
+        self.server_reload = server_reload
         self.no_reload = no_reload
         if action is None:
             self.task = Task(None, delay)

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -202,3 +202,11 @@ def test_rel_array():
     # correctly
     el = a(rel=["noopener", "noreferrer"])
     assert el.render() == '<a rel="noopener noreferrer"></a>'
+
+
+def test_custom_element():
+    from html_compose import CustomElement
+
+    custom = CustomElement.create("custom")
+    el = custom["Hello world"]
+    assert el.render() == "<custom>Hello world</custom>"

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -7,7 +7,7 @@ def test_translate():
     """
     Basic text of html -> html_compose translation
     """
-    ht = """
+    html = """
         <section id="preview">
         <h2>Preview</h2>
         <pre>  preformatted  </pre>
@@ -105,9 +105,17 @@ def test_translate():
             ],
         ],
     ]
-    lines = [line for line in t.translate(ht).strip().splitlines() if line]
-    lines[1] = lines[1] + ".render()"
-    output = eval("\n".join(lines[1:]))
-    soup1 = BeautifulSoup(output, "html.parser")
-    soup2 = BeautifulSoup(expected.render(), "html.parser")
-    assert str(soup1) == str(soup2)
+
+    tresult = t.translate(html)
+
+    def _test_translation(r: t.TranslateResult):
+        lines = "\n\n".join(tresult.elements) + ".render()"
+        exec(tresult.import_statement)
+        print(lines)
+        output = eval(lines)
+        soup1 = BeautifulSoup(output, "html.parser")
+        soup2 = BeautifulSoup(expected.render(), "html.parser")
+        assert str(soup1) == str(soup2)
+
+    _test_translation(t.translate(html))
+    _test_translation(t.translate(html, "ht"))

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -8,43 +8,42 @@ def test_translate():
     Basic text of html -> html_compose translation
     """
     html = """
-        <section id="preview">
-        <h2>Preview</h2>
-        <pre>  preformatted  </pre>
-        <pre>
-          text
+<section id="preview">
+<h2>Preview</h2>
+<pre>  preformatted  </pre>
+<pre>
+    text
 
-        </pre>
-        <p>
-          Sed ultricies dolor non ante vulputate hendrerit. Vivamus sit amet suscipit sapien. Nulla
-          iaculis eros a elit pharetra egestas.
-        </p>
-        <form>
-          <input
-            type="text"
-            name="firstname"
-            placeholder="First name"
-            aria-label="First name"
-            required
-          />
-          <input
-            type="email"
-            name="email"
-            placeholder="Email address"
-            aria-label="Email address"
-            autocomplete="email"
-            required
-          />
-          <button type="submit">Subscribe</button>
-          <fieldset>
-            <label for="terms">
-              <input type="checkbox" role="switch" id="terms" name="terms" />
-              I agree to the
-              <a href="#" onclick="event.preventDefault()">Privacy Policy</a>
-            </label>
-          </fieldset>
-        </form>
-      </section>
+</pre>
+<p>
+    Sed ultricies dolor non ante vulputate hendrerit. Vivamus sit amet suscipit sapien. Nulla
+    iaculis eros a elit pharetra egestas.
+</p>
+<form>
+    <input
+    type="text"
+    name="firstname"
+    placeholder="First name"
+    aria-label="First name"
+    required
+    />
+    <input
+    type="email"
+    name="email"
+    placeholder="Email address"
+    aria-label="Email address"
+    autocomplete="email"
+    required
+    />
+    <button type="submit">Subscribe</button>
+    <fieldset>
+    <label for="terms">
+        <input type="checkbox" role="switch" id="terms" name="terms" />I agree to the
+        <a href="#" onclick="event.preventDefault()">Privacy Policy</a>
+    </label>
+    </fieldset>
+</form>
+</section>
       """
     from html_compose import (
         a,
@@ -59,46 +58,42 @@ def test_translate():
         section,
     )
 
-    expected = section({"id": "preview"})[
+    expected = section(id="preview")[
         h2()["Preview"],
         pre()["  preformatted  "],
-        pre()["          text\n\n        "],
+        pre()["    text\n\n"],
         p()[
-            "Sed ultricies dolor non ante vulputate hendrerit. Vivamus sit amet suscipit sapien. Nulla iaculis eros a elit pharetra egestas. "
+            "Sed ultricies dolor non ante vulputate hendrerit. Vivamus sit amet suscipit sapien. Nulla iaculis eros a elit pharetra egestas."
         ],
         form()[
             input(
-                {
-                    "type": "text",
-                    "name": "firstname",
-                    "placeholder": "First name",
-                    "aria-label": "First name",
-                    "required": "",
-                }
+                {"aria-label": "First name"},
+                type="text",
+                name="firstname",
+                placeholder="First name",
+                required="",
             ),
+            " ",
             input(
-                {
-                    "type": "email",
-                    "name": "email",
-                    "placeholder": "Email address",
-                    "aria-label": "Email address",
-                    "autocomplete": "email",
-                    "required": "",
-                }
+                {"aria-label": "Email address"},
+                type="email",
+                name="email",
+                placeholder="Email address",
+                autocomplete="email",
+                required="",
             ),
-            button({"type": "submit"})["Subscribe"],
+            " ",
+            button(type="submit")["Subscribe"],
             fieldset()[
-                label({"for": "terms"})[
+                label(for_="terms")[
                     input(
-                        {
-                            "type": "checkbox",
-                            "role": "switch",
-                            "id": "terms",
-                            "name": "terms",
-                        }
+                        {"role": "switch"},
+                        type="checkbox",
+                        id="terms",
+                        name="terms",
                     ),
                     "I agree to the ",
-                    a({"href": "#", "onclick": "event.preventDefault()"})[
+                    a({"onclick": "event.preventDefault()"}, href="#")[
                         "Privacy Policy"
                     ],
                 ]
@@ -111,11 +106,36 @@ def test_translate():
     def _test_translation(r: t.TranslateResult):
         lines = "\n\n".join(tresult.elements) + ".render()"
         exec(tresult.import_statement)
-        print(lines)
         output = eval(lines)
         soup1 = BeautifulSoup(output, "html.parser")
         soup2 = BeautifulSoup(expected.render(), "html.parser")
-        assert str(soup1) == str(soup2)
+        lines = str(soup1).splitlines()
+        lines2 = str(soup2).splitlines()
+        assert len(lines) == len(lines2)
+        for i, line in enumerate(lines):
+            assert line.strip() == lines2[i].strip(), (
+                f"Line {i + 1} mismatch: {line.strip()} != {lines2[i].strip()}"
+            )
 
     _test_translation(t.translate(html))
     _test_translation(t.translate(html, "ht"))
+
+
+def test_round_trip():
+    html = (
+        "<p>Another way to understand that text is to look at the word-for-word "
+        "translation: <strong> in the home</strong> in the mind</p>"
+    )
+
+    stripped = (
+        "<p>Another way to understand that text is to look at the word-for-word "
+        "translation: <strong>in the home</strong> in the mind</p>"
+    )
+    tresult = t.translate(html)
+    print(tresult.import_statement)
+    exec(tresult.import_statement)
+    if tresult.custom_elements:
+        exec("\n".join(tresult.custom_elements))
+    lines = "\n\n".join(tresult.elements) + ".render()"
+    output = eval(lines)
+    assert output == stripped

--- a/tests/test_util_funcs.py
+++ b/tests/test_util_funcs.py
@@ -116,6 +116,6 @@ def test_glob_func():
         ),
     ]
     for pattern, target, expected in test_cases:
-        assert (
-            glob_matcher(pattern, target) == expected
-        ), f"Test failed for pattern {pattern} and target {target}"
+        assert glob_matcher(pattern, target) == expected, (
+            f"Test failed for pattern {pattern} and target {target}"
+        )

--- a/tools/generate_elements.py
+++ b/tools/generate_elements.py
@@ -183,6 +183,7 @@ def gen_elements():
             if real_element in ("link", "input", "style"):
                 # Duplicate "title" definition
                 comment = " # type: ignore[misc]"
+            categories_list = categories.split()
             template = [
                 "",
                 f"class {fixed_name}(BaseElement):{comment}",
@@ -195,6 +196,8 @@ def gen_elements():
                 f"    Interface: {interface}  ",
                 f"    Documentation: {docs}  ",
                 '    """ # fmt: skip',
+                f"    tag = {repr(real_element)}",
+                f"    categories = {repr(categories_list)}",
                 f"    class hint(GlobalAttrs{attr_string}):",
                 '        """',
                 f'        Type hints for "{real_element}" attrs  ',

--- a/tools/generated/elements.py
+++ b/tools/generated/elements.py
@@ -16,6 +16,8 @@ class a(BaseElement):
     Interface: HTMLAnchorElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a  
     """ # fmt: skip
+    tag = 'a'
+    categories = ['flow', 'phrasing*', 'interactive', 'palpable']
     class hint(GlobalAttrs, AnchorAttrs):
         """
         Type hints for "a" attrs  
@@ -259,6 +261,8 @@ class abbr(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr  
     """ # fmt: skip
+    tag = 'abbr'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "abbr" attrs  
@@ -452,6 +456,8 @@ class address(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address  
     """ # fmt: skip
+    tag = 'address'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "address" attrs  
@@ -645,6 +651,8 @@ class area(BaseElement):
     Interface: HTMLAreaElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area  
     """ # fmt: skip
+    tag = 'area'
+    categories = ['flow', 'phrasing']
     class hint(GlobalAttrs, AreaAttrs):
         """
         Type hints for "area" attrs  
@@ -891,6 +899,8 @@ class article(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article  
     """ # fmt: skip
+    tag = 'article'
+    categories = ['flow', 'sectioning', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "article" attrs  
@@ -1084,6 +1094,8 @@ class aside(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside  
     """ # fmt: skip
+    tag = 'aside'
+    categories = ['flow', 'sectioning', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "aside" attrs  
@@ -1277,6 +1289,8 @@ class audio(BaseElement):
     Interface: HTMLAudioElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio  
     """ # fmt: skip
+    tag = 'audio'
+    categories = ['flow', 'phrasing', 'embedded', 'interactive', 'palpable*']
     class hint(GlobalAttrs, AudioAttrs):
         """
         Type hints for "audio" attrs  
@@ -1507,6 +1521,8 @@ class b(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b  
     """ # fmt: skip
+    tag = 'b'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "b" attrs  
@@ -1700,6 +1716,8 @@ class base(BaseElement):
     Interface: HTMLBaseElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base  
     """ # fmt: skip
+    tag = 'base'
+    categories = ['metadata']
     class hint(GlobalAttrs, BaseAttrs):
         """
         Type hints for "base" attrs  
@@ -1907,6 +1925,8 @@ class bdi(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi  
     """ # fmt: skip
+    tag = 'bdi'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "bdi" attrs  
@@ -2100,6 +2120,8 @@ class bdo(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo  
     """ # fmt: skip
+    tag = 'bdo'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "bdo" attrs  
@@ -2293,6 +2315,8 @@ class blockquote(BaseElement):
     Interface: HTMLQuoteElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote  
     """ # fmt: skip
+    tag = 'blockquote'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs, BlockquoteAttrs):
         """
         Type hints for "blockquote" attrs  
@@ -2493,6 +2517,8 @@ class body(BaseElement):
     Interface: HTMLBodyElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body  
     """ # fmt: skip
+    tag = 'body'
+    categories = ['none']
     class hint(GlobalAttrs, BodyAttrs):
         """
         Type hints for "body" attrs  
@@ -2686,6 +2712,8 @@ class br(BaseElement):
     Interface: HTMLBRElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br  
     """ # fmt: skip
+    tag = 'br'
+    categories = ['flow', 'phrasing']
     class hint(GlobalAttrs):
         """
         Type hints for "br" attrs  
@@ -2879,6 +2907,8 @@ class button(BaseElement):
     Interface: HTMLButtonElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button  
     """ # fmt: skip
+    tag = 'button'
+    categories = ['flow', 'phrasing', 'interactive', 'listed', 'labelable', 'submittable', 'form-associated', 'palpable']
     class hint(GlobalAttrs, ButtonAttrs):
         """
         Type hints for "button" attrs  
@@ -3140,6 +3170,8 @@ class canvas(BaseElement):
     Interface: HTMLCanvasElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas  
     """ # fmt: skip
+    tag = 'canvas'
+    categories = ['flow', 'phrasing', 'embedded', 'palpable']
     class hint(GlobalAttrs, CanvasAttrs):
         """
         Type hints for "canvas" attrs  
@@ -3343,6 +3375,8 @@ class caption(BaseElement):
     Interface: HTMLTableCaptionElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption  
     """ # fmt: skip
+    tag = 'caption'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "caption" attrs  
@@ -3536,6 +3570,8 @@ class cite(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite  
     """ # fmt: skip
+    tag = 'cite'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "cite" attrs  
@@ -3729,6 +3765,8 @@ class code(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code  
     """ # fmt: skip
+    tag = 'code'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "code" attrs  
@@ -3922,6 +3960,8 @@ class col(BaseElement):
     Interface: HTMLTableColElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col  
     """ # fmt: skip
+    tag = 'col'
+    categories = ['none']
     class hint(GlobalAttrs, ColAttrs):
         """
         Type hints for "col" attrs  
@@ -4122,6 +4162,8 @@ class colgroup(BaseElement):
     Interface: HTMLTableColElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup  
     """ # fmt: skip
+    tag = 'colgroup'
+    categories = ['none']
     class hint(GlobalAttrs, ColgroupAttrs):
         """
         Type hints for "colgroup" attrs  
@@ -4322,6 +4364,8 @@ class data(BaseElement):
     Interface: HTMLDataElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data  
     """ # fmt: skip
+    tag = 'data'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs, DataAttrs):
         """
         Type hints for "data" attrs  
@@ -4520,6 +4564,8 @@ class datalist(BaseElement):
     Interface: HTMLDataListElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist  
     """ # fmt: skip
+    tag = 'datalist'
+    categories = ['flow', 'phrasing']
     class hint(GlobalAttrs):
         """
         Type hints for "datalist" attrs  
@@ -4713,6 +4759,8 @@ class dd(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd  
     """ # fmt: skip
+    tag = 'dd'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "dd" attrs  
@@ -4906,6 +4954,8 @@ class del_(BaseElement):
     Interface: HTMLModElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del  
     """ # fmt: skip
+    tag = 'del'
+    categories = ['flow', 'phrasing*', 'palpable']
     class hint(GlobalAttrs, DelAttrs):
         """
         Type hints for "del" attrs  
@@ -5113,6 +5163,8 @@ class details(BaseElement):
     Interface: HTMLDetailsElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details  
     """ # fmt: skip
+    tag = 'details'
+    categories = ['flow', 'interactive', 'palpable']
     class hint(GlobalAttrs, DetailsAttrs):
         """
         Type hints for "details" attrs  
@@ -5316,6 +5368,8 @@ class dfn(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn  
     """ # fmt: skip
+    tag = 'dfn'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "dfn" attrs  
@@ -5509,6 +5563,8 @@ class dialog(BaseElement):
     Interface: HTMLDialogElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog  
     """ # fmt: skip
+    tag = 'dialog'
+    categories = ['flow']
     class hint(GlobalAttrs, DialogAttrs):
         """
         Type hints for "dialog" attrs  
@@ -5707,6 +5763,8 @@ class div(BaseElement):
     Interface: HTMLDivElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div  
     """ # fmt: skip
+    tag = 'div'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "div" attrs  
@@ -5900,6 +5958,8 @@ class dl(BaseElement):
     Interface: HTMLDListElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl  
     """ # fmt: skip
+    tag = 'dl'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "dl" attrs  
@@ -6093,6 +6153,8 @@ class dt(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt  
     """ # fmt: skip
+    tag = 'dt'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "dt" attrs  
@@ -6286,6 +6348,8 @@ class em(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em  
     """ # fmt: skip
+    tag = 'em'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "em" attrs  
@@ -6479,6 +6543,8 @@ class embed(BaseElement):
     Interface: HTMLEmbedElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed  
     """ # fmt: skip
+    tag = 'embed'
+    categories = ['flow', 'phrasing', 'embedded', 'interactive', 'palpable']
     class hint(GlobalAttrs, EmbedAttrs):
         """
         Type hints for "embed" attrs  
@@ -6696,6 +6762,8 @@ class fieldset(BaseElement):
     Interface: HTMLFieldSetElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset  
     """ # fmt: skip
+    tag = 'fieldset'
+    categories = ['flow', 'listed', 'form-associated', 'palpable']
     class hint(GlobalAttrs, FieldsetAttrs):
         """
         Type hints for "fieldset" attrs  
@@ -6906,6 +6974,8 @@ class figcaption(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption  
     """ # fmt: skip
+    tag = 'figcaption'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "figcaption" attrs  
@@ -7099,6 +7169,8 @@ class figure(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure  
     """ # fmt: skip
+    tag = 'figure'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "figure" attrs  
@@ -7292,6 +7364,8 @@ class footer(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer  
     """ # fmt: skip
+    tag = 'footer'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "footer" attrs  
@@ -7485,6 +7559,8 @@ class form(BaseElement):
     Interface: HTMLFormElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form  
     """ # fmt: skip
+    tag = 'form'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs, FormAttrs):
         """
         Type hints for "form" attrs  
@@ -7724,6 +7800,8 @@ class h1(BaseElement):
     Interface: HTMLHeadingElement  
     Documentation: None  
     """ # fmt: skip
+    tag = 'h1'
+    categories = ['flow', 'heading', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "h1" attrs  
@@ -7917,6 +7995,8 @@ class h2(BaseElement):
     Interface: HTMLHeadingElement  
     Documentation: None  
     """ # fmt: skip
+    tag = 'h2'
+    categories = ['flow', 'heading', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "h2" attrs  
@@ -8110,6 +8190,8 @@ class h3(BaseElement):
     Interface: HTMLHeadingElement  
     Documentation: None  
     """ # fmt: skip
+    tag = 'h3'
+    categories = ['flow', 'heading', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "h3" attrs  
@@ -8303,6 +8385,8 @@ class h4(BaseElement):
     Interface: HTMLHeadingElement  
     Documentation: None  
     """ # fmt: skip
+    tag = 'h4'
+    categories = ['flow', 'heading', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "h4" attrs  
@@ -8496,6 +8580,8 @@ class h5(BaseElement):
     Interface: HTMLHeadingElement  
     Documentation: None  
     """ # fmt: skip
+    tag = 'h5'
+    categories = ['flow', 'heading', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "h5" attrs  
@@ -8689,6 +8775,8 @@ class h6(BaseElement):
     Interface: HTMLHeadingElement  
     Documentation: None  
     """ # fmt: skip
+    tag = 'h6'
+    categories = ['flow', 'heading', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "h6" attrs  
@@ -8882,6 +8970,8 @@ class head(BaseElement):
     Interface: HTMLHeadElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head  
     """ # fmt: skip
+    tag = 'head'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "head" attrs  
@@ -9075,6 +9165,8 @@ class header(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header  
     """ # fmt: skip
+    tag = 'header'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "header" attrs  
@@ -9268,6 +9360,8 @@ class hgroup(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup  
     """ # fmt: skip
+    tag = 'hgroup'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "hgroup" attrs  
@@ -9461,6 +9555,8 @@ class hr(BaseElement):
     Interface: HTMLHRElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr  
     """ # fmt: skip
+    tag = 'hr'
+    categories = ['flow']
     class hint(GlobalAttrs):
         """
         Type hints for "hr" attrs  
@@ -9654,6 +9750,8 @@ class html(BaseElement):
     Interface: HTMLHtmlElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html  
     """ # fmt: skip
+    tag = 'html'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "html" attrs  
@@ -9847,6 +9945,8 @@ class i(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i  
     """ # fmt: skip
+    tag = 'i'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "i" attrs  
@@ -10040,6 +10140,8 @@ class iframe(BaseElement):
     Interface: HTMLIFrameElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe  
     """ # fmt: skip
+    tag = 'iframe'
+    categories = ['flow', 'phrasing', 'embedded', 'interactive', 'palpable']
     class hint(GlobalAttrs, IframeAttrs):
         """
         Type hints for "iframe" attrs  
@@ -10293,6 +10395,8 @@ class img(BaseElement):
     Interface: HTMLImageElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img  
     """ # fmt: skip
+    tag = 'img'
+    categories = ['flow', 'phrasing', 'embedded', 'interactive*', 'form-associated', 'palpable']
     class hint(GlobalAttrs, ImgAttrs):
         """
         Type hints for "img" attrs  
@@ -10561,6 +10665,8 @@ class input(BaseElement): # type: ignore[misc]
     Interface: HTMLInputElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input  
     """ # fmt: skip
+    tag = 'input'
+    categories = ['flow', 'phrasing', 'interactive*', 'listed', 'labelable', 'submittable', 'resettable', 'form-associated', 'palpable*']
     class hint(GlobalAttrs, InputAttrs):
         """
         Type hints for "input" attrs  
@@ -10952,6 +11058,8 @@ class ins(BaseElement):
     Interface: HTMLModElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins  
     """ # fmt: skip
+    tag = 'ins'
+    categories = ['flow', 'phrasing*', 'palpable']
     class hint(GlobalAttrs, InsAttrs):
         """
         Type hints for "ins" attrs  
@@ -11159,6 +11267,8 @@ class kbd(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd  
     """ # fmt: skip
+    tag = 'kbd'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "kbd" attrs  
@@ -11352,6 +11462,8 @@ class label(BaseElement):
     Interface: HTMLLabelElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label  
     """ # fmt: skip
+    tag = 'label'
+    categories = ['flow', 'phrasing', 'interactive', 'palpable']
     class hint(GlobalAttrs, LabelAttrs):
         """
         Type hints for "label" attrs  
@@ -11552,6 +11664,8 @@ class legend(BaseElement):
     Interface: HTMLLegendElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend  
     """ # fmt: skip
+    tag = 'legend'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "legend" attrs  
@@ -11745,6 +11859,8 @@ class li(BaseElement):
     Interface: HTMLLIElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li  
     """ # fmt: skip
+    tag = 'li'
+    categories = ['none']
     class hint(GlobalAttrs, LiAttrs):
         """
         Type hints for "li" attrs  
@@ -11943,6 +12059,8 @@ class link(BaseElement): # type: ignore[misc]
     Interface: HTMLLinkElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link  
     """ # fmt: skip
+    tag = 'link'
+    categories = ['metadata', 'flow*', 'phrasing*']
     class hint(GlobalAttrs, LinkAttrs):
         """
         Type hints for "link" attrs  
@@ -12236,6 +12354,8 @@ class main(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main  
     """ # fmt: skip
+    tag = 'main'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "main" attrs  
@@ -12429,6 +12549,8 @@ class map(BaseElement):
     Interface: HTMLMapElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map  
     """ # fmt: skip
+    tag = 'map'
+    categories = ['flow', 'phrasing*', 'palpable']
     class hint(GlobalAttrs, MapAttrs):
         """
         Type hints for "map" attrs  
@@ -12627,6 +12749,8 @@ class mark(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark  
     """ # fmt: skip
+    tag = 'mark'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "mark" attrs  
@@ -12820,6 +12944,8 @@ class menu(BaseElement):
     Interface: HTMLMenuElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu  
     """ # fmt: skip
+    tag = 'menu'
+    categories = ['flow', 'palpable*']
     class hint(GlobalAttrs):
         """
         Type hints for "menu" attrs  
@@ -13013,6 +13139,8 @@ class meta(BaseElement):
     Interface: HTMLMetaElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta  
     """ # fmt: skip
+    tag = 'meta'
+    categories = ['metadata', 'flow*', 'phrasing*']
     class hint(GlobalAttrs, MetaAttrs):
         """
         Type hints for "meta" attrs  
@@ -13233,6 +13361,8 @@ class meter(BaseElement):
     Interface: HTMLMeterElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter  
     """ # fmt: skip
+    tag = 'meter'
+    categories = ['flow', 'phrasing', 'labelable', 'palpable']
     class hint(GlobalAttrs, MeterAttrs):
         """
         Type hints for "meter" attrs  
@@ -13456,6 +13586,8 @@ class nav(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav  
     """ # fmt: skip
+    tag = 'nav'
+    categories = ['flow', 'sectioning', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "nav" attrs  
@@ -13649,6 +13781,8 @@ class noscript(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript  
     """ # fmt: skip
+    tag = 'noscript'
+    categories = ['metadata', 'flow', 'phrasing']
     class hint(GlobalAttrs):
         """
         Type hints for "noscript" attrs  
@@ -13842,6 +13976,8 @@ class object(BaseElement):
     Interface: HTMLObjectElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object  
     """ # fmt: skip
+    tag = 'object'
+    categories = ['flow', 'phrasing', 'embedded', 'interactive*', 'listed', 'form-associated', 'palpable']
     class hint(GlobalAttrs, ObjectAttrs):
         """
         Type hints for "object" attrs  
@@ -14073,6 +14209,8 @@ class ol(BaseElement):
     Interface: HTMLOListElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol  
     """ # fmt: skip
+    tag = 'ol'
+    categories = ['flow', 'palpable*']
     class hint(GlobalAttrs, OlAttrs):
         """
         Type hints for "ol" attrs  
@@ -14281,6 +14419,8 @@ class optgroup(BaseElement):
     Interface: HTMLOptGroupElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup  
     """ # fmt: skip
+    tag = 'optgroup'
+    categories = ['none']
     class hint(GlobalAttrs, OptgroupAttrs):
         """
         Type hints for "optgroup" attrs  
@@ -14484,6 +14624,8 @@ class option(BaseElement):
     Interface: HTMLOptionElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option  
     """ # fmt: skip
+    tag = 'option'
+    categories = ['none']
     class hint(GlobalAttrs, OptionAttrs):
         """
         Type hints for "option" attrs  
@@ -14697,6 +14839,8 @@ class output(BaseElement):
     Interface: HTMLOutputElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output  
     """ # fmt: skip
+    tag = 'output'
+    categories = ['flow', 'phrasing', 'listed', 'labelable', 'resettable', 'form-associated', 'palpable']
     class hint(GlobalAttrs, OutputAttrs):
         """
         Type hints for "output" attrs  
@@ -14907,6 +15051,8 @@ class p(BaseElement):
     Interface: HTMLParagraphElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p  
     """ # fmt: skip
+    tag = 'p'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "p" attrs  
@@ -15100,6 +15246,8 @@ class picture(BaseElement):
     Interface: HTMLPictureElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture  
     """ # fmt: skip
+    tag = 'picture'
+    categories = ['flow', 'phrasing', 'embedded', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "picture" attrs  
@@ -15293,6 +15441,8 @@ class pre(BaseElement):
     Interface: HTMLPreElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre  
     """ # fmt: skip
+    tag = 'pre'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "pre" attrs  
@@ -15486,6 +15636,8 @@ class progress(BaseElement):
     Interface: HTMLProgressElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress  
     """ # fmt: skip
+    tag = 'progress'
+    categories = ['flow', 'phrasing', 'labelable', 'palpable']
     class hint(GlobalAttrs, ProgressAttrs):
         """
         Type hints for "progress" attrs  
@@ -15689,6 +15841,8 @@ class q(BaseElement):
     Interface: HTMLQuoteElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q  
     """ # fmt: skip
+    tag = 'q'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs, QAttrs):
         """
         Type hints for "q" attrs  
@@ -15889,6 +16043,8 @@ class rp(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp  
     """ # fmt: skip
+    tag = 'rp'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "rp" attrs  
@@ -16082,6 +16238,8 @@ class rt(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt  
     """ # fmt: skip
+    tag = 'rt'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "rt" attrs  
@@ -16275,6 +16433,8 @@ class ruby(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby  
     """ # fmt: skip
+    tag = 'ruby'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "ruby" attrs  
@@ -16468,6 +16628,8 @@ class s(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s  
     """ # fmt: skip
+    tag = 's'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "s" attrs  
@@ -16661,6 +16823,8 @@ class samp(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp  
     """ # fmt: skip
+    tag = 'samp'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "samp" attrs  
@@ -16854,6 +17018,8 @@ class script(BaseElement):
     Interface: HTMLScriptElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script  
     """ # fmt: skip
+    tag = 'script'
+    categories = ['metadata', 'flow', 'phrasing', 'script-supporting']
     class hint(GlobalAttrs, ScriptAttrs):
         """
         Type hints for "script" attrs  
@@ -17103,6 +17269,8 @@ class search(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search  
     """ # fmt: skip
+    tag = 'search'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "search" attrs  
@@ -17296,6 +17464,8 @@ class section(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section  
     """ # fmt: skip
+    tag = 'section'
+    categories = ['flow', 'sectioning', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "section" attrs  
@@ -17489,6 +17659,8 @@ class select(BaseElement):
     Interface: HTMLSelectElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select  
     """ # fmt: skip
+    tag = 'select'
+    categories = ['flow', 'phrasing', 'interactive', 'listed', 'labelable', 'submittable', 'resettable', 'form-associated', 'palpable']
     class hint(GlobalAttrs, SelectAttrs):
         """
         Type hints for "select" attrs  
@@ -17723,6 +17895,8 @@ class slot(BaseElement):
     Interface: HTMLSlotElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot  
     """ # fmt: skip
+    tag = 'slot'
+    categories = ['flow', 'phrasing']
     class hint(GlobalAttrs, SlotAttrs):
         """
         Type hints for "slot" attrs  
@@ -17921,6 +18095,8 @@ class small(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small  
     """ # fmt: skip
+    tag = 'small'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "small" attrs  
@@ -18114,6 +18290,8 @@ class source(BaseElement):
     Interface: HTMLSourceElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source  
     """ # fmt: skip
+    tag = 'source'
+    categories = ['none']
     class hint(GlobalAttrs, SourceAttrs):
         """
         Type hints for "source" attrs  
@@ -18352,6 +18530,8 @@ class span(BaseElement):
     Interface: HTMLSpanElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span  
     """ # fmt: skip
+    tag = 'span'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "span" attrs  
@@ -18545,6 +18725,8 @@ class strong(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong  
     """ # fmt: skip
+    tag = 'strong'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "strong" attrs  
@@ -18738,6 +18920,8 @@ class style(BaseElement): # type: ignore[misc]
     Interface: HTMLStyleElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style  
     """ # fmt: skip
+    tag = 'style'
+    categories = ['metadata']
     class hint(GlobalAttrs, StyleAttrs):
         """
         Type hints for "style" attrs  
@@ -18943,6 +19127,8 @@ class sub(BaseElement):
     Interface: HTMLElement  
     Documentation: None  
     """ # fmt: skip
+    tag = 'sub'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "sub" attrs  
@@ -19136,6 +19322,8 @@ class summary(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary  
     """ # fmt: skip
+    tag = 'summary'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "summary" attrs  
@@ -19329,6 +19517,8 @@ class sup(BaseElement):
     Interface: HTMLElement  
     Documentation: None  
     """ # fmt: skip
+    tag = 'sup'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "sup" attrs  
@@ -19522,6 +19712,8 @@ class svg(BaseElement):
     Interface: SVGSVGElement  
     Documentation: None  
     """ # fmt: skip
+    tag = 'svg'
+    categories = ['flow', 'phrasing', 'embedded', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "svg" attrs  
@@ -19715,6 +19907,8 @@ class table(BaseElement):
     Interface: HTMLTableElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table  
     """ # fmt: skip
+    tag = 'table'
+    categories = ['flow', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "table" attrs  
@@ -19908,6 +20102,8 @@ class tbody(BaseElement):
     Interface: HTMLTableSectionElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody  
     """ # fmt: skip
+    tag = 'tbody'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "tbody" attrs  
@@ -20101,6 +20297,8 @@ class td(BaseElement):
     Interface: HTMLTableCellElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td  
     """ # fmt: skip
+    tag = 'td'
+    categories = ['none']
     class hint(GlobalAttrs, TdAttrs):
         """
         Type hints for "td" attrs  
@@ -20311,6 +20509,8 @@ class template(BaseElement):
     Interface: HTMLTemplateElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template  
     """ # fmt: skip
+    tag = 'template'
+    categories = ['metadata', 'flow', 'phrasing', 'script-supporting']
     class hint(GlobalAttrs, TemplateAttrs):
         """
         Type hints for "template" attrs  
@@ -20524,6 +20724,8 @@ class textarea(BaseElement):
     Interface: HTMLTextAreaElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea  
     """ # fmt: skip
+    tag = 'textarea'
+    categories = ['flow', 'phrasing', 'interactive', 'listed', 'labelable', 'submittable', 'resettable', 'form-associated', 'palpable']
     class hint(GlobalAttrs, TextareaAttrs):
         """
         Type hints for "textarea" attrs  
@@ -20790,6 +20992,8 @@ class tfoot(BaseElement):
     Interface: HTMLTableSectionElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot  
     """ # fmt: skip
+    tag = 'tfoot'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "tfoot" attrs  
@@ -20983,6 +21187,8 @@ class th(BaseElement):
     Interface: HTMLTableCellElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th  
     """ # fmt: skip
+    tag = 'th'
+    categories = ['interactive*']
     class hint(GlobalAttrs, ThAttrs):
         """
         Type hints for "th" attrs  
@@ -21203,6 +21409,8 @@ class thead(BaseElement):
     Interface: HTMLTableSectionElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead  
     """ # fmt: skip
+    tag = 'thead'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "thead" attrs  
@@ -21396,6 +21604,8 @@ class time(BaseElement):
     Interface: HTMLTimeElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time  
     """ # fmt: skip
+    tag = 'time'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs, TimeAttrs):
         """
         Type hints for "time" attrs  
@@ -21596,6 +21806,8 @@ class title(BaseElement):
     Interface: HTMLTitleElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title  
     """ # fmt: skip
+    tag = 'title'
+    categories = ['metadata']
     class hint(GlobalAttrs):
         """
         Type hints for "title" attrs  
@@ -21789,6 +22001,8 @@ class tr(BaseElement):
     Interface: HTMLTableRowElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr  
     """ # fmt: skip
+    tag = 'tr'
+    categories = ['none']
     class hint(GlobalAttrs):
         """
         Type hints for "tr" attrs  
@@ -21982,6 +22196,8 @@ class track(BaseElement):
     Interface: HTMLTrackElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track  
     """ # fmt: skip
+    tag = 'track'
+    categories = ['none']
     class hint(GlobalAttrs, TrackAttrs):
         """
         Type hints for "track" attrs  
@@ -22204,6 +22420,8 @@ class u(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u  
     """ # fmt: skip
+    tag = 'u'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "u" attrs  
@@ -22397,6 +22615,8 @@ class ul(BaseElement):
     Interface: HTMLUListElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul  
     """ # fmt: skip
+    tag = 'ul'
+    categories = ['flow', 'palpable*']
     class hint(GlobalAttrs):
         """
         Type hints for "ul" attrs  
@@ -22590,6 +22810,8 @@ class var(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var  
     """ # fmt: skip
+    tag = 'var'
+    categories = ['flow', 'phrasing', 'palpable']
     class hint(GlobalAttrs):
         """
         Type hints for "var" attrs  
@@ -22783,6 +23005,8 @@ class video(BaseElement):
     Interface: HTMLVideoElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video  
     """ # fmt: skip
+    tag = 'video'
+    categories = ['flow', 'phrasing', 'embedded', 'interactive', 'palpable']
     class hint(GlobalAttrs, VideoAttrs):
         """
         Type hints for "video" attrs  
@@ -23035,6 +23259,8 @@ class wbr(BaseElement):
     Interface: HTMLElement  
     Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr  
     """ # fmt: skip
+    tag = 'wbr'
+    categories = ['flow', 'phrasing']
     class hint(GlobalAttrs):
         """
         Type hints for "wbr" attrs  

--- a/tools/spec_generator.py
+++ b/tools/spec_generator.py
@@ -184,9 +184,9 @@ class Hextract:
         assert len(event_result) == 1, "Expected 1, check the parser"
         event_result = event_result[0]
 
-        assert (
-            event_result["columns"] == attr_result["columns"]
-        ), "Columns mismatch"
+        assert event_result["columns"] == attr_result["columns"], (
+            "Columns mismatch"
+        )
         elements = []
         for result in [attr_result, event_result]:
             columns = result["columns"]
@@ -330,9 +330,9 @@ class MDNSpec:
                 status["standard_track"],
                 status["deprecated"],
             )
-            assert not (
-                experimental or deprecated or not standard_track
-            ), "Out of support element not typically found here in MDN"
+            assert not (experimental or deprecated or not standard_track), (
+                "Out of support element not typically found here in MDN"
+            )
             elements[element.name] = element
 
         output = {}


### PR DESCRIPTION
# 0.8.0
* Add custom element generator CustomElement.create or create_element
  * BaseElement now takes id/class_ params because this justifies their existence
* html translator will now output an array if an array is given
* Improve import statement output in translator
* Translator will generate custom elements for elements it does not recognize.
  - One reason this was added is that html_compose has no intention of implementing
    deprecated HTML elements, but it previously breaks when trying to reproduce
    them.
* Fix translator inappropriately stripping leading whitespace
* WatchConds can optionally not reload the server via server_reload param

The translator changes... I'm dubious about. https://github.com/kangax/html-minifier/blob/gh-pages/src/htmlminifier.js gave some inspiration but I'm not sure what I built is perfect.