### PR TITLE
0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,12 @@ a([tab]
   ```
 
 * 🎭 Type hints for the editor generated from WhatWG spec
-* ⚡ Live Reload server for rapid development  
+
+## Live Reload server for rapid development  
   Run your Python webserver (i.e. Flask, FastAPI, anything!) with live-reload superpowers powered by [livereload-js](https://www.npmjs.com/package/livereload-js). See browser updates in real-time!
 
-  Note: This feature requires optional dependencies. `pip install html-compose[live-reload]` or `pip install html-compose[full]`. The feature also fetches livereload-js from a CDN.
+  Note: This feature requires optional dependencies. `pip install html-compose[live-reload]` or `pip install html-compose[full]`. 
+  The feature also loads livereload-js from a CDN.
   
   `livereload.py`
   ```python

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,16 @@
   The signature is now different which may require updates.
 * HTML converter improvements: Survive round trip for more text. 
   Output single elements when we identify an attribute could be a list
-
+* Documentation improvements
+  * Migrate element/attr docstrings to Google style.  
+    Pyright on Zed seems to tolerate this better.
+  * Fix a weird pylance bug on WatchCond
+* Live reload now accepts daemon host/port/timeout and can wait to send browser
+  reload until after the server responds
+* py.typed improvements to module exports
+* Child elements passed uninstantiated will be instantiated at render time
+  * This means you can `p['line 1', br, 'line 2']` where previously you had to `br()`
+* notebook.render accepts _HasHtml which includes documents and elements
 
 # 0.10.1
 * Style parameter: when input is a dict[str, str], assume the user wants simple f"{key}: {value}" css statements

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,12 +3,11 @@
   js_import, css_import, and font_import helpers
 * html_compose.document: Add streaming document generators which will produce
   head element before other content.
-* Add html_compose.document document_generator and document_streamer for use
-  with html_compose.resource imports, acting as the most helpful way to generate
-  an HTML document
-* Importer improvements: Survive round trip for more text. Output single elements
-  when we identify an attribtue could be a list
-* Minor documentation improvements
+* Add js/css/font composition along with other changes to html_compose.document
+* Change HTML5Document into a class with a .render and .stream function
+  which wrap other functionality in the module
+* HTML converter improvements: Survive round trip for more text. 
+  Output single elements when we identify an attribute could be a list
 
 
 # 0.10.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,9 @@
 * Add html_compose.document document_generator and document_streamer for use
   with html_compose.resource imports, acting as the most helpful way to generate
   an HTML document
+* Importer improvements: Survive round trip for more text. Output single elements
+  when we identify an attribtue could be a list
+* Minor documentation improvements
 
 
 # 0.10.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,8 +4,9 @@
 * html_compose.document: Add streaming document generators which will produce
   head element before other content.
 * Add js/css/font composition along with other changes to html_compose.document
-* Change HTML5Document into a class with a .render and .stream function
-  which wrap other functionality in the module
+* [breaking] Change HTML5Document into a class with a .render and .stream function
+  which wrap other functionality in the module. 
+  The signature is now different which may require updates.
 * HTML converter improvements: Survive round trip for more text. 
   Output single elements when we identify an attribute could be a list
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,13 @@
+# 0.11.0
+* Add html_compose.resource module which includes 
+  js_import, css_import, and font_import helpers
+* html_compose.document: Add streaming document generators which will produce
+  head element before other content.
+* Add html_compose.document document_generator and document_streamer for use
+  with html_compose.resource imports, acting as the most helpful way to generate
+  an HTML document
+
+
 # 0.10.1
 * Style parameter: when input is a dict[str, str], assume the user wants simple f"{key}: {value}" css statements
 * Type hints: Cleanup type hints to all be 3.10 style

--- a/doc/ideas/03_code_generator.md
+++ b/doc/ideas/03_code_generator.md
@@ -1,18 +1,28 @@
 # Code Generator
+
 Idea: What if your editor had built-in hinting around HTML properties?
 
 ## Implementation
+
 We take information from the HTML spec living document and MDN.
 
 We place generated code in a separated directory, keeping magic out of the code.
 
 the `tools` directory contains:
- * The spec generator `spec_generator.py`
-   * Pull, parse, and dump json we think is interesting
- * The attribute code generator `generate_attributes.py`
-   * Put that interesting information in generated class attributes using our formula defined in previous specs. If an attribute is a keyword or restricted by Python, append `_` to the end of the name so autocomplete works. Dump those in `src/html_compose/attributes`
 
-* `tools/generated/*_attrs.py` is the intermediate directory so runs do not write to source control directory, but you can see when a new change has happened.
+- The spec generator `spec_generator.py`
+  - Pull, parse, and dump json we think is interesting
+- The attribute code generator `generate_attributes.py`
+  - Put that interesting information in generated class attributes using our
+    formula defined in previous specs. If an attribute is a keyword or
+    restricted by Python, append `_` to the end of the name so autocomplete
+    works. Dump those in `src/html_compose/attributes`
+- The element code generator `generate_elements.py`
+
+  - Same deal as for attributes. Dump in src/html_compose/elements.
+
+- `tools/generated/*.py` is the intermediate directory so runs do not write to
+  the source control directory, but you can see when a new change has happened.
 
 <!-- ## Extension of this idea:
 TBD

--- a/doc/ideas/04_attrs.md
+++ b/doc/ideas/04_attrs.md
@@ -105,7 +105,7 @@ div.hint.style({
 The implementation is the simplest `<key>: <value>. 
 User is therefore responsible for quoting.
 
-## `attrs=` parameter syntax
+## attrs= parameter syntax
 
 In the constructor for any element, you can specify the `attrs` parameter.
 
@@ -184,7 +184,7 @@ a(href="https://google.com", tabindex=1)
 Under the hood, it's all translated to the `BaseAttribute` class, and the value is
 escaped before rendering.
 
-# Breakdown
+## Breakdown
 
 There are a number of options for declaring an attribute value, which are shown above. 
 The basic idea is 

--- a/doc/ideas/04_attrs.md
+++ b/doc/ideas/04_attrs.md
@@ -225,7 +225,7 @@ class htmx:
     '''
 
     @staticmethod
-    def hx_get(value: str) -> BaseAttribute:
+    def get(value: str) -> BaseAttribute:
         '''
         htmx attribute: hx-get
             The hx-get attribute will cause an element to issue a
@@ -244,7 +244,7 @@ Where we can write
 
 ```python
 button(
-    [htmx.hx_get("/api/data")], 
+    [htmx.get("/api/data")], 
     class_="btn primary"
 )["Click me!"]
 ```

--- a/doc/ideas/05_livereload.md
+++ b/doc/ideas/05_livereload.md
@@ -127,7 +127,7 @@ If you're using nginx, you would include something like this in your server bloc
     }
 ```
 
-Since you're serving your websocket over SSL, you can now specify when calling `live.server(`:
+Since you're serving your websocket over SSL, you can now specify when calling `live.server`:
 * `proxy_host`: host to reach for the livereload websocket. used in browser instead of `host` parameter.
 
     Example: `my-sweet-website.com`

--- a/doc/ideas/06_resource_imports.md
+++ b/doc/ideas/06_resource_imports.md
@@ -1,0 +1,263 @@
+# Resource imports (js / css / fonts)
+
+There are now many standards in the web platform for correctly importing
+your remote resources.
+
+We no longer need to use nodejs and bundling to use module import semantics.
+
+We can preload js and assign it a module name for importing.
+
+We give helpers for managing css/js imports and the many attributes needed
+to successfully preload and validate resource integrity.
+
+We also give two font helpers, one for fonts resolved in css and one for
+manually setting up .woff/etc font imports.
+
+## Browser tech overview
+
+- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap
+- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
+- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/modulepreload
+- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload
+
+## How our library makes resource setup better
+
+By providing small helpers, we reduce the amount of redundant html to write.
+
+```python
+import html_compose.elements as el
+from html_compose.resource import css_import, js_import, to_elements
+from html_compose.document import document_generator
+
+def get_css():
+    return [
+        css_import("./static/admin.css", cache_bust=False),
+        css_import(
+            "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css",
+            hash=(
+                "sha384-9ndCyUaIbzAi2FUVXJi0CjmCapS"
+                "mO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
+            ),
+            crossorigin="anonymous",
+            preload=True,
+        ),
+    ]
+
+def get_js():
+    return [
+        js_import("./static/admin.js", name="admin", cache_bust=True),
+        js_import(
+            "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm",
+            name="alpinejs",
+            preload=True,
+            hash=(
+                "sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/"
+                "9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p"
+            ),
+            crossorigin="anonymous",
+        ),
+    ]
+
+
+def get_fonts():
+    return [
+        font_import_manual(
+            "./static/fonts/MyFont.woff2",
+            family="MyFont",
+            weight="normal",
+            style="normal",
+            display="swap",
+            cache_bust=False,
+        ),
+        font_import_provider(
+            href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap",
+            preconnect=[
+                "https://fonts.googleapis.com",
+                "https://fonts.gstatic.com",
+            ],
+            preconnect_crossorigin="anonymous",
+        ),
+    ]
+
+
+
+def test_importer():
+    css = get_css()
+    js = get_js()
+    elements = to_elements(js, css)
+    print(el.head()[elements].render())
+
+
+def test_document_generator():
+    css = get_css()
+    js = get_js()
+    print(document_generator(
+        title="demo",
+        lang="en",
+        js=js,
+        css=css,
+        body_content=[el.h1("Hello world")])
+
+```
+
+**test_importer:**
+
+```html
+<head>
+  <link
+    href="https://fonts.googleapis.com"
+    crossorigin="anonymous"
+    rel="preconnect"
+  />
+  <link
+    href="https://fonts.gstatic.com"
+    crossorigin="anonymous"
+    rel="preconnect"
+  />
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+    integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
+    crossorigin="anonymous"
+    as="style"
+    rel="preload"
+  />
+  <link
+    href="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"
+    integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p"
+    crossorigin="anonymous"
+    rel="modulepreload"
+  />
+  <link
+    href="./static/fonts/MyFont.woff2"
+    type="font/woff2"
+    as="font"
+    rel="preload"
+  />
+  <link href="./static/admin.css" rel="stylesheet" />
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+    integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
+    crossorigin="anonymous"
+    rel="stylesheet"
+  />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&amp;display=swap"
+    rel="stylesheet"
+  />
+  <style>
+    @font-face {
+      font-family: "MyFont";
+      src: url("./static/fonts/MyFont.woff2");
+      font-style: normal;
+      font-display: swap;
+      font-weight: normal;
+    }
+  </style>
+  <script type="importmap">
+    {
+      "imports": {
+        "admin": "./static/admin.js?ts=1760157623",
+        "alpinejs": "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"
+      }
+    }
+  </script>
+  <script src="./static/admin.js?ts=1760157623" type="module"></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"
+    type="module"
+    integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p"
+    crossorigin="anonymous"
+  ></script>
+</head>
+```
+
+**test_document**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>demo</title>
+    <link
+      href="https://fonts.googleapis.com"
+      crossorigin="anonymous"
+      rel="preconnect"
+    />
+    <link
+      href="https://fonts.gstatic.com"
+      crossorigin="anonymous"
+      rel="preconnect"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
+      crossorigin="anonymous"
+      as="style"
+      rel="preload"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"
+      integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p"
+      crossorigin="anonymous"
+      rel="modulepreload"
+    />
+    <link
+      href="./static/fonts/MyFont.woff2"
+      type="font/woff2"
+      as="font"
+      rel="preload"
+    />
+    <link href="./static/admin.css" rel="stylesheet" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
+      crossorigin="anonymous"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&amp;display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      @font-face {
+        font-family: "MyFont";
+        src: url("./static/fonts/MyFont.woff2");
+        font-style: normal;
+        font-display: swap;
+        font-weight: normal;
+      }
+    </style>
+    <script type="importmap">
+      {
+        "imports": {
+          "admin": "./static/admin.js?ts=1760157623",
+          "alpinejs": "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"
+        }
+      }
+    </script>
+    <script src="./static/admin.js?ts=1760157623" type="module"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"
+      type="module"
+      integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p"
+      crossorigin="anonymous"
+    ></script>
+  </head>
+
+  <body>
+    <h1>Hello world</h1>
+  </body>
+</html>
+```
+
+## Where to go from here
+
+We've informed the browser how to optimally and in parallel load our resources.
+
+Now we are free to develop without bundling javascript if we so desire.
+
+Heck, you could even map a package.json used in your development environment
+into a `js_import` generator.
+
+The sky is the limit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "html-compose"
-version = "0.10.1"
+version = "0.11.0"
 description = "Composable HTML generation in python"
 authors = [
     { name = "jealouscloud", email = "github@noaha.org" }

--- a/src/html_compose/__init__.py
+++ b/src/html_compose/__init__.py
@@ -1,74 +1,202 @@
 """
+# html-compose
 
-`html-compose` is a library for natural HTML composition directly in Python.
+A library for natural HTML composition directly in Python.
 
-## Quick Start Guide
+Focused on fast, flexible, extensible document generation,
+its goal is to make the web platform fun to work with while using
+modern browser technologies.
 
-For user comfort, the `[]` syntax provides a natural way to define child
-elements which makes the code look more like the HTML structure it represents and
-less like a list of procedures.
+## Quick Start
 
-Behind the scenes, this is just the .base_element.BaseElement.append method.
+All HTML elements from the [living spec](https://html.spec.whatwg.org/multipage/)
+are available to use with full type hinting:
 
-Text is always escaped, so XSS directly in the HTML is not possible.
-Via this mechanism, JavaScript within HTML attributes is always escaped.
+```python
+from html_compose import a
 
+element = a(href="/logout")["Log out"]
+print(element.render())
+# <a href="/logout">Log out</a>
+```
+
+The `[]` syntax provides a natural way to define child elements, making the code
+resemble the HTML structure it represents.
+
+Behind the scenes, this is `.base_element.BaseElement.append`, which accepts text,
+elements, lists, nested lists, and callables. It returns self for chaining.
+
+Think of it as:
+* `()` sets attributes
+* `[]` adds children
+
+Set non-constructor attributes with a dict:
+
+```python
+a({"@click": "alert(1)"}, href="#")["Click me"]
+```
+
+**Security**: The children of HTML elements are always HTML escaped,
+so XSS directly in the HTML is not possible.
+
+JavaScript within HTML attribute values is always escaped.
 Just don't pass user input into JavaScript attributes.
 
-If you want to insert unsafe text, use the `unsafe_text(...)` function.
+Use `.unsafe_text()` when you need unescaped content.
 
-You can import elements directly from this module or .elements i.e.
-* `from html_compose import a, div, span` or
-* `from html_compose.elements import a, div, span` or
-* `import html_compose.elements as e`
+All HTML nodes treat their children as if they contain HTML.
+This means if you have a `<script>` or `<style>` element or something
+else that isn't read as HTML, you may need to handle escaping yourself before
+passing to `.unsafe_text()`.
 
-If you think HTML frame boilerplate is no fun, you can use the `HTML5Document` function
-to generate a complete HTML5 document with a title, language, and body content.
+### Imports
 
-It will return a string you can send directly to the client.
+You can import elements from this module or `html_compose.elements`:
+
+- `from html_compose import a, div, span`
+- `from html_compose.elements import a, div, span`
+- `import html_compose.elements as el`
+
+### Building Documents
+
+Use `document_generator` for complete HTML5 documents with optimized resource management:
+
+```python
+from html_compose import p
+from html_compose.document import document_generator
+from html_compose.resource import js_import, css_import
+
+# Local module with cache-busting
+admin_script = js_import(
+    "./static/admin.js",
+    name="admin",
+    cache_bust=True,
+    preload=True
+)
+
+# Remote library
+alpine = js_import(
+    'https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js',
+    defer=True
+)
+
+# CSS with integrity checking and preload
+bootstrap_css = css_import(
+    "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css",
+    preload=True,
+    hash="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM",
+    crossorigin="anonymous"
+)
+
+doc: str = document_generator(
+    title="My App",
+    css=[bootstrap_css],
+    js=[admin_script, alpine],
+    head_extra=[],  # anything you want to add to head
+    body_content=[
+        p(class_="container")["Hello, world!"]
+    ]
+)
+```
+
+Generates HTML with correct `<link>`, `<script>`, `importmap`, and preload tags
+in the optimal order.
+
+For streaming responses, use `document_streamer` to send the `<head>` early.
+
+### Basic Document API
+
+If you prefer simpler boilerplate generation, `HTML5Document` returns a complete
+document string:
 
 ```python
 from html_compose import HTML5Document, p, script, link
 
-doc = HTML5Document(
+doc: str = HTML5Document(
     "Site Title",
     lang="en",
     head=[
-            script(src="/public/bundle.js"),
-            link(rel="stylesheet", href="/public/style.css"),
+        script(src="/public/bundle.js"),
+        link(rel="stylesheet", href="/public/style.css"),
     ],
     body=[p["Hello, world!"]],
 )
 ```
 
-Custom elements can be created with `CustomElement.create` / `create_element`.
+### Composing Elements
+
+The constructor for an element defines attributes, so if it has none the call
+to the constructor can be skipped like the `p` and `strong` elements below:
+
+```python
+from html_compose import div, strong, a
+
+user = "github wanderer"
+content = div(class_="profile")[
+    p["Welcome, ", strong[user], "!"],
+    a(href="/logout")["Log out"]
+]
+
+print(content.render())
+# <div class="profile"><p>Welcome, <strong>github wanderer</strong>!</p><a href="/logout">Log out</a></div>
+```
+
+## More Features
+
+### Custom Elements
+
+Create custom elements with `CustomElement.create` or `create_element`:
 
 ```python
 from html_compose.custom_element import CustomElement
-foo = CustomElement.create("foo")
-foo["Hello world"].render() # <foo>Hello world</foo>
 
+foo = CustomElement.create("foo")
+foo["Hello world"].render()  # <foo>Hello world</foo>
+
+# Or use the shorthand
 from html_compose import create_element
+
 bar = create_element("bar")
-bar()["Hello world"].render() # <bar>Hello world</bar>
+bar()["Hello world"].render()  # <bar>Hello world</bar>
 ```
 
-## Type hints
-Type hints are given wherever possible, so you can use your IDE to
-complete element names and attributes.
+### Type Hints
 
-Read more about these in the [elements documentation](html_compose/elements).
+All elements and attributes are fully type-hinted for IDE support. Your editor
+can complete element names and attributes.
+
+### Flexible Attributes
+
+Attributes support multiple input formats:
+
+```python
+img([img.hint.src("..."), {"@click": "..."}, onmouseleave="..."])
+```
+
+### Extensions
+
+Custom attributes for frameworks can be packaged as reusable modules:
+
+```python
+from pretend_extensions import htmx
+from html_compose import button, div
+
+button([htmx.get('/url'), htmx.target('#result')])
+# <button hx-get="/url" hx-target="#result"></button>
+```
 
 ## Command-line Interface
-An `html-compose` command-line interface is available which can be used to
-convert native HTML into html-compose syntax.
-This is useful when starting from a tutorial or template.
 
-```
-$ html-compose convert {filename or empty for stdin}
+Convert HTML to html-compose syntax—useful when starting from tutorials or templates:
+
+```sh
+html-compose convert {filename or empty for stdin}
+html-compose convert --noimport el  # produces el.div() style references
 ```
 
-## Core Ideas
+`html-convert` provides access to this tool as shorthand.
+
+# Core Ideas
 We are going to dive into the technicals and core ideas of the library.
 
 .. include:: ../../doc/ideas/01_iterator.md

--- a/src/html_compose/__init__.py
+++ b/src/html_compose/__init__.py
@@ -267,12 +267,9 @@ from .custom_element import CustomElement
 create_element = CustomElement.create
 
 # ruff: noqa: F401, E402
-from .document import (
-    HTML5Document,
-    HTML5Stream,
-    document_generator,
-    document_streamer,
-)
+from .document import HTML5Document as HTML5Document
+from .document import document_generator as document_generator
+from .document import document_streamer as document_streamer
 
 # ruff: noqa: F401, E402
 from .elements import (

--- a/src/html_compose/__init__.py
+++ b/src/html_compose/__init__.py
@@ -260,138 +260,139 @@ def doctype(dtype: str = "html"):
     return unsafe_text(f"<!DOCTYPE {dtype}>")
 
 
-from .base_attribute import BaseAttribute
-from .base_element import BaseElement
-from .custom_element import CustomElement
+# The imports are organized to avoid circular dependencies
+# The import x as x pattern is interpreted by some tools as "public export"
+
+# ruff: noqa: E402
+
+# Library primitives
+from .base_attribute import BaseAttribute as BaseAttribute
+from .base_element import BaseElement as BaseElement
+from .custom_element import CustomElement as CustomElement
 
 create_element = CustomElement.create
-
-# ruff: noqa: F401, E402
+# Document features
 from .document import HTML5Document as HTML5Document
 from .document import document_generator as document_generator
 from .document import document_streamer as document_streamer
 
-# ruff: noqa: F401, E402
-from .elements import (
-    a,
-    abbr,
-    address,
-    area,
-    article,
-    aside,
-    audio,
-    b,
-    base,
-    bdi,
-    bdo,
-    blockquote,
-    body,
-    br,
-    button,
-    canvas,
-    caption,
-    cite,
-    code,
-    col,
-    colgroup,
-    data,
-    datalist,
-    dd,
-    del_,
-    details,
-    dfn,
-    dialog,
-    div,
-    dl,
-    dt,
-    em,
-    embed,
-    fieldset,
-    figcaption,
-    figure,
-    footer,
-    form,
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    head,
-    header,
-    hgroup,
-    hr,
-    html,
-    i,
-    iframe,
-    img,
-    input,
-    ins,
-    kbd,
-    label,
-    legend,
-    li,
-    link,
-    main,
-    map,
-    mark,
-    menu,
-    meta,
-    meter,
-    nav,
-    noscript,
-    object,
-    ol,
-    optgroup,
-    option,
-    output,
-    p,
-    picture,
-    pre,
-    progress,
-    q,
-    rp,
-    rt,
-    ruby,
-    s,
-    samp,
-    script,
-    search,
-    section,
-    select,
-    slot,
-    small,
-    source,
-    span,
-    strong,
-    style,
-    sub,
-    summary,
-    sup,
-    svg,
-    table,
-    tbody,
-    td,
-    template,
-    textarea,
-    tfoot,
-    th,
-    thead,
-    time,
-    title,
-    tr,
-    track,
-    u,
-    ul,
-    var,
-    video,
-    wbr,
-)
+# Elements
+from .elements import a as a
+from .elements import abbr as abbr
+from .elements import address as address
+from .elements import area as area
+from .elements import article as article
+from .elements import aside as aside
+from .elements import audio as audio
+from .elements import b as b
+from .elements import base as base
+from .elements import bdi as bdi
+from .elements import bdo as bdo
+from .elements import blockquote as blockquote
+from .elements import body as body
+from .elements import br as br
+from .elements import button as button
+from .elements import canvas as canvas
+from .elements import caption as caption
+from .elements import cite as cite
+from .elements import code as code
+from .elements import col as col
+from .elements import colgroup as colgroup
+from .elements import data as data
+from .elements import datalist as datalist
+from .elements import dd as dd
+from .elements import del_ as del_
+from .elements import details as details
+from .elements import dfn as dfn
+from .elements import dialog as dialog
+from .elements import div as div
+from .elements import dl as dl
+from .elements import dt as dt
+from .elements import em as em
+from .elements import embed as embed
+from .elements import fieldset as fieldset
+from .elements import figcaption as figcaption
+from .elements import figure as figure
+from .elements import footer as footer
+from .elements import form as form
+from .elements import h1 as h1
+from .elements import h2 as h2
+from .elements import h3 as h3
+from .elements import h4 as h4
+from .elements import h5 as h5
+from .elements import h6 as h6
+from .elements import head as head
+from .elements import header as header
+from .elements import hgroup as hgroup
+from .elements import hr as hr
+from .elements import html as html
+from .elements import i as i
+from .elements import iframe as iframe
+from .elements import img as img
+from .elements import input as input
+from .elements import ins as ins
+from .elements import kbd as kbd
+from .elements import label as label
+from .elements import legend as legend
+from .elements import li as li
+from .elements import link as link
+from .elements import main as main
+from .elements import map as map
+from .elements import mark as mark
+from .elements import menu as menu
+from .elements import meta as meta
+from .elements import meter as meter
+from .elements import nav as nav
+from .elements import noscript as noscript
+from .elements import object as object
+from .elements import ol as ol
+from .elements import optgroup as optgroup
+from .elements import option as option
+from .elements import output as output
+from .elements import p as p
+from .elements import picture as picture
+from .elements import pre as pre
+from .elements import progress as progress
+from .elements import q as q
+from .elements import rp as rp
+from .elements import rt as rt
+from .elements import ruby as ruby
+from .elements import s as s
+from .elements import samp as samp
+from .elements import script as script
+from .elements import search as search
+from .elements import section as section
+from .elements import select as select
+from .elements import slot as slot
+from .elements import small as small
+from .elements import source as source
+from .elements import span as span
+from .elements import strong as strong
+from .elements import style as style
+from .elements import sub as sub
+from .elements import summary as summary
+from .elements import sup as sup
+from .elements import svg as svg
+from .elements import table as table
+from .elements import tbody as tbody
+from .elements import td as td
+from .elements import template as template
+from .elements import textarea as textarea
+from .elements import tfoot as tfoot
+from .elements import th as th
+from .elements import thead as thead
+from .elements import time as time
+from .elements import title as title
+from .elements import tr as tr
+from .elements import track as track
+from .elements import u as u
+from .elements import ul as ul
+from .elements import var as var
+from .elements import video as video
+from .elements import wbr as wbr
 
-# ruff: noqa: F401, E402
-from .resource import (
-    css_import,
-    font_import_manual,
-    font_import_provider,
-    js_import,
-)
+# Resource features
+from .resource import css_import as css_import
+from .resource import font_import_manual as font_import_manual
+from .resource import font_import_provider as font_import_provider
+from .resource import js_import as js_import

--- a/src/html_compose/__init__.py
+++ b/src/html_compose/__init__.py
@@ -76,6 +76,7 @@ We are going to dive into the technicals and core ideas of the library.
 .. include:: ../../doc/ideas/03_code_generator.md
 .. include:: ../../doc/ideas/04_attrs.md
 .. include:: ../../doc/ideas/05_livereload.md
+.. include:: ../../doc/ideas/06_resource_imports.md
 """
 
 from markupsafe import Markup, escape
@@ -137,7 +138,13 @@ from .custom_element import CustomElement
 
 create_element = CustomElement.create
 
-from .document import HTML5Document
+# ruff: noqa: F401, E402
+from .document import (
+    HTML5Document,
+    HTML5Stream,
+    document_generator,
+    document_streamer,
+)
 
 # ruff: noqa: F401, E402
 from .elements import (
@@ -254,4 +261,12 @@ from .elements import (
     var,
     video,
     wbr,
+)
+
+# ruff: noqa: F401, E402
+from .resource import (
+    css_import,
+    font_import_manual,
+    font_import_provider,
+    js_import,
 )

--- a/src/html_compose/attributes/__init__.py
+++ b/src/html_compose/attributes/__init__.py
@@ -1,3 +1,9 @@
+"""
+This module contains HTML attributes.
+
+They typically aren't imported directly
+"""
+
 # ruff: noqa
 from ..base_attribute import BaseAttribute
 from .global_attrs import GlobalAttrs

--- a/src/html_compose/attributes/a_attrs.py
+++ b/src/html_compose/attributes/a_attrs.py
@@ -11,95 +11,135 @@ class AnchorAttrs:
     @staticmethod
     def download(value: StrLike) -> BaseAttribute:
         """
-        "a" attribute: download  
-        Whether to download the resource instead of navigating to it, and its filename if so  
+        "a" attribute: download
+        Whether to download the resource instead of navigating to it, and its filename if so
 
-        :param value: Text  
-        :return: An download attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An download attribute to be added to your element
+
+        """
 
         return BaseAttribute("download", value)
 
     @staticmethod
     def href(value) -> BaseAttribute:
         """
-        "a" attribute: href  
-        Address of the hyperlink  
+        "a" attribute: href
+        Address of the hyperlink
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An href attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+
+        Returns:
+            An href attribute to be added to your element
+
+        """
 
         return BaseAttribute("href", value)
 
     @staticmethod
     def hreflang(value) -> BaseAttribute:
         """
-        "a" attribute: hreflang  
-        Language of the linked resource  
+        "a" attribute: hreflang
+        Language of the linked resource
 
-        :param value: Valid BCP 47 language tag  
-        :return: An hreflang attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid BCP 47 language tag
+
+        Returns:
+            An hreflang attribute to be added to your element
+
+        """
 
         return BaseAttribute("hreflang", value)
 
     @staticmethod
     def ping(value: Resolvable) -> BaseAttribute:
         """
-        "a" attribute: ping  
-        URLs to ping  
+        "a" attribute: ping
+        URLs to ping
 
-        :param value: Set of space-separated tokens consisting of valid non-empty URLs  
-        :return: An ping attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Set of space-separated tokens consisting of valid non-empty URLs
+
+        Returns:
+            An ping attribute to be added to your element
+
+        """
 
         return BaseAttribute("ping", value)
 
     @staticmethod
     def referrerpolicy(value) -> BaseAttribute:
         """
-        "a" attribute: referrerpolicy  
-        Referrer policy for fetches initiated by the element  
+        "a" attribute: referrerpolicy
+        Referrer policy for fetches initiated by the element
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Referrer policy
+
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
 
         return BaseAttribute("referrerpolicy", value)
 
     @staticmethod
     def rel(value: Resolvable) -> BaseAttribute:
         """
-        "a" attribute: rel  
-        Relationship between the location in the document containing the hyperlink and the destination resource  
+        "a" attribute: rel
+        Relationship between the location in the document containing the hyperlink and the destination resource
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An rel attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+
+        Returns:
+            An rel attribute to be added to your element
+
+        """
 
         return BaseAttribute("rel", value)
 
     @staticmethod
     def target(value) -> BaseAttribute:
         """
-        "a" attribute: target  
-        Navigable for hyperlink navigation  
+        "a" attribute: target
+        Navigable for hyperlink navigation
 
-        :param value: Valid navigable target name or keyword  
-        :return: An target attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+
+        Returns:
+            An target attribute to be added to your element
+
+        """
 
         return BaseAttribute("target", value)
 
     @staticmethod
     def type(value) -> BaseAttribute:
         """
-        "a" attribute: type  
-        Hint for the type of the referenced resource  
+        "a" attribute: type
+        Hint for the type of the referenced resource
 
-        :param value: Valid MIME type string  
-        :return: An type attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid MIME type string
+
+        Returns:
+            An type attribute to be added to your element
+
+        """
 
         return BaseAttribute("type", value)

--- a/src/html_compose/attributes/abbr_attrs.py
+++ b/src/html_compose/attributes/abbr_attrs.py
@@ -11,11 +11,16 @@ class AbbrAttrs:
     @staticmethod
     def title(value: StrLike) -> BaseAttribute:
         """
-        "abbr" attribute: title  
-        Full term or expansion of abbreviation  
+        "abbr" attribute: title
+        Full term or expansion of abbreviation
 
-        :param value: Text  
-        :return: An title attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An title attribute to be added to your element
+
+        """
 
         return BaseAttribute("title", value)

--- a/src/html_compose/attributes/area_attrs.py
+++ b/src/html_compose/attributes/area_attrs.py
@@ -12,84 +12,119 @@ class AreaAttrs:
     @staticmethod
     def alt(value: StrLike) -> BaseAttribute:
         """
-        "area" attribute: alt  
-        Replacement text for use when images are not available  
+        "area" attribute: alt
+        Replacement text for use when images are not available
 
-        :param value: Text*  
-        :return: An alt attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An alt attribute to be added to your element
+
+        """
 
         return BaseAttribute("alt", value)
 
     @staticmethod
     def coords(value) -> BaseAttribute:
         """
-        "area" attribute: coords  
-        Coordinates for the shape to be created in an image map  
+        "area" attribute: coords
+        Coordinates for the shape to be created in an image map
 
-        :param value: Valid list of floating-point numbers*  
-        :return: An coords attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid list of floating-point numbers*
+
+        Returns:
+            An coords attribute to be added to your element
+
+        """
 
         return BaseAttribute("coords", value)
 
     @staticmethod
     def download(value: StrLike) -> BaseAttribute:
         """
-        "area" attribute: download  
-        Whether to download the resource instead of navigating to it, and its filename if so  
+        "area" attribute: download
+        Whether to download the resource instead of navigating to it, and its filename if so
 
-        :param value: Text  
-        :return: An download attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An download attribute to be added to your element
+
+        """
 
         return BaseAttribute("download", value)
 
     @staticmethod
     def href(value) -> BaseAttribute:
         """
-        "area" attribute: href  
-        Address of the hyperlink  
+        "area" attribute: href
+        Address of the hyperlink
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An href attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+
+        Returns:
+            An href attribute to be added to your element
+
+        """
 
         return BaseAttribute("href", value)
 
     @staticmethod
     def ping(value: Resolvable) -> BaseAttribute:
         """
-        "area" attribute: ping  
-        URLs to ping  
+        "area" attribute: ping
+        URLs to ping
 
-        :param value: Set of space-separated tokens consisting of valid non-empty URLs  
-        :return: An ping attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Set of space-separated tokens consisting of valid non-empty URLs
+
+        Returns:
+            An ping attribute to be added to your element
+
+        """
 
         return BaseAttribute("ping", value)
 
     @staticmethod
     def referrerpolicy(value) -> BaseAttribute:
         """
-        "area" attribute: referrerpolicy  
-        Referrer policy for fetches initiated by the element  
+        "area" attribute: referrerpolicy
+        Referrer policy for fetches initiated by the element
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Referrer policy
+
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
 
         return BaseAttribute("referrerpolicy", value)
 
     @staticmethod
     def rel(value: Resolvable) -> BaseAttribute:
         """
-        "area" attribute: rel  
-        Relationship between the location in the document containing the hyperlink and the destination resource  
+        "area" attribute: rel
+        Relationship between the location in the document containing the hyperlink and the destination resource
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An rel attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+
+        Returns:
+            An rel attribute to be added to your element
+
+        """
 
         return BaseAttribute("rel", value)
 
@@ -98,23 +133,33 @@ class AreaAttrs:
         value: Literal["circle", "default", "poly", "rect"],
     ) -> BaseAttribute:
         """
-        "area" attribute: shape  
-        The kind of shape to be created in an image map  
+        "area" attribute: shape
+        The kind of shape to be created in an image map
 
-        :param value: ['circle', 'default', 'poly', 'rect']  
-        :return: An shape attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['circle', 'default', 'poly', 'rect']
+
+        Returns:
+            An shape attribute to be added to your element
+
+        """
 
         return BaseAttribute("shape", value)
 
     @staticmethod
     def target(value) -> BaseAttribute:
         """
-        "area" attribute: target  
-        Navigable for hyperlink navigation  
+        "area" attribute: target
+        Navigable for hyperlink navigation
 
-        :param value: Valid navigable target name or keyword  
-        :return: An target attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+
+        Returns:
+            An target attribute to be added to your element
+
+        """
 
         return BaseAttribute("target", value)

--- a/src/html_compose/attributes/audio_attrs.py
+++ b/src/html_compose/attributes/audio_attrs.py
@@ -11,24 +11,34 @@ class AudioAttrs:
     @staticmethod
     def autoplay(value: bool) -> BaseAttribute:
         """
-        "audio" attribute: autoplay  
-        Hint that the media resource can be started automatically when the page is loaded  
+        "audio" attribute: autoplay
+        Hint that the media resource can be started automatically when the page is loaded
 
-        :param value: Boolean attribute  
-        :return: An autoplay attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An autoplay attribute to be added to your element
+
+        """
 
         return BaseAttribute("autoplay", value)
 
     @staticmethod
     def controls(value: bool) -> BaseAttribute:
         """
-        "audio" attribute: controls  
-        Show user agent controls  
+        "audio" attribute: controls
+        Show user agent controls
 
-        :param value: Boolean attribute  
-        :return: An controls attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An controls attribute to be added to your element
+
+        """
 
         return BaseAttribute("controls", value)
 
@@ -37,59 +47,84 @@ class AudioAttrs:
         value: Literal["anonymous", "use-credentials"],
     ) -> BaseAttribute:
         """
-        "audio" attribute: crossorigin  
-        How the element handles crossorigin requests  
+        "audio" attribute: crossorigin
+        How the element handles crossorigin requests
 
-        :param value: ['anonymous', 'use-credentials']  
-        :return: An crossorigin attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['anonymous', 'use-credentials']
+
+        Returns:
+            An crossorigin attribute to be added to your element
+
+        """
 
         return BaseAttribute("crossorigin", value)
 
     @staticmethod
     def loop(value: bool) -> BaseAttribute:
         """
-        "audio" attribute: loop  
-        Whether to loop the media resource  
+        "audio" attribute: loop
+        Whether to loop the media resource
 
-        :param value: Boolean attribute  
-        :return: An loop attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An loop attribute to be added to your element
+
+        """
 
         return BaseAttribute("loop", value)
 
     @staticmethod
     def muted(value: bool) -> BaseAttribute:
         """
-        "audio" attribute: muted  
-        Whether to mute the media resource by default  
+        "audio" attribute: muted
+        Whether to mute the media resource by default
 
-        :param value: Boolean attribute  
-        :return: An muted attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An muted attribute to be added to your element
+
+        """
 
         return BaseAttribute("muted", value)
 
     @staticmethod
     def preload(value: Literal["none", "metadata", "auto"]) -> BaseAttribute:
         """
-        "audio" attribute: preload  
-        Hints how much buffering the media resource will likely need  
+        "audio" attribute: preload
+        Hints how much buffering the media resource will likely need
 
-        :param value: ['none', 'metadata', 'auto']  
-        :return: An preload attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['none', 'metadata', 'auto']
+
+        Returns:
+            An preload attribute to be added to your element
+
+        """
 
         return BaseAttribute("preload", value)
 
     @staticmethod
     def src(value) -> BaseAttribute:
         """
-        "audio" attribute: src  
-        Address of the resource  
+        "audio" attribute: src
+        Address of the resource
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An src attribute to be added to your element
+
+        """
 
         return BaseAttribute("src", value)

--- a/src/html_compose/attributes/base_attrs.py
+++ b/src/html_compose/attributes/base_attrs.py
@@ -10,23 +10,33 @@ class BaseAttrs:
     @staticmethod
     def href(value) -> BaseAttribute:
         """
-        "base" attribute: href  
-        Document base URL  
+        "base" attribute: href
+        Document base URL
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An href attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+
+        Returns:
+            An href attribute to be added to your element
+
+        """
 
         return BaseAttribute("href", value)
 
     @staticmethod
     def target(value) -> BaseAttribute:
         """
-        "base" attribute: target  
-        Default navigable for hyperlink navigation and form submission  
+        "base" attribute: target
+        Default navigable for hyperlink navigation and form submission
 
-        :param value: Valid navigable target name or keyword  
-        :return: An target attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+
+        Returns:
+            An target attribute to be added to your element
+
+        """
 
         return BaseAttribute("target", value)

--- a/src/html_compose/attributes/bdo_attrs.py
+++ b/src/html_compose/attributes/bdo_attrs.py
@@ -11,11 +11,16 @@ class BdoAttrs:
     @staticmethod
     def dir(value: Literal["ltr", "rtl"]) -> BaseAttribute:
         """
-        "bdo" attribute: dir  
-        The text directionality of the element  
+        "bdo" attribute: dir
+        The text directionality of the element
 
-        :param value: ['ltr', 'rtl']  
-        :return: An dir attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['ltr', 'rtl']
+
+        Returns:
+            An dir attribute to be added to your element
+
+        """
 
         return BaseAttribute("dir", value)

--- a/src/html_compose/attributes/blockquote_attrs.py
+++ b/src/html_compose/attributes/blockquote_attrs.py
@@ -10,11 +10,16 @@ class BlockquoteAttrs:
     @staticmethod
     def cite(value) -> BaseAttribute:
         """
-        "blockquote" attribute: cite  
-        Link to the source of the quotation or more information about the edit  
+        "blockquote" attribute: cite
+        Link to the source of the quotation or more information about the edit
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An cite attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+
+        Returns:
+            An cite attribute to be added to your element
+
+        """
 
         return BaseAttribute("cite", value)

--- a/src/html_compose/attributes/body_attrs.py
+++ b/src/html_compose/attributes/body_attrs.py
@@ -10,215 +10,305 @@ class BodyAttrs:
     @staticmethod
     def onafterprint(value) -> BaseAttribute:
         """
-        "body" attribute: onafterprint  
-        afterprint event handler for Window object  
+        "body" attribute: onafterprint
+        afterprint event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onafterprint attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onafterprint attribute to be added to your element
+
+        """
 
         return BaseAttribute("onafterprint", value)
 
     @staticmethod
     def onbeforeprint(value) -> BaseAttribute:
         """
-        "body" attribute: onbeforeprint  
-        beforeprint event handler for Window object  
+        "body" attribute: onbeforeprint
+        beforeprint event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onbeforeprint attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onbeforeprint attribute to be added to your element
+
+        """
 
         return BaseAttribute("onbeforeprint", value)
 
     @staticmethod
     def onbeforeunload(value) -> BaseAttribute:
         """
-        "body" attribute: onbeforeunload  
-        beforeunload event handler for Window object  
+        "body" attribute: onbeforeunload
+        beforeunload event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onbeforeunload attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onbeforeunload attribute to be added to your element
+
+        """
 
         return BaseAttribute("onbeforeunload", value)
 
     @staticmethod
     def onhashchange(value) -> BaseAttribute:
         """
-        "body" attribute: onhashchange  
-        hashchange event handler for Window object  
+        "body" attribute: onhashchange
+        hashchange event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onhashchange attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onhashchange attribute to be added to your element
+
+        """
 
         return BaseAttribute("onhashchange", value)
 
     @staticmethod
     def onlanguagechange(value) -> BaseAttribute:
         """
-        "body" attribute: onlanguagechange  
-        languagechange event handler for Window object  
+        "body" attribute: onlanguagechange
+        languagechange event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onlanguagechange attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onlanguagechange attribute to be added to your element
+
+        """
 
         return BaseAttribute("onlanguagechange", value)
 
     @staticmethod
     def onmessage(value) -> BaseAttribute:
         """
-        "body" attribute: onmessage  
-        message event handler for Window object  
+        "body" attribute: onmessage
+        message event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onmessage attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onmessage attribute to be added to your element
+
+        """
 
         return BaseAttribute("onmessage", value)
 
     @staticmethod
     def onmessageerror(value) -> BaseAttribute:
         """
-        "body" attribute: onmessageerror  
-        messageerror event handler for Window object  
+        "body" attribute: onmessageerror
+        messageerror event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onmessageerror attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onmessageerror attribute to be added to your element
+
+        """
 
         return BaseAttribute("onmessageerror", value)
 
     @staticmethod
     def onoffline(value) -> BaseAttribute:
         """
-        "body" attribute: onoffline  
-        offline event handler for Window object  
+        "body" attribute: onoffline
+        offline event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onoffline attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onoffline attribute to be added to your element
+
+        """
 
         return BaseAttribute("onoffline", value)
 
     @staticmethod
     def ononline(value) -> BaseAttribute:
         """
-        "body" attribute: ononline  
-        online event handler for Window object  
+        "body" attribute: ononline
+        online event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An ononline attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ononline attribute to be added to your element
+
+        """
 
         return BaseAttribute("ononline", value)
 
     @staticmethod
     def onpagehide(value) -> BaseAttribute:
         """
-        "body" attribute: onpagehide  
-        pagehide event handler for Window object  
+        "body" attribute: onpagehide
+        pagehide event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onpagehide attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onpagehide attribute to be added to your element
+
+        """
 
         return BaseAttribute("onpagehide", value)
 
     @staticmethod
     def onpagereveal(value) -> BaseAttribute:
         """
-        "body" attribute: onpagereveal  
-        pagereveal event handler for Window object  
+        "body" attribute: onpagereveal
+        pagereveal event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onpagereveal attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onpagereveal attribute to be added to your element
+
+        """
 
         return BaseAttribute("onpagereveal", value)
 
     @staticmethod
     def onpageshow(value) -> BaseAttribute:
         """
-        "body" attribute: onpageshow  
-        pageshow event handler for Window object  
+        "body" attribute: onpageshow
+        pageshow event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onpageshow attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onpageshow attribute to be added to your element
+
+        """
 
         return BaseAttribute("onpageshow", value)
 
     @staticmethod
     def onpageswap(value) -> BaseAttribute:
         """
-        "body" attribute: onpageswap  
-        pageswap event handler for Window object  
+        "body" attribute: onpageswap
+        pageswap event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onpageswap attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onpageswap attribute to be added to your element
+
+        """
 
         return BaseAttribute("onpageswap", value)
 
     @staticmethod
     def onpopstate(value) -> BaseAttribute:
         """
-        "body" attribute: onpopstate  
-        popstate event handler for Window object  
+        "body" attribute: onpopstate
+        popstate event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onpopstate attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onpopstate attribute to be added to your element
+
+        """
 
         return BaseAttribute("onpopstate", value)
 
     @staticmethod
     def onrejectionhandled(value) -> BaseAttribute:
         """
-        "body" attribute: onrejectionhandled  
-        rejectionhandled event handler for Window object  
+        "body" attribute: onrejectionhandled
+        rejectionhandled event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onrejectionhandled attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onrejectionhandled attribute to be added to your element
+
+        """
 
         return BaseAttribute("onrejectionhandled", value)
 
     @staticmethod
     def onstorage(value) -> BaseAttribute:
         """
-        "body" attribute: onstorage  
-        storage event handler for Window object  
+        "body" attribute: onstorage
+        storage event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onstorage attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onstorage attribute to be added to your element
+
+        """
 
         return BaseAttribute("onstorage", value)
 
     @staticmethod
     def onunhandledrejection(value) -> BaseAttribute:
         """
-        "body" attribute: onunhandledrejection  
-        unhandledrejection event handler for Window object  
+        "body" attribute: onunhandledrejection
+        unhandledrejection event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onunhandledrejection attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onunhandledrejection attribute to be added to your element
+
+        """
 
         return BaseAttribute("onunhandledrejection", value)
 
     @staticmethod
     def onunload(value) -> BaseAttribute:
         """
-        "body" attribute: onunload  
-        unload event handler for Window object  
+        "body" attribute: onunload
+        unload event handler for Window object
 
-        :param value: Event handler content attribute  
-        :return: An onunload attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onunload attribute to be added to your element
+
+        """
 
         return BaseAttribute("onunload", value)

--- a/src/html_compose/attributes/button_attrs.py
+++ b/src/html_compose/attributes/button_attrs.py
@@ -12,36 +12,51 @@ class ButtonAttrs:
     @staticmethod
     def disabled(value: bool) -> BaseAttribute:
         """
-        "button" attribute: disabled  
-        Whether the form control is disabled  
+        "button" attribute: disabled
+        Whether the form control is disabled
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
 
         return BaseAttribute("disabled", value)
 
     @staticmethod
     def form(value) -> BaseAttribute:
         """
-        "button" attribute: form  
-        Associates the element with a form element  
+        "button" attribute: form
+        Associates the element with a form element
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An form attribute to be added to your element
+
+        """
 
         return BaseAttribute("form", value)
 
     @staticmethod
     def formaction(value) -> BaseAttribute:
         """
-        "button" attribute: formaction  
-        URL to use for form submission  
+        "button" attribute: formaction
+        URL to use for form submission
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An formaction attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An formaction attribute to be added to your element
+
+        """
 
         return BaseAttribute("formaction", value)
 
@@ -54,72 +69,102 @@ class ButtonAttrs:
         ],
     ) -> BaseAttribute:
         """
-        "button" attribute: formenctype  
-        Entry list encoding type to use for form submission  
+        "button" attribute: formenctype
+        Entry list encoding type to use for form submission
 
-        :param value: ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']  
-        :return: An formenctype attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']
+
+        Returns:
+            An formenctype attribute to be added to your element
+
+        """
 
         return BaseAttribute("formenctype", value)
 
     @staticmethod
     def formmethod(value: Literal["GET", "POST", "dialog"]) -> BaseAttribute:
         """
-        "button" attribute: formmethod  
-        Variant to use for form submission  
+        "button" attribute: formmethod
+        Variant to use for form submission
 
-        :param value: ['GET', 'POST', 'dialog']  
-        :return: An formmethod attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['GET', 'POST', 'dialog']
+
+        Returns:
+            An formmethod attribute to be added to your element
+
+        """
 
         return BaseAttribute("formmethod", value)
 
     @staticmethod
     def formnovalidate(value: bool) -> BaseAttribute:
         """
-        "button" attribute: formnovalidate  
-        Bypass form control validation for form submission  
+        "button" attribute: formnovalidate
+        Bypass form control validation for form submission
 
-        :param value: Boolean attribute  
-        :return: An formnovalidate attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An formnovalidate attribute to be added to your element
+
+        """
 
         return BaseAttribute("formnovalidate", value)
 
     @staticmethod
     def formtarget(value) -> BaseAttribute:
         """
-        "button" attribute: formtarget  
-        Navigable for form submission  
+        "button" attribute: formtarget
+        Navigable for form submission
 
-        :param value: Valid navigable target name or keyword  
-        :return: An formtarget attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+
+        Returns:
+            An formtarget attribute to be added to your element
+
+        """
 
         return BaseAttribute("formtarget", value)
 
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "button" attribute: name  
-        Name of the element to use for form submission and in the form.elements API  
+        "button" attribute: name
+        Name of the element to use for form submission and in the form.elements API
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)
 
     @staticmethod
     def popovertarget(value) -> BaseAttribute:
         """
-        "button" attribute: popovertarget  
-        Targets a popover element to toggle, show, or hide  
+        "button" attribute: popovertarget
+        Targets a popover element to toggle, show, or hide
 
-        :param value: ID*  
-        :return: An popovertarget attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An popovertarget attribute to be added to your element
+
+        """
 
         return BaseAttribute("popovertarget", value)
 
@@ -128,35 +173,50 @@ class ButtonAttrs:
         value: Literal["toggle", "show", "hide"],
     ) -> BaseAttribute:
         """
-        "button" attribute: popovertargetaction  
-        Indicates whether a targeted popover element is to be toggled, shown, or hidden  
+        "button" attribute: popovertargetaction
+        Indicates whether a targeted popover element is to be toggled, shown, or hidden
 
-        :param value: ['toggle', 'show', 'hide']  
-        :return: An popovertargetaction attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['toggle', 'show', 'hide']
+
+        Returns:
+            An popovertargetaction attribute to be added to your element
+
+        """
 
         return BaseAttribute("popovertargetaction", value)
 
     @staticmethod
     def type(value: Literal["submit", "reset", "button"]) -> BaseAttribute:
         """
-        "button" attribute: type  
-        Type of button  
+        "button" attribute: type
+        Type of button
 
-        :param value: ['submit', 'reset', 'button']  
-        :return: An type attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['submit', 'reset', 'button']
+
+        Returns:
+            An type attribute to be added to your element
+
+        """
 
         return BaseAttribute("type", value)
 
     @staticmethod
     def value(value: StrLike) -> BaseAttribute:
         """
-        "button" attribute: value  
-        Value to be used for form submission  
+        "button" attribute: value
+        Value to be used for form submission
 
-        :param value: Text  
-        :return: An value attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An value attribute to be added to your element
+
+        """
 
         return BaseAttribute("value", value)

--- a/src/html_compose/attributes/canvas_attrs.py
+++ b/src/html_compose/attributes/canvas_attrs.py
@@ -10,23 +10,33 @@ class CanvasAttrs:
     @staticmethod
     def height(value: int) -> BaseAttribute:
         """
-        "canvas" attribute: height  
-        Vertical dimension  
+        "canvas" attribute: height
+        Vertical dimension
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An height attribute to be added to your element
+
+        """
 
         return BaseAttribute("height", value)
 
     @staticmethod
     def width(value: int) -> BaseAttribute:
         """
-        "canvas" attribute: width  
-        Horizontal dimension  
+        "canvas" attribute: width
+        Horizontal dimension
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An width attribute to be added to your element
+
+        """
 
         return BaseAttribute("width", value)

--- a/src/html_compose/attributes/col_attrs.py
+++ b/src/html_compose/attributes/col_attrs.py
@@ -10,11 +10,16 @@ class ColAttrs:
     @staticmethod
     def span(value) -> BaseAttribute:
         """
-        "col" attribute: span  
-        Number of columns spanned by the element  
+        "col" attribute: span
+        Number of columns spanned by the element
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An span attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+
+        Returns:
+            An span attribute to be added to your element
+
+        """
 
         return BaseAttribute("span", value)

--- a/src/html_compose/attributes/colgroup_attrs.py
+++ b/src/html_compose/attributes/colgroup_attrs.py
@@ -10,11 +10,16 @@ class ColgroupAttrs:
     @staticmethod
     def span(value) -> BaseAttribute:
         """
-        "colgroup" attribute: span  
-        Number of columns spanned by the element  
+        "colgroup" attribute: span
+        Number of columns spanned by the element
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An span attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+
+        Returns:
+            An span attribute to be added to your element
+
+        """
 
         return BaseAttribute("span", value)

--- a/src/html_compose/attributes/data_attrs.py
+++ b/src/html_compose/attributes/data_attrs.py
@@ -11,11 +11,16 @@ class DataAttrs:
     @staticmethod
     def value(value: StrLike) -> BaseAttribute:
         """
-        "data" attribute: value  
-        Machine-readable value  
+        "data" attribute: value
+        Machine-readable value
 
-        :param value: Text*  
-        :return: An value attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An value attribute to be added to your element
+
+        """
 
         return BaseAttribute("value", value)

--- a/src/html_compose/attributes/del_attrs.py
+++ b/src/html_compose/attributes/del_attrs.py
@@ -10,23 +10,33 @@ class DelAttrs:
     @staticmethod
     def cite(value) -> BaseAttribute:
         """
-        "del" attribute: cite  
-        Link to the source of the quotation or more information about the edit  
+        "del" attribute: cite
+        Link to the source of the quotation or more information about the edit
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An cite attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+
+        Returns:
+            An cite attribute to be added to your element
+
+        """
 
         return BaseAttribute("cite", value)
 
     @staticmethod
     def datetime(value) -> BaseAttribute:
         """
-        "del" attribute: datetime  
-        Date and (optionally) time of the change  
+        "del" attribute: datetime
+        Date and (optionally) time of the change
 
-        :param value: Valid date string with optional time  
-        :return: An datetime attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid date string with optional time
+
+        Returns:
+            An datetime attribute to be added to your element
+
+        """
 
         return BaseAttribute("datetime", value)

--- a/src/html_compose/attributes/details_attrs.py
+++ b/src/html_compose/attributes/details_attrs.py
@@ -11,23 +11,33 @@ class DetailsAttrs:
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "details" attribute: name  
-        Name of group of mutually-exclusive details elements  
+        "details" attribute: name
+        Name of group of mutually-exclusive details elements
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)
 
     @staticmethod
     def open(value: bool) -> BaseAttribute:
         """
-        "details" attribute: open  
-        Whether the details are visible  
+        "details" attribute: open
+        Whether the details are visible
 
-        :param value: Boolean attribute  
-        :return: An open attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An open attribute to be added to your element
+
+        """
 
         return BaseAttribute("open", value)

--- a/src/html_compose/attributes/dfn_attrs.py
+++ b/src/html_compose/attributes/dfn_attrs.py
@@ -11,11 +11,16 @@ class DfnAttrs:
     @staticmethod
     def title(value: StrLike) -> BaseAttribute:
         """
-        "dfn" attribute: title  
-        Full term or expansion of abbreviation  
+        "dfn" attribute: title
+        Full term or expansion of abbreviation
 
-        :param value: Text  
-        :return: An title attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An title attribute to be added to your element
+
+        """
 
         return BaseAttribute("title", value)

--- a/src/html_compose/attributes/dialog_attrs.py
+++ b/src/html_compose/attributes/dialog_attrs.py
@@ -10,11 +10,16 @@ class DialogAttrs:
     @staticmethod
     def open(value: bool) -> BaseAttribute:
         """
-        "dialog" attribute: open  
-        Whether the dialog box is showing  
+        "dialog" attribute: open
+        Whether the dialog box is showing
 
-        :param value: Boolean attribute  
-        :return: An open attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An open attribute to be added to your element
+
+        """
 
         return BaseAttribute("open", value)

--- a/src/html_compose/attributes/embed_attrs.py
+++ b/src/html_compose/attributes/embed_attrs.py
@@ -10,47 +10,67 @@ class EmbedAttrs:
     @staticmethod
     def height(value: int) -> BaseAttribute:
         """
-        "embed" attribute: height  
-        Vertical dimension  
+        "embed" attribute: height
+        Vertical dimension
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An height attribute to be added to your element
+
+        """
 
         return BaseAttribute("height", value)
 
     @staticmethod
     def src(value) -> BaseAttribute:
         """
-        "embed" attribute: src  
-        Address of the resource  
+        "embed" attribute: src
+        Address of the resource
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An src attribute to be added to your element
+
+        """
 
         return BaseAttribute("src", value)
 
     @staticmethod
     def type(value) -> BaseAttribute:
         """
-        "embed" attribute: type  
-        Type of embedded resource  
+        "embed" attribute: type
+        Type of embedded resource
 
-        :param value: Valid MIME type string  
-        :return: An type attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid MIME type string
+
+        Returns:
+            An type attribute to be added to your element
+
+        """
 
         return BaseAttribute("type", value)
 
     @staticmethod
     def width(value: int) -> BaseAttribute:
         """
-        "embed" attribute: width  
-        Horizontal dimension  
+        "embed" attribute: width
+        Horizontal dimension
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An width attribute to be added to your element
+
+        """
 
         return BaseAttribute("width", value)

--- a/src/html_compose/attributes/fieldset_attrs.py
+++ b/src/html_compose/attributes/fieldset_attrs.py
@@ -11,35 +11,50 @@ class FieldsetAttrs:
     @staticmethod
     def disabled(value: bool) -> BaseAttribute:
         """
-        "fieldset" attribute: disabled  
-        Whether the descendant form controls, except any inside legend, are disabled  
+        "fieldset" attribute: disabled
+        Whether the descendant form controls, except any inside legend, are disabled
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
 
         return BaseAttribute("disabled", value)
 
     @staticmethod
     def form(value) -> BaseAttribute:
         """
-        "fieldset" attribute: form  
-        Associates the element with a form element  
+        "fieldset" attribute: form
+        Associates the element with a form element
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An form attribute to be added to your element
+
+        """
 
         return BaseAttribute("form", value)
 
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "fieldset" attribute: name  
-        Name of the element to use for form submission and in the form.elements API  
+        "fieldset" attribute: name
+        Name of the element to use for form submission and in the form.elements API
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)

--- a/src/html_compose/attributes/form_attrs.py
+++ b/src/html_compose/attributes/form_attrs.py
@@ -12,36 +12,51 @@ class FormAttrs:
     @staticmethod
     def accept_charset(value) -> BaseAttribute:
         """
-        "form" attribute: accept-charset  
-        Character encodings to use for form submission  
+        "form" attribute: accept-charset
+        Character encodings to use for form submission
 
-        :param value: ASCII case-insensitive match for "UTF-8"  
-        :return: An accept-charset attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ASCII case-insensitive match for "UTF-8"
+
+        Returns:
+            An accept-charset attribute to be added to your element
+
+        """
 
         return BaseAttribute("accept-charset", value)
 
     @staticmethod
     def action(value) -> BaseAttribute:
         """
-        "form" attribute: action  
-        URL to use for form submission  
+        "form" attribute: action
+        URL to use for form submission
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An action attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An action attribute to be added to your element
+
+        """
 
         return BaseAttribute("action", value)
 
     @staticmethod
     def autocomplete(value: Literal["on", "off"]) -> BaseAttribute:
         """
-        "form" attribute: autocomplete  
-        Default setting for autofill feature for controls in the form  
+        "form" attribute: autocomplete
+        Default setting for autofill feature for controls in the form
 
-        :param value: ['on', 'off']  
-        :return: An autocomplete attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['on', 'off']
+
+        Returns:
+            An autocomplete attribute to be added to your element
+
+        """
 
         return BaseAttribute("autocomplete", value)
 
@@ -54,59 +69,84 @@ class FormAttrs:
         ],
     ) -> BaseAttribute:
         """
-        "form" attribute: enctype  
-        Entry list encoding type to use for form submission  
+        "form" attribute: enctype
+        Entry list encoding type to use for form submission
 
-        :param value: ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']  
-        :return: An enctype attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']
+
+        Returns:
+            An enctype attribute to be added to your element
+
+        """
 
         return BaseAttribute("enctype", value)
 
     @staticmethod
     def method(value: Literal["GET", "POST", "dialog"]) -> BaseAttribute:
         """
-        "form" attribute: method  
-        Variant to use for form submission  
+        "form" attribute: method
+        Variant to use for form submission
 
-        :param value: ['GET', 'POST', 'dialog']  
-        :return: An method attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['GET', 'POST', 'dialog']
+
+        Returns:
+            An method attribute to be added to your element
+
+        """
 
         return BaseAttribute("method", value)
 
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "form" attribute: name  
-        Name of form to use in the document.forms API  
+        "form" attribute: name
+        Name of form to use in the document.forms API
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)
 
     @staticmethod
     def novalidate(value: bool) -> BaseAttribute:
         """
-        "form" attribute: novalidate  
-        Bypass form control validation for form submission  
+        "form" attribute: novalidate
+        Bypass form control validation for form submission
 
-        :param value: Boolean attribute  
-        :return: An novalidate attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An novalidate attribute to be added to your element
+
+        """
 
         return BaseAttribute("novalidate", value)
 
     @staticmethod
     def target(value) -> BaseAttribute:
         """
-        "form" attribute: target  
-        Navigable for form submission  
+        "form" attribute: target
+        Navigable for form submission
 
-        :param value: Valid navigable target name or keyword  
-        :return: An target attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+
+        Returns:
+            An target attribute to be added to your element
+
+        """
 
         return BaseAttribute("target", value)

--- a/src/html_compose/attributes/global_attrs.py
+++ b/src/html_compose/attributes/global_attrs.py
@@ -12,12 +12,17 @@ class GlobalAttrs:
     @staticmethod
     def accesskey(value: Resolvable) -> BaseAttribute:
         """
-        "global" attribute: accesskey  
-        Keyboard shortcut to activate or focus element  
+        "global" attribute: accesskey
+        Keyboard shortcut to activate or focus element
 
-        :param value: Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length  
-        :return: An accesskey attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+
+        Returns:
+            An accesskey attribute to be added to your element
+
+        """
 
         return BaseAttribute("accesskey", value)
 
@@ -26,48 +31,68 @@ class GlobalAttrs:
         value: Literal["on", "off", "none", "sentences", "words", "characters"],
     ) -> BaseAttribute:
         """
-        "global" attribute: autocapitalize  
-        Recommended autocapitalization behavior (for supported input methods)  
+        "global" attribute: autocapitalize
+        Recommended autocapitalization behavior (for supported input methods)
 
-        :param value: ['on', 'off', 'none', 'sentences', 'words', 'characters']  
-        :return: An autocapitalize attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['on', 'off', 'none', 'sentences', 'words', 'characters']
+
+        Returns:
+            An autocapitalize attribute to be added to your element
+
+        """
 
         return BaseAttribute("autocapitalize", value)
 
     @staticmethod
     def autocorrect(value: Literal["on", "off"]) -> BaseAttribute:
         """
-        "global" attribute: autocorrect  
-        Recommended autocorrection behavior (for supported input methods)  
+        "global" attribute: autocorrect
+        Recommended autocorrection behavior (for supported input methods)
 
-        :param value: ['on', 'off']  
-        :return: An autocorrect attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['on', 'off']
+
+        Returns:
+            An autocorrect attribute to be added to your element
+
+        """
 
         return BaseAttribute("autocorrect", value)
 
     @staticmethod
     def autofocus(value: bool) -> BaseAttribute:
         """
-        "global" attribute: autofocus  
-        Automatically focus the element when the page is loaded  
+        "global" attribute: autofocus
+        Automatically focus the element when the page is loaded
 
-        :param value: Boolean attribute  
-        :return: An autofocus attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An autofocus attribute to be added to your element
+
+        """
 
         return BaseAttribute("autofocus", value)
 
     @staticmethod
     def class_(value: StrLike | Iterable[StrLike]) -> BaseAttribute:
         """
-        "global" attribute: class  
-        Classes to which the element belongs  
+        "global" attribute: class
+        Classes to which the element belongs
 
-        :param value: Set of space-separated tokens  
-        :return: An class attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Set of space-separated tokens
+
+        Returns:
+            An class attribute to be added to your element
+
+        """
 
         return BaseAttribute("class", value)
 
@@ -76,36 +101,51 @@ class GlobalAttrs:
         value: Literal["true", "plaintext-only", "false"],
     ) -> BaseAttribute:
         """
-        "global" attribute: contenteditable  
-        Whether the element is editable  
+        "global" attribute: contenteditable
+        Whether the element is editable
 
-        :param value: ['true', 'plaintext-only', 'false']  
-        :return: An contenteditable attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['true', 'plaintext-only', 'false']
+
+        Returns:
+            An contenteditable attribute to be added to your element
+
+        """
 
         return BaseAttribute("contenteditable", value)
 
     @staticmethod
     def dir(value: Literal["ltr", "rtl", "auto"]) -> BaseAttribute:
         """
-        "global" attribute: dir  
-        The text directionality of the element  
+        "global" attribute: dir
+        The text directionality of the element
 
-        :param value: ['ltr', 'rtl', 'auto']  
-        :return: An dir attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['ltr', 'rtl', 'auto']
+
+        Returns:
+            An dir attribute to be added to your element
+
+        """
 
         return BaseAttribute("dir", value)
 
     @staticmethod
     def draggable(value: Literal["true", "false"]) -> BaseAttribute:
         """
-        "global" attribute: draggable  
-        Whether the element is draggable  
+        "global" attribute: draggable
+        Whether the element is draggable
 
-        :param value: ['true', 'false']  
-        :return: An draggable attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['true', 'false']
+
+        Returns:
+            An draggable attribute to be added to your element
+
+        """
 
         return BaseAttribute("draggable", value)
 
@@ -116,48 +156,68 @@ class GlobalAttrs:
         ],
     ) -> BaseAttribute:
         """
-        "global" attribute: enterkeyhint  
-        Hint for selecting an enter key action  
+        "global" attribute: enterkeyhint
+        Hint for selecting an enter key action
 
-        :param value: ['enter', 'done', 'go', 'next', 'previous', 'search', 'send']  
-        :return: An enterkeyhint attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['enter', 'done', 'go', 'next', 'previous', 'search', 'send']
+
+        Returns:
+            An enterkeyhint attribute to be added to your element
+
+        """
 
         return BaseAttribute("enterkeyhint", value)
 
     @staticmethod
     def hidden(value: Literal["until-found", "hidden", ""]) -> BaseAttribute:
         """
-        "global" attribute: hidden  
-        Whether the element is relevant  
+        "global" attribute: hidden
+        Whether the element is relevant
 
-        :param value: ['until-found', 'hidden', '']  
-        :return: An hidden attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['until-found', 'hidden', '']
+
+        Returns:
+            An hidden attribute to be added to your element
+
+        """
 
         return BaseAttribute("hidden", value)
 
     @staticmethod
     def id(value: StrLike) -> BaseAttribute:
         """
-        "global" attribute: id  
-        The element's ID  
+        "global" attribute: id
+        The element's ID
 
-        :param value: Text*  
-        :return: An id attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An id attribute to be added to your element
+
+        """
 
         return BaseAttribute("id", value)
 
     @staticmethod
     def inert(value: bool) -> BaseAttribute:
         """
-        "global" attribute: inert  
-        Whether the element is inert.  
+        "global" attribute: inert
+        Whether the element is inert.
 
-        :param value: Boolean attribute  
-        :return: An inert attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An inert attribute to be added to your element
+
+        """
 
         return BaseAttribute("inert", value)
 
@@ -175,192 +235,272 @@ class GlobalAttrs:
         ],
     ) -> BaseAttribute:
         """
-        "global" attribute: inputmode  
-        Hint for selecting an input modality  
+        "global" attribute: inputmode
+        Hint for selecting an input modality
 
-        :param value: ['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']  
-        :return: An inputmode attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']
+
+        Returns:
+            An inputmode attribute to be added to your element
+
+        """
 
         return BaseAttribute("inputmode", value)
 
     @staticmethod
     def is_(value) -> BaseAttribute:
         """
-        "global" attribute: is  
-        Creates a customized built-in element  
+        "global" attribute: is
+        Creates a customized built-in element
 
-        :param value: Valid custom element name of a defined customized built-in element  
-        :return: An is attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid custom element name of a defined customized built-in element
+
+        Returns:
+            An is attribute to be added to your element
+
+        """
 
         return BaseAttribute("is", value)
 
     @staticmethod
     def itemid(value) -> BaseAttribute:
         """
-        "global" attribute: itemid  
-        Global identifier for a microdata item  
+        "global" attribute: itemid
+        Global identifier for a microdata item
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An itemid attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+
+        Returns:
+            An itemid attribute to be added to your element
+
+        """
 
         return BaseAttribute("itemid", value)
 
     @staticmethod
     def itemprop(value: Resolvable) -> BaseAttribute:
         """
-        "global" attribute: itemprop  
-        Property names of a microdata item  
+        "global" attribute: itemprop
+        Property names of a microdata item
 
-        :param value: Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*  
-        :return: An itemprop attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+
+        Returns:
+            An itemprop attribute to be added to your element
+
+        """
 
         return BaseAttribute("itemprop", value)
 
     @staticmethod
     def itemref(value: Resolvable) -> BaseAttribute:
         """
-        "global" attribute: itemref  
-        Referenced elements  
+        "global" attribute: itemref
+        Referenced elements
 
-        :param value: Unordered set of unique space-separated tokens consisting of IDs*  
-        :return: An itemref attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of IDs*
+
+        Returns:
+            An itemref attribute to be added to your element
+
+        """
 
         return BaseAttribute("itemref", value)
 
     @staticmethod
     def itemscope(value: bool) -> BaseAttribute:
         """
-        "global" attribute: itemscope  
-        Introduces a microdata item  
+        "global" attribute: itemscope
+        Introduces a microdata item
 
-        :param value: Boolean attribute  
-        :return: An itemscope attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An itemscope attribute to be added to your element
+
+        """
 
         return BaseAttribute("itemscope", value)
 
     @staticmethod
     def itemtype(value: Resolvable) -> BaseAttribute:
         """
-        "global" attribute: itemtype  
-        Item types of a microdata item  
+        "global" attribute: itemtype
+        Item types of a microdata item
 
-        :param value: Unordered set of unique space-separated tokens consisting of valid absolute URLs*  
-        :return: An itemtype attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+
+        Returns:
+            An itemtype attribute to be added to your element
+
+        """
 
         return BaseAttribute("itemtype", value)
 
     @staticmethod
     def lang(value) -> BaseAttribute:
         """
-        "global" attribute: lang  
-        Language of the element  
+        "global" attribute: lang
+        Language of the element
 
-        :param value: Valid BCP 47 language tag or the empty string  
-        :return: An lang attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid BCP 47 language tag or the empty string
+
+        Returns:
+            An lang attribute to be added to your element
+
+        """
 
         return BaseAttribute("lang", value)
 
     @staticmethod
     def nonce(value: StrLike) -> BaseAttribute:
         """
-        "global" attribute: nonce  
-        Cryptographic nonce used in Content Security Policy checks [CSP]  
+        "global" attribute: nonce
+        Cryptographic nonce used in Content Security Policy checks [CSP]
 
-        :param value: Text  
-        :return: An nonce attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An nonce attribute to be added to your element
+
+        """
 
         return BaseAttribute("nonce", value)
 
     @staticmethod
     def popover(value: Literal["auto", "manual"]) -> BaseAttribute:
         """
-        "global" attribute: popover  
-        Makes the element a popover element  
+        "global" attribute: popover
+        Makes the element a popover element
 
-        :param value: ['auto', 'manual']  
-        :return: An popover attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['auto', 'manual']
+
+        Returns:
+            An popover attribute to be added to your element
+
+        """
 
         return BaseAttribute("popover", value)
 
     @staticmethod
     def slot(value: StrLike) -> BaseAttribute:
         """
-        "global" attribute: slot  
-        The element's desired slot  
+        "global" attribute: slot
+        The element's desired slot
 
-        :param value: Text  
-        :return: An slot attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An slot attribute to be added to your element
+
+        """
 
         return BaseAttribute("slot", value)
 
     @staticmethod
     def spellcheck(value: Literal["true", "false", ""]) -> BaseAttribute:
         """
-        "global" attribute: spellcheck  
-        Whether the element is to have its spelling and grammar checked  
+        "global" attribute: spellcheck
+        Whether the element is to have its spelling and grammar checked
 
-        :param value: ['true', 'false', '']  
-        :return: An spellcheck attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['true', 'false', '']
+
+        Returns:
+            An spellcheck attribute to be added to your element
+
+        """
 
         return BaseAttribute("spellcheck", value)
 
     @staticmethod
     def style(value: Resolvable | Mapping[StrLike, StrLike]) -> BaseAttribute:
         """
-        "global" attribute: style  
-        Presentational and formatting instructions  
+        "global" attribute: style
+        Presentational and formatting instructions
 
-        :param value: CSS declarations*  
-        :return: An style attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                CSS declarations*
+
+        Returns:
+            An style attribute to be added to your element
+
+        """
 
         return BaseAttribute("style", value, delimiter="; ")
 
     @staticmethod
     def tabindex(value: int) -> BaseAttribute:
         """
-        "global" attribute: tabindex  
-        Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation  
+        "global" attribute: tabindex
+        Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
 
-        :param value: Valid integer  
-        :return: An tabindex attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid integer
+
+        Returns:
+            An tabindex attribute to be added to your element
+
+        """
 
         return BaseAttribute("tabindex", value)
 
     @staticmethod
     def title(value: StrLike) -> BaseAttribute:
         """
-        "global" attribute: title  
-        Advisory information for the element  
+        "global" attribute: title
+        Advisory information for the element
 
-        :param value: Text  
-        :return: An title attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An title attribute to be added to your element
+
+        """
 
         return BaseAttribute("title", value)
 
     @staticmethod
     def translate(value: Literal["yes", "no"]) -> BaseAttribute:
         """
-        "global" attribute: translate  
-        Whether the element is to be translated when the page is localized  
+        "global" attribute: translate
+        Whether the element is to be translated when the page is localized
 
-        :param value: ['yes', 'no']  
-        :return: An translate attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['yes', 'no']
+
+        Returns:
+            An translate attribute to be added to your element
+
+        """
 
         return BaseAttribute("translate", value)
 
@@ -369,851 +509,1206 @@ class GlobalAttrs:
         value: Literal["true", "false", ""],
     ) -> BaseAttribute:
         """
-        "global" attribute: writingsuggestions  
-        Whether the element can offer writing suggestions or not.  
+        "global" attribute: writingsuggestions
+        Whether the element can offer writing suggestions or not.
 
-        :param value: ['true', 'false', '']  
-        :return: An writingsuggestions attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['true', 'false', '']
+
+        Returns:
+            An writingsuggestions attribute to be added to your element
+
+        """
 
         return BaseAttribute("writingsuggestions", value)
 
     @staticmethod
     def onauxclick(value) -> BaseAttribute:
         """
-        "global" attribute: onauxclick  
-        auxclick event handler  
+        "global" attribute: onauxclick
+        auxclick event handler
 
-        :param value: Event handler content attribute  
-        :return: An onauxclick attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onauxclick attribute to be added to your element
+
+        """
 
         return BaseAttribute("onauxclick", value)
 
     @staticmethod
     def onbeforeinput(value) -> BaseAttribute:
         """
-        "global" attribute: onbeforeinput  
-        beforeinput event handler  
+        "global" attribute: onbeforeinput
+        beforeinput event handler
 
-        :param value: Event handler content attribute  
-        :return: An onbeforeinput attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onbeforeinput attribute to be added to your element
+
+        """
 
         return BaseAttribute("onbeforeinput", value)
 
     @staticmethod
     def onbeforematch(value) -> BaseAttribute:
         """
-        "global" attribute: onbeforematch  
-        beforematch event handler  
+        "global" attribute: onbeforematch
+        beforematch event handler
 
-        :param value: Event handler content attribute  
-        :return: An onbeforematch attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onbeforematch attribute to be added to your element
+
+        """
 
         return BaseAttribute("onbeforematch", value)
 
     @staticmethod
     def onbeforetoggle(value) -> BaseAttribute:
         """
-        "global" attribute: onbeforetoggle  
-        beforetoggle event handler  
+        "global" attribute: onbeforetoggle
+        beforetoggle event handler
 
-        :param value: Event handler content attribute  
-        :return: An onbeforetoggle attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onbeforetoggle attribute to be added to your element
+
+        """
 
         return BaseAttribute("onbeforetoggle", value)
 
     @staticmethod
     def onblur(value) -> BaseAttribute:
         """
-        "global" attribute: onblur  
-        blur event handler  
+        "global" attribute: onblur
+        blur event handler
 
-        :param value: Event handler content attribute  
-        :return: An onblur attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onblur attribute to be added to your element
+
+        """
 
         return BaseAttribute("onblur", value)
 
     @staticmethod
     def oncancel(value) -> BaseAttribute:
         """
-        "global" attribute: oncancel  
-        cancel event handler  
+        "global" attribute: oncancel
+        cancel event handler
 
-        :param value: Event handler content attribute  
-        :return: An oncancel attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oncancel attribute to be added to your element
+
+        """
 
         return BaseAttribute("oncancel", value)
 
     @staticmethod
     def oncanplay(value) -> BaseAttribute:
         """
-        "global" attribute: oncanplay  
-        canplay event handler  
+        "global" attribute: oncanplay
+        canplay event handler
 
-        :param value: Event handler content attribute  
-        :return: An oncanplay attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oncanplay attribute to be added to your element
+
+        """
 
         return BaseAttribute("oncanplay", value)
 
     @staticmethod
     def oncanplaythrough(value) -> BaseAttribute:
         """
-        "global" attribute: oncanplaythrough  
-        canplaythrough event handler  
+        "global" attribute: oncanplaythrough
+        canplaythrough event handler
 
-        :param value: Event handler content attribute  
-        :return: An oncanplaythrough attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oncanplaythrough attribute to be added to your element
+
+        """
 
         return BaseAttribute("oncanplaythrough", value)
 
     @staticmethod
     def onchange(value) -> BaseAttribute:
         """
-        "global" attribute: onchange  
-        change event handler  
+        "global" attribute: onchange
+        change event handler
 
-        :param value: Event handler content attribute  
-        :return: An onchange attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onchange attribute to be added to your element
+
+        """
 
         return BaseAttribute("onchange", value)
 
     @staticmethod
     def onclick(value) -> BaseAttribute:
         """
-        "global" attribute: onclick  
-        click event handler  
+        "global" attribute: onclick
+        click event handler
 
-        :param value: Event handler content attribute  
-        :return: An onclick attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onclick attribute to be added to your element
+
+        """
 
         return BaseAttribute("onclick", value)
 
     @staticmethod
     def onclose(value) -> BaseAttribute:
         """
-        "global" attribute: onclose  
-        close event handler  
+        "global" attribute: onclose
+        close event handler
 
-        :param value: Event handler content attribute  
-        :return: An onclose attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onclose attribute to be added to your element
+
+        """
 
         return BaseAttribute("onclose", value)
 
     @staticmethod
     def oncontextlost(value) -> BaseAttribute:
         """
-        "global" attribute: oncontextlost  
-        contextlost event handler  
+        "global" attribute: oncontextlost
+        contextlost event handler
 
-        :param value: Event handler content attribute  
-        :return: An oncontextlost attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oncontextlost attribute to be added to your element
+
+        """
 
         return BaseAttribute("oncontextlost", value)
 
     @staticmethod
     def oncontextmenu(value) -> BaseAttribute:
         """
-        "global" attribute: oncontextmenu  
-        contextmenu event handler  
+        "global" attribute: oncontextmenu
+        contextmenu event handler
 
-        :param value: Event handler content attribute  
-        :return: An oncontextmenu attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oncontextmenu attribute to be added to your element
+
+        """
 
         return BaseAttribute("oncontextmenu", value)
 
     @staticmethod
     def oncontextrestored(value) -> BaseAttribute:
         """
-        "global" attribute: oncontextrestored  
-        contextrestored event handler  
+        "global" attribute: oncontextrestored
+        contextrestored event handler
 
-        :param value: Event handler content attribute  
-        :return: An oncontextrestored attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oncontextrestored attribute to be added to your element
+
+        """
 
         return BaseAttribute("oncontextrestored", value)
 
     @staticmethod
     def oncopy(value) -> BaseAttribute:
         """
-        "global" attribute: oncopy  
-        copy event handler  
+        "global" attribute: oncopy
+        copy event handler
 
-        :param value: Event handler content attribute  
-        :return: An oncopy attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oncopy attribute to be added to your element
+
+        """
 
         return BaseAttribute("oncopy", value)
 
     @staticmethod
     def oncuechange(value) -> BaseAttribute:
         """
-        "global" attribute: oncuechange  
-        cuechange event handler  
+        "global" attribute: oncuechange
+        cuechange event handler
 
-        :param value: Event handler content attribute  
-        :return: An oncuechange attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oncuechange attribute to be added to your element
+
+        """
 
         return BaseAttribute("oncuechange", value)
 
     @staticmethod
     def oncut(value) -> BaseAttribute:
         """
-        "global" attribute: oncut  
-        cut event handler  
+        "global" attribute: oncut
+        cut event handler
 
-        :param value: Event handler content attribute  
-        :return: An oncut attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oncut attribute to be added to your element
+
+        """
 
         return BaseAttribute("oncut", value)
 
     @staticmethod
     def ondblclick(value) -> BaseAttribute:
         """
-        "global" attribute: ondblclick  
-        dblclick event handler  
+        "global" attribute: ondblclick
+        dblclick event handler
 
-        :param value: Event handler content attribute  
-        :return: An ondblclick attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ondblclick attribute to be added to your element
+
+        """
 
         return BaseAttribute("ondblclick", value)
 
     @staticmethod
     def ondrag(value) -> BaseAttribute:
         """
-        "global" attribute: ondrag  
-        drag event handler  
+        "global" attribute: ondrag
+        drag event handler
 
-        :param value: Event handler content attribute  
-        :return: An ondrag attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ondrag attribute to be added to your element
+
+        """
 
         return BaseAttribute("ondrag", value)
 
     @staticmethod
     def ondragend(value) -> BaseAttribute:
         """
-        "global" attribute: ondragend  
-        dragend event handler  
+        "global" attribute: ondragend
+        dragend event handler
 
-        :param value: Event handler content attribute  
-        :return: An ondragend attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ondragend attribute to be added to your element
+
+        """
 
         return BaseAttribute("ondragend", value)
 
     @staticmethod
     def ondragenter(value) -> BaseAttribute:
         """
-        "global" attribute: ondragenter  
-        dragenter event handler  
+        "global" attribute: ondragenter
+        dragenter event handler
 
-        :param value: Event handler content attribute  
-        :return: An ondragenter attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ondragenter attribute to be added to your element
+
+        """
 
         return BaseAttribute("ondragenter", value)
 
     @staticmethod
     def ondragleave(value) -> BaseAttribute:
         """
-        "global" attribute: ondragleave  
-        dragleave event handler  
+        "global" attribute: ondragleave
+        dragleave event handler
 
-        :param value: Event handler content attribute  
-        :return: An ondragleave attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ondragleave attribute to be added to your element
+
+        """
 
         return BaseAttribute("ondragleave", value)
 
     @staticmethod
     def ondragover(value) -> BaseAttribute:
         """
-        "global" attribute: ondragover  
-        dragover event handler  
+        "global" attribute: ondragover
+        dragover event handler
 
-        :param value: Event handler content attribute  
-        :return: An ondragover attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ondragover attribute to be added to your element
+
+        """
 
         return BaseAttribute("ondragover", value)
 
     @staticmethod
     def ondragstart(value) -> BaseAttribute:
         """
-        "global" attribute: ondragstart  
-        dragstart event handler  
+        "global" attribute: ondragstart
+        dragstart event handler
 
-        :param value: Event handler content attribute  
-        :return: An ondragstart attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ondragstart attribute to be added to your element
+
+        """
 
         return BaseAttribute("ondragstart", value)
 
     @staticmethod
     def ondrop(value) -> BaseAttribute:
         """
-        "global" attribute: ondrop  
-        drop event handler  
+        "global" attribute: ondrop
+        drop event handler
 
-        :param value: Event handler content attribute  
-        :return: An ondrop attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ondrop attribute to be added to your element
+
+        """
 
         return BaseAttribute("ondrop", value)
 
     @staticmethod
     def ondurationchange(value) -> BaseAttribute:
         """
-        "global" attribute: ondurationchange  
-        durationchange event handler  
+        "global" attribute: ondurationchange
+        durationchange event handler
 
-        :param value: Event handler content attribute  
-        :return: An ondurationchange attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ondurationchange attribute to be added to your element
+
+        """
 
         return BaseAttribute("ondurationchange", value)
 
     @staticmethod
     def onemptied(value) -> BaseAttribute:
         """
-        "global" attribute: onemptied  
-        emptied event handler  
+        "global" attribute: onemptied
+        emptied event handler
 
-        :param value: Event handler content attribute  
-        :return: An onemptied attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onemptied attribute to be added to your element
+
+        """
 
         return BaseAttribute("onemptied", value)
 
     @staticmethod
     def onended(value) -> BaseAttribute:
         """
-        "global" attribute: onended  
-        ended event handler  
+        "global" attribute: onended
+        ended event handler
 
-        :param value: Event handler content attribute  
-        :return: An onended attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onended attribute to be added to your element
+
+        """
 
         return BaseAttribute("onended", value)
 
     @staticmethod
     def onerror(value) -> BaseAttribute:
         """
-        "global" attribute: onerror  
-        error event handler  
+        "global" attribute: onerror
+        error event handler
 
-        :param value: Event handler content attribute  
-        :return: An onerror attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onerror attribute to be added to your element
+
+        """
 
         return BaseAttribute("onerror", value)
 
     @staticmethod
     def onfocus(value) -> BaseAttribute:
         """
-        "global" attribute: onfocus  
-        focus event handler  
+        "global" attribute: onfocus
+        focus event handler
 
-        :param value: Event handler content attribute  
-        :return: An onfocus attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onfocus attribute to be added to your element
+
+        """
 
         return BaseAttribute("onfocus", value)
 
     @staticmethod
     def onformdata(value) -> BaseAttribute:
         """
-        "global" attribute: onformdata  
-        formdata event handler  
+        "global" attribute: onformdata
+        formdata event handler
 
-        :param value: Event handler content attribute  
-        :return: An onformdata attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onformdata attribute to be added to your element
+
+        """
 
         return BaseAttribute("onformdata", value)
 
     @staticmethod
     def oninput(value) -> BaseAttribute:
         """
-        "global" attribute: oninput  
-        input event handler  
+        "global" attribute: oninput
+        input event handler
 
-        :param value: Event handler content attribute  
-        :return: An oninput attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oninput attribute to be added to your element
+
+        """
 
         return BaseAttribute("oninput", value)
 
     @staticmethod
     def oninvalid(value) -> BaseAttribute:
         """
-        "global" attribute: oninvalid  
-        invalid event handler  
+        "global" attribute: oninvalid
+        invalid event handler
 
-        :param value: Event handler content attribute  
-        :return: An oninvalid attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An oninvalid attribute to be added to your element
+
+        """
 
         return BaseAttribute("oninvalid", value)
 
     @staticmethod
     def onkeydown(value) -> BaseAttribute:
         """
-        "global" attribute: onkeydown  
-        keydown event handler  
+        "global" attribute: onkeydown
+        keydown event handler
 
-        :param value: Event handler content attribute  
-        :return: An onkeydown attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onkeydown attribute to be added to your element
+
+        """
 
         return BaseAttribute("onkeydown", value)
 
     @staticmethod
     def onkeypress(value) -> BaseAttribute:
         """
-        "global" attribute: onkeypress  
-        keypress event handler  
+        "global" attribute: onkeypress
+        keypress event handler
 
-        :param value: Event handler content attribute  
-        :return: An onkeypress attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onkeypress attribute to be added to your element
+
+        """
 
         return BaseAttribute("onkeypress", value)
 
     @staticmethod
     def onkeyup(value) -> BaseAttribute:
         """
-        "global" attribute: onkeyup  
-        keyup event handler  
+        "global" attribute: onkeyup
+        keyup event handler
 
-        :param value: Event handler content attribute  
-        :return: An onkeyup attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onkeyup attribute to be added to your element
+
+        """
 
         return BaseAttribute("onkeyup", value)
 
     @staticmethod
     def onload(value) -> BaseAttribute:
         """
-        "global" attribute: onload  
-        load event handler  
+        "global" attribute: onload
+        load event handler
 
-        :param value: Event handler content attribute  
-        :return: An onload attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onload attribute to be added to your element
+
+        """
 
         return BaseAttribute("onload", value)
 
     @staticmethod
     def onloadeddata(value) -> BaseAttribute:
         """
-        "global" attribute: onloadeddata  
-        loadeddata event handler  
+        "global" attribute: onloadeddata
+        loadeddata event handler
 
-        :param value: Event handler content attribute  
-        :return: An onloadeddata attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onloadeddata attribute to be added to your element
+
+        """
 
         return BaseAttribute("onloadeddata", value)
 
     @staticmethod
     def onloadedmetadata(value) -> BaseAttribute:
         """
-        "global" attribute: onloadedmetadata  
-        loadedmetadata event handler  
+        "global" attribute: onloadedmetadata
+        loadedmetadata event handler
 
-        :param value: Event handler content attribute  
-        :return: An onloadedmetadata attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onloadedmetadata attribute to be added to your element
+
+        """
 
         return BaseAttribute("onloadedmetadata", value)
 
     @staticmethod
     def onloadstart(value) -> BaseAttribute:
         """
-        "global" attribute: onloadstart  
-        loadstart event handler  
+        "global" attribute: onloadstart
+        loadstart event handler
 
-        :param value: Event handler content attribute  
-        :return: An onloadstart attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onloadstart attribute to be added to your element
+
+        """
 
         return BaseAttribute("onloadstart", value)
 
     @staticmethod
     def onmousedown(value) -> BaseAttribute:
         """
-        "global" attribute: onmousedown  
-        mousedown event handler  
+        "global" attribute: onmousedown
+        mousedown event handler
 
-        :param value: Event handler content attribute  
-        :return: An onmousedown attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onmousedown attribute to be added to your element
+
+        """
 
         return BaseAttribute("onmousedown", value)
 
     @staticmethod
     def onmouseenter(value) -> BaseAttribute:
         """
-        "global" attribute: onmouseenter  
-        mouseenter event handler  
+        "global" attribute: onmouseenter
+        mouseenter event handler
 
-        :param value: Event handler content attribute  
-        :return: An onmouseenter attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onmouseenter attribute to be added to your element
+
+        """
 
         return BaseAttribute("onmouseenter", value)
 
     @staticmethod
     def onmouseleave(value) -> BaseAttribute:
         """
-        "global" attribute: onmouseleave  
-        mouseleave event handler  
+        "global" attribute: onmouseleave
+        mouseleave event handler
 
-        :param value: Event handler content attribute  
-        :return: An onmouseleave attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onmouseleave attribute to be added to your element
+
+        """
 
         return BaseAttribute("onmouseleave", value)
 
     @staticmethod
     def onmousemove(value) -> BaseAttribute:
         """
-        "global" attribute: onmousemove  
-        mousemove event handler  
+        "global" attribute: onmousemove
+        mousemove event handler
 
-        :param value: Event handler content attribute  
-        :return: An onmousemove attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onmousemove attribute to be added to your element
+
+        """
 
         return BaseAttribute("onmousemove", value)
 
     @staticmethod
     def onmouseout(value) -> BaseAttribute:
         """
-        "global" attribute: onmouseout  
-        mouseout event handler  
+        "global" attribute: onmouseout
+        mouseout event handler
 
-        :param value: Event handler content attribute  
-        :return: An onmouseout attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onmouseout attribute to be added to your element
+
+        """
 
         return BaseAttribute("onmouseout", value)
 
     @staticmethod
     def onmouseover(value) -> BaseAttribute:
         """
-        "global" attribute: onmouseover  
-        mouseover event handler  
+        "global" attribute: onmouseover
+        mouseover event handler
 
-        :param value: Event handler content attribute  
-        :return: An onmouseover attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onmouseover attribute to be added to your element
+
+        """
 
         return BaseAttribute("onmouseover", value)
 
     @staticmethod
     def onmouseup(value) -> BaseAttribute:
         """
-        "global" attribute: onmouseup  
-        mouseup event handler  
+        "global" attribute: onmouseup
+        mouseup event handler
 
-        :param value: Event handler content attribute  
-        :return: An onmouseup attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onmouseup attribute to be added to your element
+
+        """
 
         return BaseAttribute("onmouseup", value)
 
     @staticmethod
     def onpaste(value) -> BaseAttribute:
         """
-        "global" attribute: onpaste  
-        paste event handler  
+        "global" attribute: onpaste
+        paste event handler
 
-        :param value: Event handler content attribute  
-        :return: An onpaste attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onpaste attribute to be added to your element
+
+        """
 
         return BaseAttribute("onpaste", value)
 
     @staticmethod
     def onpause(value) -> BaseAttribute:
         """
-        "global" attribute: onpause  
-        pause event handler  
+        "global" attribute: onpause
+        pause event handler
 
-        :param value: Event handler content attribute  
-        :return: An onpause attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onpause attribute to be added to your element
+
+        """
 
         return BaseAttribute("onpause", value)
 
     @staticmethod
     def onplay(value) -> BaseAttribute:
         """
-        "global" attribute: onplay  
-        play event handler  
+        "global" attribute: onplay
+        play event handler
 
-        :param value: Event handler content attribute  
-        :return: An onplay attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onplay attribute to be added to your element
+
+        """
 
         return BaseAttribute("onplay", value)
 
     @staticmethod
     def onplaying(value) -> BaseAttribute:
         """
-        "global" attribute: onplaying  
-        playing event handler  
+        "global" attribute: onplaying
+        playing event handler
 
-        :param value: Event handler content attribute  
-        :return: An onplaying attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onplaying attribute to be added to your element
+
+        """
 
         return BaseAttribute("onplaying", value)
 
     @staticmethod
     def onprogress(value) -> BaseAttribute:
         """
-        "global" attribute: onprogress  
-        progress event handler  
+        "global" attribute: onprogress
+        progress event handler
 
-        :param value: Event handler content attribute  
-        :return: An onprogress attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onprogress attribute to be added to your element
+
+        """
 
         return BaseAttribute("onprogress", value)
 
     @staticmethod
     def onratechange(value) -> BaseAttribute:
         """
-        "global" attribute: onratechange  
-        ratechange event handler  
+        "global" attribute: onratechange
+        ratechange event handler
 
-        :param value: Event handler content attribute  
-        :return: An onratechange attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onratechange attribute to be added to your element
+
+        """
 
         return BaseAttribute("onratechange", value)
 
     @staticmethod
     def onreset(value) -> BaseAttribute:
         """
-        "global" attribute: onreset  
-        reset event handler  
+        "global" attribute: onreset
+        reset event handler
 
-        :param value: Event handler content attribute  
-        :return: An onreset attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onreset attribute to be added to your element
+
+        """
 
         return BaseAttribute("onreset", value)
 
     @staticmethod
     def onresize(value) -> BaseAttribute:
         """
-        "global" attribute: onresize  
-        resize event handler  
+        "global" attribute: onresize
+        resize event handler
 
-        :param value: Event handler content attribute  
-        :return: An onresize attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onresize attribute to be added to your element
+
+        """
 
         return BaseAttribute("onresize", value)
 
     @staticmethod
     def onscroll(value) -> BaseAttribute:
         """
-        "global" attribute: onscroll  
-        scroll event handler  
+        "global" attribute: onscroll
+        scroll event handler
 
-        :param value: Event handler content attribute  
-        :return: An onscroll attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onscroll attribute to be added to your element
+
+        """
 
         return BaseAttribute("onscroll", value)
 
     @staticmethod
     def onscrollend(value) -> BaseAttribute:
         """
-        "global" attribute: onscrollend  
-        scrollend event handler  
+        "global" attribute: onscrollend
+        scrollend event handler
 
-        :param value: Event handler content attribute  
-        :return: An onscrollend attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onscrollend attribute to be added to your element
+
+        """
 
         return BaseAttribute("onscrollend", value)
 
     @staticmethod
     def onsecuritypolicyviolation(value) -> BaseAttribute:
         """
-        "global" attribute: onsecuritypolicyviolation  
-        securitypolicyviolation event handler  
+        "global" attribute: onsecuritypolicyviolation
+        securitypolicyviolation event handler
 
-        :param value: Event handler content attribute  
-        :return: An onsecuritypolicyviolation attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onsecuritypolicyviolation attribute to be added to your element
+
+        """
 
         return BaseAttribute("onsecuritypolicyviolation", value)
 
     @staticmethod
     def onseeked(value) -> BaseAttribute:
         """
-        "global" attribute: onseeked  
-        seeked event handler  
+        "global" attribute: onseeked
+        seeked event handler
 
-        :param value: Event handler content attribute  
-        :return: An onseeked attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onseeked attribute to be added to your element
+
+        """
 
         return BaseAttribute("onseeked", value)
 
     @staticmethod
     def onseeking(value) -> BaseAttribute:
         """
-        "global" attribute: onseeking  
-        seeking event handler  
+        "global" attribute: onseeking
+        seeking event handler
 
-        :param value: Event handler content attribute  
-        :return: An onseeking attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onseeking attribute to be added to your element
+
+        """
 
         return BaseAttribute("onseeking", value)
 
     @staticmethod
     def onselect(value) -> BaseAttribute:
         """
-        "global" attribute: onselect  
-        select event handler  
+        "global" attribute: onselect
+        select event handler
 
-        :param value: Event handler content attribute  
-        :return: An onselect attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onselect attribute to be added to your element
+
+        """
 
         return BaseAttribute("onselect", value)
 
     @staticmethod
     def onslotchange(value) -> BaseAttribute:
         """
-        "global" attribute: onslotchange  
-        slotchange event handler  
+        "global" attribute: onslotchange
+        slotchange event handler
 
-        :param value: Event handler content attribute  
-        :return: An onslotchange attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onslotchange attribute to be added to your element
+
+        """
 
         return BaseAttribute("onslotchange", value)
 
     @staticmethod
     def onstalled(value) -> BaseAttribute:
         """
-        "global" attribute: onstalled  
-        stalled event handler  
+        "global" attribute: onstalled
+        stalled event handler
 
-        :param value: Event handler content attribute  
-        :return: An onstalled attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onstalled attribute to be added to your element
+
+        """
 
         return BaseAttribute("onstalled", value)
 
     @staticmethod
     def onsubmit(value) -> BaseAttribute:
         """
-        "global" attribute: onsubmit  
-        submit event handler  
+        "global" attribute: onsubmit
+        submit event handler
 
-        :param value: Event handler content attribute  
-        :return: An onsubmit attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onsubmit attribute to be added to your element
+
+        """
 
         return BaseAttribute("onsubmit", value)
 
     @staticmethod
     def onsuspend(value) -> BaseAttribute:
         """
-        "global" attribute: onsuspend  
-        suspend event handler  
+        "global" attribute: onsuspend
+        suspend event handler
 
-        :param value: Event handler content attribute  
-        :return: An onsuspend attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onsuspend attribute to be added to your element
+
+        """
 
         return BaseAttribute("onsuspend", value)
 
     @staticmethod
     def ontimeupdate(value) -> BaseAttribute:
         """
-        "global" attribute: ontimeupdate  
-        timeupdate event handler  
+        "global" attribute: ontimeupdate
+        timeupdate event handler
 
-        :param value: Event handler content attribute  
-        :return: An ontimeupdate attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ontimeupdate attribute to be added to your element
+
+        """
 
         return BaseAttribute("ontimeupdate", value)
 
     @staticmethod
     def ontoggle(value) -> BaseAttribute:
         """
-        "global" attribute: ontoggle  
-        toggle event handler  
+        "global" attribute: ontoggle
+        toggle event handler
 
-        :param value: Event handler content attribute  
-        :return: An ontoggle attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An ontoggle attribute to be added to your element
+
+        """
 
         return BaseAttribute("ontoggle", value)
 
     @staticmethod
     def onvolumechange(value) -> BaseAttribute:
         """
-        "global" attribute: onvolumechange  
-        volumechange event handler  
+        "global" attribute: onvolumechange
+        volumechange event handler
 
-        :param value: Event handler content attribute  
-        :return: An onvolumechange attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onvolumechange attribute to be added to your element
+
+        """
 
         return BaseAttribute("onvolumechange", value)
 
     @staticmethod
     def onwaiting(value) -> BaseAttribute:
         """
-        "global" attribute: onwaiting  
-        waiting event handler  
+        "global" attribute: onwaiting
+        waiting event handler
 
-        :param value: Event handler content attribute  
-        :return: An onwaiting attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onwaiting attribute to be added to your element
+
+        """
 
         return BaseAttribute("onwaiting", value)
 
     @staticmethod
     def onwheel(value) -> BaseAttribute:
         """
-        "global" attribute: onwheel  
-        wheel event handler  
+        "global" attribute: onwheel
+        wheel event handler
 
-        :param value: Event handler content attribute  
-        :return: An onwheel attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+
+        Returns:
+            An onwheel attribute to be added to your element
+
+        """
 
         return BaseAttribute("onwheel", value)

--- a/src/html_compose/attributes/iframe_attrs.py
+++ b/src/html_compose/attributes/iframe_attrs.py
@@ -12,119 +12,169 @@ class IframeAttrs:
     @staticmethod
     def allow(value) -> BaseAttribute:
         """
-        "iframe" attribute: allow  
-        Permissions policy to be applied to the iframe's contents  
+        "iframe" attribute: allow
+        Permissions policy to be applied to the iframe's contents
 
-        :param value: Serialized permissions policy  
-        :return: An allow attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Serialized permissions policy
+
+        Returns:
+            An allow attribute to be added to your element
+
+        """
 
         return BaseAttribute("allow", value)
 
     @staticmethod
     def allowfullscreen(value: bool) -> BaseAttribute:
         """
-        "iframe" attribute: allowfullscreen  
-        Whether to allow the iframe's contents to use requestFullscreen()  
+        "iframe" attribute: allowfullscreen
+        Whether to allow the iframe's contents to use requestFullscreen()
 
-        :param value: Boolean attribute  
-        :return: An allowfullscreen attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An allowfullscreen attribute to be added to your element
+
+        """
 
         return BaseAttribute("allowfullscreen", value)
 
     @staticmethod
     def height(value: int) -> BaseAttribute:
         """
-        "iframe" attribute: height  
-        Vertical dimension  
+        "iframe" attribute: height
+        Vertical dimension
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An height attribute to be added to your element
+
+        """
 
         return BaseAttribute("height", value)
 
     @staticmethod
     def loading(value: Literal["lazy", "eager"]) -> BaseAttribute:
         """
-        "iframe" attribute: loading  
-        Used when determining loading deferral  
+        "iframe" attribute: loading
+        Used when determining loading deferral
 
-        :param value: ['lazy', 'eager']  
-        :return: An loading attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['lazy', 'eager']
+
+        Returns:
+            An loading attribute to be added to your element
+
+        """
 
         return BaseAttribute("loading", value)
 
     @staticmethod
     def name(value) -> BaseAttribute:
         """
-        "iframe" attribute: name  
-        Name of content navigable  
+        "iframe" attribute: name
+        Name of content navigable
 
-        :param value: Valid navigable target name or keyword  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)
 
     @staticmethod
     def referrerpolicy(value) -> BaseAttribute:
         """
-        "iframe" attribute: referrerpolicy  
-        Referrer policy for fetches initiated by the element  
+        "iframe" attribute: referrerpolicy
+        Referrer policy for fetches initiated by the element
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Referrer policy
+
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
 
         return BaseAttribute("referrerpolicy", value)
 
     @staticmethod
     def sandbox(value: Resolvable) -> BaseAttribute:
         """
-        "iframe" attribute: sandbox  
-        Security rules for nested content  
+        "iframe" attribute: sandbox
+        Security rules for nested content
 
-        :param value: Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of "allow-downloads" "allow-forms" "allow-modals" "allow-orientation-lock" "allow-pointer-lock" "allow-popups" "allow-popups-to-escape-sandbox" "allow-presentation" "allow-same-origin" "allow-scripts" "allow-top-navigation" "allow-top-navigation-by-user-activation" "allow-top-navigation-to-custom-protocols"  
-        :return: An sandbox attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of "allow-downloads" "allow-forms" "allow-modals" "allow-orientation-lock" "allow-pointer-lock" "allow-popups" "allow-popups-to-escape-sandbox" "allow-presentation" "allow-same-origin" "allow-scripts" "allow-top-navigation" "allow-top-navigation-by-user-activation" "allow-top-navigation-to-custom-protocols"
+
+        Returns:
+            An sandbox attribute to be added to your element
+
+        """
 
         return BaseAttribute("sandbox", value)
 
     @staticmethod
     def src(value) -> BaseAttribute:
         """
-        "iframe" attribute: src  
-        Address of the resource  
+        "iframe" attribute: src
+        Address of the resource
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An src attribute to be added to your element
+
+        """
 
         return BaseAttribute("src", value)
 
     @staticmethod
     def srcdoc(value) -> BaseAttribute:
         """
-        "iframe" attribute: srcdoc  
-        A document to render in the iframe  
+        "iframe" attribute: srcdoc
+        A document to render in the iframe
 
-        :param value: The source of an iframe srcdoc document*  
-        :return: An srcdoc attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                The source of an iframe srcdoc document*
+
+        Returns:
+            An srcdoc attribute to be added to your element
+
+        """
 
         return BaseAttribute("srcdoc", value)
 
     @staticmethod
     def width(value: int) -> BaseAttribute:
         """
-        "iframe" attribute: width  
-        Horizontal dimension  
+        "iframe" attribute: width
+        Horizontal dimension
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An width attribute to be added to your element
+
+        """
 
         return BaseAttribute("width", value)

--- a/src/html_compose/attributes/img_attrs.py
+++ b/src/html_compose/attributes/img_attrs.py
@@ -12,12 +12,17 @@ class ImgAttrs:
     @staticmethod
     def alt(value: StrLike) -> BaseAttribute:
         """
-        "img" attribute: alt  
-        Replacement text for use when images are not available  
+        "img" attribute: alt
+        Replacement text for use when images are not available
 
-        :param value: Text*  
-        :return: An alt attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An alt attribute to be added to your element
+
+        """
 
         return BaseAttribute("alt", value)
 
@@ -26,143 +31,203 @@ class ImgAttrs:
         value: Literal["anonymous", "use-credentials"],
     ) -> BaseAttribute:
         """
-        "img" attribute: crossorigin  
-        How the element handles crossorigin requests  
+        "img" attribute: crossorigin
+        How the element handles crossorigin requests
 
-        :param value: ['anonymous', 'use-credentials']  
-        :return: An crossorigin attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['anonymous', 'use-credentials']
+
+        Returns:
+            An crossorigin attribute to be added to your element
+
+        """
 
         return BaseAttribute("crossorigin", value)
 
     @staticmethod
     def decoding(value: Literal["sync", "async", "auto"]) -> BaseAttribute:
         """
-        "img" attribute: decoding  
-        Decoding hint to use when processing this image for presentation  
+        "img" attribute: decoding
+        Decoding hint to use when processing this image for presentation
 
-        :param value: ['sync', 'async', 'auto']  
-        :return: An decoding attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['sync', 'async', 'auto']
+
+        Returns:
+            An decoding attribute to be added to your element
+
+        """
 
         return BaseAttribute("decoding", value)
 
     @staticmethod
     def fetchpriority(value: Literal["auto", "high", "low"]) -> BaseAttribute:
         """
-        "img" attribute: fetchpriority  
-        Sets the priority for fetches initiated by the element  
+        "img" attribute: fetchpriority
+        Sets the priority for fetches initiated by the element
 
-        :param value: ['auto', 'high', 'low']  
-        :return: An fetchpriority attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['auto', 'high', 'low']
+
+        Returns:
+            An fetchpriority attribute to be added to your element
+
+        """
 
         return BaseAttribute("fetchpriority", value)
 
     @staticmethod
     def height(value: int) -> BaseAttribute:
         """
-        "img" attribute: height  
-        Vertical dimension  
+        "img" attribute: height
+        Vertical dimension
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An height attribute to be added to your element
+
+        """
 
         return BaseAttribute("height", value)
 
     @staticmethod
     def ismap(value: bool) -> BaseAttribute:
         """
-        "img" attribute: ismap  
-        Whether the image is a server-side image map  
+        "img" attribute: ismap
+        Whether the image is a server-side image map
 
-        :param value: Boolean attribute  
-        :return: An ismap attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An ismap attribute to be added to your element
+
+        """
 
         return BaseAttribute("ismap", value)
 
     @staticmethod
     def loading(value: Literal["lazy", "eager"]) -> BaseAttribute:
         """
-        "img" attribute: loading  
-        Used when determining loading deferral  
+        "img" attribute: loading
+        Used when determining loading deferral
 
-        :param value: ['lazy', 'eager']  
-        :return: An loading attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['lazy', 'eager']
+
+        Returns:
+            An loading attribute to be added to your element
+
+        """
 
         return BaseAttribute("loading", value)
 
     @staticmethod
     def referrerpolicy(value) -> BaseAttribute:
         """
-        "img" attribute: referrerpolicy  
-        Referrer policy for fetches initiated by the element  
+        "img" attribute: referrerpolicy
+        Referrer policy for fetches initiated by the element
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Referrer policy
+
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
 
         return BaseAttribute("referrerpolicy", value)
 
     @staticmethod
     def sizes(value) -> BaseAttribute:
         """
-        "img" attribute: sizes  
-        Image sizes for different page layouts  
+        "img" attribute: sizes
+        Image sizes for different page layouts
 
-        :param value: Valid source size list  
-        :return: An sizes attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid source size list
+
+        Returns:
+            An sizes attribute to be added to your element
+
+        """
 
         return BaseAttribute("sizes", value)
 
     @staticmethod
     def src(value) -> BaseAttribute:
         """
-        "img" attribute: src  
-        Address of the resource  
+        "img" attribute: src
+        Address of the resource
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An src attribute to be added to your element
+
+        """
 
         return BaseAttribute("src", value)
 
     @staticmethod
     def srcset(value) -> BaseAttribute:
         """
-        "img" attribute: srcset  
-        Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
+        "img" attribute: srcset
+        Images to use in different situations, e.g., high-resolution displays, small monitors, etc.
 
-        :param value: Comma-separated list of image candidate strings  
-        :return: An srcset attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Comma-separated list of image candidate strings
+
+        Returns:
+            An srcset attribute to be added to your element
+
+        """
 
         return BaseAttribute("srcset", value)
 
     @staticmethod
     def usemap(value) -> BaseAttribute:
         """
-        "img" attribute: usemap  
-        Name of image map to use  
+        "img" attribute: usemap
+        Name of image map to use
 
-        :param value: Valid hash-name reference*  
-        :return: An usemap attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid hash-name reference*
+
+        Returns:
+            An usemap attribute to be added to your element
+
+        """
 
         return BaseAttribute("usemap", value)
 
     @staticmethod
     def width(value: int) -> BaseAttribute:
         """
-        "img" attribute: width  
-        Horizontal dimension  
+        "img" attribute: width
+        Horizontal dimension
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An width attribute to be added to your element
+
+        """
 
         return BaseAttribute("width", value)

--- a/src/html_compose/attributes/input_attrs.py
+++ b/src/html_compose/attributes/input_attrs.py
@@ -12,60 +12,85 @@ class InputAttrs:
     @staticmethod
     def accept(value) -> BaseAttribute:
         """
-        "input" attribute: accept  
-        Hint for expected file type in file upload controls  
+        "input" attribute: accept
+        Hint for expected file type in file upload controls
 
-        :param value: Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*  
-        :return: An accept attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*
+
+        Returns:
+            An accept attribute to be added to your element
+
+        """
 
         return BaseAttribute("accept", value)
 
     @staticmethod
     def alpha(value: bool) -> BaseAttribute:
         """
-        "input" attribute: alpha  
-        Allow the color's alpha component to be set  
+        "input" attribute: alpha
+        Allow the color's alpha component to be set
 
-        :param value: Boolean attribute  
-        :return: An alpha attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An alpha attribute to be added to your element
+
+        """
 
         return BaseAttribute("alpha", value)
 
     @staticmethod
     def alt(value: StrLike) -> BaseAttribute:
         """
-        "input" attribute: alt  
-        Replacement text for use when images are not available  
+        "input" attribute: alt
+        Replacement text for use when images are not available
 
-        :param value: Text*  
-        :return: An alt attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An alt attribute to be added to your element
+
+        """
 
         return BaseAttribute("alt", value)
 
     @staticmethod
     def autocomplete(value) -> BaseAttribute:
         """
-        "input" attribute: autocomplete  
-        Hint for form autofill feature  
+        "input" attribute: autocomplete
+        Hint for form autofill feature
 
-        :param value: Autofill field name and related tokens*  
-        :return: An autocomplete attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Autofill field name and related tokens*
+
+        Returns:
+            An autocomplete attribute to be added to your element
+
+        """
 
         return BaseAttribute("autocomplete", value)
 
     @staticmethod
     def checked(value: bool) -> BaseAttribute:
         """
-        "input" attribute: checked  
-        Whether the control is checked  
+        "input" attribute: checked
+        Whether the control is checked
 
-        :param value: Boolean attribute  
-        :return: An checked attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An checked attribute to be added to your element
+
+        """
 
         return BaseAttribute("checked", value)
 
@@ -74,60 +99,85 @@ class InputAttrs:
         value: Literal["limited-srgb", "display-p3"],
     ) -> BaseAttribute:
         """
-        "input" attribute: colorspace  
-        The color space of the serialized color  
+        "input" attribute: colorspace
+        The color space of the serialized color
 
-        :param value: ['limited-srgb', 'display-p3']  
-        :return: An colorspace attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['limited-srgb', 'display-p3']
+
+        Returns:
+            An colorspace attribute to be added to your element
+
+        """
 
         return BaseAttribute("colorspace", value)
 
     @staticmethod
     def dirname(value: StrLike) -> BaseAttribute:
         """
-        "input" attribute: dirname  
-        Name of form control to use for sending the element's directionality in form submission  
+        "input" attribute: dirname
+        Name of form control to use for sending the element's directionality in form submission
 
-        :param value: Text*  
-        :return: An dirname attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An dirname attribute to be added to your element
+
+        """
 
         return BaseAttribute("dirname", value)
 
     @staticmethod
     def disabled(value: bool) -> BaseAttribute:
         """
-        "input" attribute: disabled  
-        Whether the form control is disabled  
+        "input" attribute: disabled
+        Whether the form control is disabled
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
 
         return BaseAttribute("disabled", value)
 
     @staticmethod
     def form(value) -> BaseAttribute:
         """
-        "input" attribute: form  
-        Associates the element with a form element  
+        "input" attribute: form
+        Associates the element with a form element
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An form attribute to be added to your element
+
+        """
 
         return BaseAttribute("form", value)
 
     @staticmethod
     def formaction(value) -> BaseAttribute:
         """
-        "input" attribute: formaction  
-        URL to use for form submission  
+        "input" attribute: formaction
+        URL to use for form submission
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An formaction attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An formaction attribute to be added to your element
+
+        """
 
         return BaseAttribute("formaction", value)
 
@@ -140,180 +190,255 @@ class InputAttrs:
         ],
     ) -> BaseAttribute:
         """
-        "input" attribute: formenctype  
-        Entry list encoding type to use for form submission  
+        "input" attribute: formenctype
+        Entry list encoding type to use for form submission
 
-        :param value: ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']  
-        :return: An formenctype attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']
+
+        Returns:
+            An formenctype attribute to be added to your element
+
+        """
 
         return BaseAttribute("formenctype", value)
 
     @staticmethod
     def formmethod(value: Literal["GET", "POST", "dialog"]) -> BaseAttribute:
         """
-        "input" attribute: formmethod  
-        Variant to use for form submission  
+        "input" attribute: formmethod
+        Variant to use for form submission
 
-        :param value: ['GET', 'POST', 'dialog']  
-        :return: An formmethod attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['GET', 'POST', 'dialog']
+
+        Returns:
+            An formmethod attribute to be added to your element
+
+        """
 
         return BaseAttribute("formmethod", value)
 
     @staticmethod
     def formnovalidate(value: bool) -> BaseAttribute:
         """
-        "input" attribute: formnovalidate  
-        Bypass form control validation for form submission  
+        "input" attribute: formnovalidate
+        Bypass form control validation for form submission
 
-        :param value: Boolean attribute  
-        :return: An formnovalidate attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An formnovalidate attribute to be added to your element
+
+        """
 
         return BaseAttribute("formnovalidate", value)
 
     @staticmethod
     def formtarget(value) -> BaseAttribute:
         """
-        "input" attribute: formtarget  
-        Navigable for form submission  
+        "input" attribute: formtarget
+        Navigable for form submission
 
-        :param value: Valid navigable target name or keyword  
-        :return: An formtarget attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+
+        Returns:
+            An formtarget attribute to be added to your element
+
+        """
 
         return BaseAttribute("formtarget", value)
 
     @staticmethod
     def height(value: int) -> BaseAttribute:
         """
-        "input" attribute: height  
-        Vertical dimension  
+        "input" attribute: height
+        Vertical dimension
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An height attribute to be added to your element
+
+        """
 
         return BaseAttribute("height", value)
 
     @staticmethod
     def list(value) -> BaseAttribute:
         """
-        "input" attribute: list  
-        List of autocomplete options  
+        "input" attribute: list
+        List of autocomplete options
 
-        :param value: ID*  
-        :return: An list attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An list attribute to be added to your element
+
+        """
 
         return BaseAttribute("list", value)
 
     @staticmethod
     def max(value) -> BaseAttribute:
         """
-        "input" attribute: max  
-        Maximum value  
+        "input" attribute: max
+        Maximum value
 
-        :param value: Varies*  
-        :return: An max attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Varies*
+
+        Returns:
+            An max attribute to be added to your element
+
+        """
 
         return BaseAttribute("max", value)
 
     @staticmethod
     def maxlength(value: int) -> BaseAttribute:
         """
-        "input" attribute: maxlength  
-        Maximum length of value  
+        "input" attribute: maxlength
+        Maximum length of value
 
-        :param value: Valid non-negative integer  
-        :return: An maxlength attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An maxlength attribute to be added to your element
+
+        """
 
         return BaseAttribute("maxlength", value)
 
     @staticmethod
     def min(value) -> BaseAttribute:
         """
-        "input" attribute: min  
-        Minimum value  
+        "input" attribute: min
+        Minimum value
 
-        :param value: Varies*  
-        :return: An min attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Varies*
+
+        Returns:
+            An min attribute to be added to your element
+
+        """
 
         return BaseAttribute("min", value)
 
     @staticmethod
     def minlength(value: int) -> BaseAttribute:
         """
-        "input" attribute: minlength  
-        Minimum length of value  
+        "input" attribute: minlength
+        Minimum length of value
 
-        :param value: Valid non-negative integer  
-        :return: An minlength attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An minlength attribute to be added to your element
+
+        """
 
         return BaseAttribute("minlength", value)
 
     @staticmethod
     def multiple(value: bool) -> BaseAttribute:
         """
-        "input" attribute: multiple  
-        Whether to allow multiple values  
+        "input" attribute: multiple
+        Whether to allow multiple values
 
-        :param value: Boolean attribute  
-        :return: An multiple attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An multiple attribute to be added to your element
+
+        """
 
         return BaseAttribute("multiple", value)
 
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "input" attribute: name  
-        Name of the element to use for form submission and in the form.elements API  
+        "input" attribute: name
+        Name of the element to use for form submission and in the form.elements API
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)
 
     @staticmethod
     def pattern(value) -> BaseAttribute:
         """
-        "input" attribute: pattern  
-        Pattern to be matched by the form control's value  
+        "input" attribute: pattern
+        Pattern to be matched by the form control's value
 
-        :param value: Regular expression matching the JavaScript Pattern production  
-        :return: An pattern attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Regular expression matching the JavaScript Pattern production
+
+        Returns:
+            An pattern attribute to be added to your element
+
+        """
 
         return BaseAttribute("pattern", value)
 
     @staticmethod
     def placeholder(value: StrLike) -> BaseAttribute:
         """
-        "input" attribute: placeholder  
-        User-visible label to be placed within the form control  
+        "input" attribute: placeholder
+        User-visible label to be placed within the form control
 
-        :param value: Text*  
-        :return: An placeholder attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An placeholder attribute to be added to your element
+
+        """
 
         return BaseAttribute("placeholder", value)
 
     @staticmethod
     def popovertarget(value) -> BaseAttribute:
         """
-        "input" attribute: popovertarget  
-        Targets a popover element to toggle, show, or hide  
+        "input" attribute: popovertarget
+        Targets a popover element to toggle, show, or hide
 
-        :param value: ID*  
-        :return: An popovertarget attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An popovertarget attribute to be added to your element
+
+        """
 
         return BaseAttribute("popovertarget", value)
 
@@ -322,119 +447,169 @@ class InputAttrs:
         value: Literal["toggle", "show", "hide"],
     ) -> BaseAttribute:
         """
-        "input" attribute: popovertargetaction  
-        Indicates whether a targeted popover element is to be toggled, shown, or hidden  
+        "input" attribute: popovertargetaction
+        Indicates whether a targeted popover element is to be toggled, shown, or hidden
 
-        :param value: ['toggle', 'show', 'hide']  
-        :return: An popovertargetaction attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['toggle', 'show', 'hide']
+
+        Returns:
+            An popovertargetaction attribute to be added to your element
+
+        """
 
         return BaseAttribute("popovertargetaction", value)
 
     @staticmethod
     def readonly(value: bool) -> BaseAttribute:
         """
-        "input" attribute: readonly  
-        Whether to allow the value to be edited by the user  
+        "input" attribute: readonly
+        Whether to allow the value to be edited by the user
 
-        :param value: Boolean attribute  
-        :return: An readonly attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An readonly attribute to be added to your element
+
+        """
 
         return BaseAttribute("readonly", value)
 
     @staticmethod
     def required(value: bool) -> BaseAttribute:
         """
-        "input" attribute: required  
-        Whether the control is required for form submission  
+        "input" attribute: required
+        Whether the control is required for form submission
 
-        :param value: Boolean attribute  
-        :return: An required attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An required attribute to be added to your element
+
+        """
 
         return BaseAttribute("required", value)
 
     @staticmethod
     def size(value) -> BaseAttribute:
         """
-        "input" attribute: size  
-        Size of the control  
+        "input" attribute: size
+        Size of the control
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An size attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+
+        Returns:
+            An size attribute to be added to your element
+
+        """
 
         return BaseAttribute("size", value)
 
     @staticmethod
     def src(value) -> BaseAttribute:
         """
-        "input" attribute: src  
-        Address of the resource  
+        "input" attribute: src
+        Address of the resource
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An src attribute to be added to your element
+
+        """
 
         return BaseAttribute("src", value)
 
     @staticmethod
     def step(value: float) -> BaseAttribute:
         """
-        "input" attribute: step  
-        Granularity to be matched by the form control's value  
+        "input" attribute: step
+        Granularity to be matched by the form control's value
 
-        :param value: Valid floating-point number greater than zero, or "any"  
-        :return: An step attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid floating-point number greater than zero, or "any"
+
+        Returns:
+            An step attribute to be added to your element
+
+        """
 
         return BaseAttribute("step", value)
 
     @staticmethod
     def title(value: StrLike) -> BaseAttribute:
         """
-        "input" attribute: title  
-        Description of pattern (when used with pattern attribute)  
+        "input" attribute: title
+        Description of pattern (when used with pattern attribute)
 
-        :param value: Text  
-        :return: An title attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An title attribute to be added to your element
+
+        """
 
         return BaseAttribute("title", value)
 
     @staticmethod
     def type(value) -> BaseAttribute:
         """
-        "input" attribute: type  
-        Type of form control  
+        "input" attribute: type
+        Type of form control
 
-        :param value: input type keyword  
-        :return: An type attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                input type keyword
+
+        Returns:
+            An type attribute to be added to your element
+
+        """
 
         return BaseAttribute("type", value)
 
     @staticmethod
     def value(value) -> BaseAttribute:
         """
-        "input" attribute: value  
-        Value of the form control  
+        "input" attribute: value
+        Value of the form control
 
-        :param value: Varies*  
-        :return: An value attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Varies*
+
+        Returns:
+            An value attribute to be added to your element
+
+        """
 
         return BaseAttribute("value", value)
 
     @staticmethod
     def width(value: int) -> BaseAttribute:
         """
-        "input" attribute: width  
-        Horizontal dimension  
+        "input" attribute: width
+        Horizontal dimension
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An width attribute to be added to your element
+
+        """
 
         return BaseAttribute("width", value)

--- a/src/html_compose/attributes/ins_attrs.py
+++ b/src/html_compose/attributes/ins_attrs.py
@@ -10,23 +10,33 @@ class InsAttrs:
     @staticmethod
     def cite(value) -> BaseAttribute:
         """
-        "ins" attribute: cite  
-        Link to the source of the quotation or more information about the edit  
+        "ins" attribute: cite
+        Link to the source of the quotation or more information about the edit
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An cite attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+
+        Returns:
+            An cite attribute to be added to your element
+
+        """
 
         return BaseAttribute("cite", value)
 
     @staticmethod
     def datetime(value) -> BaseAttribute:
         """
-        "ins" attribute: datetime  
-        Date and (optionally) time of the change  
+        "ins" attribute: datetime
+        Date and (optionally) time of the change
 
-        :param value: Valid date string with optional time  
-        :return: An datetime attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid date string with optional time
+
+        Returns:
+            An datetime attribute to be added to your element
+
+        """
 
         return BaseAttribute("datetime", value)

--- a/src/html_compose/attributes/label_attrs.py
+++ b/src/html_compose/attributes/label_attrs.py
@@ -10,11 +10,16 @@ class LabelAttrs:
     @staticmethod
     def for_(value) -> BaseAttribute:
         """
-        "label" attribute: for  
-        Associate the label with form control  
+        "label" attribute: for
+        Associate the label with form control
 
-        :param value: ID*  
-        :return: An for attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An for attribute to be added to your element
+
+        """
 
         return BaseAttribute("for", value)

--- a/src/html_compose/attributes/li_attrs.py
+++ b/src/html_compose/attributes/li_attrs.py
@@ -10,11 +10,16 @@ class LiAttrs:
     @staticmethod
     def value(value: int) -> BaseAttribute:
         """
-        "li" attribute: value  
-        Ordinal value of the list item  
+        "li" attribute: value
+        Ordinal value of the list item
 
-        :param value: Valid integer  
-        :return: An value attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid integer
+
+        Returns:
+            An value attribute to be added to your element
+
+        """
 
         return BaseAttribute("value", value)

--- a/src/html_compose/attributes/link_attrs.py
+++ b/src/html_compose/attributes/link_attrs.py
@@ -12,36 +12,51 @@ class LinkAttrs:
     @staticmethod
     def as_(value) -> BaseAttribute:
         """
-        "link" attribute: as  
-        Potential destination for a preload request (for rel="preload" and rel="modulepreload")  
+        "link" attribute: as
+        Potential destination for a preload request (for rel="preload" and rel="modulepreload")
 
-        :param value: Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"  
-        :return: An as attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
+
+        Returns:
+            An as attribute to be added to your element
+
+        """
 
         return BaseAttribute("as", value)
 
     @staticmethod
     def blocking(value: Resolvable) -> BaseAttribute:
         """
-        "link" attribute: blocking  
-        Whether the element is potentially render-blocking  
+        "link" attribute: blocking
+        Whether the element is potentially render-blocking
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An blocking attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+
+        Returns:
+            An blocking attribute to be added to your element
+
+        """
 
         return BaseAttribute("blocking", value)
 
     @staticmethod
     def color(value) -> BaseAttribute:
         """
-        "link" attribute: color  
-        Color to use when customizing a site's icon (for rel="mask-icon")  
+        "link" attribute: color
+        Color to use when customizing a site's icon (for rel="mask-icon")
 
-        :param value: CSS <color>  
-        :return: An color attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                CSS <color>
+
+        Returns:
+            An color attribute to be added to your element
+
+        """
 
         return BaseAttribute("color", value)
 
@@ -50,167 +65,237 @@ class LinkAttrs:
         value: Literal["anonymous", "use-credentials"],
     ) -> BaseAttribute:
         """
-        "link" attribute: crossorigin  
-        How the element handles crossorigin requests  
+        "link" attribute: crossorigin
+        How the element handles crossorigin requests
 
-        :param value: ['anonymous', 'use-credentials']  
-        :return: An crossorigin attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['anonymous', 'use-credentials']
+
+        Returns:
+            An crossorigin attribute to be added to your element
+
+        """
 
         return BaseAttribute("crossorigin", value)
 
     @staticmethod
     def disabled(value: bool) -> BaseAttribute:
         """
-        "link" attribute: disabled  
-        Whether the link is disabled  
+        "link" attribute: disabled
+        Whether the link is disabled
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
 
         return BaseAttribute("disabled", value)
 
     @staticmethod
     def fetchpriority(value: Literal["auto", "high", "low"]) -> BaseAttribute:
         """
-        "link" attribute: fetchpriority  
-        Sets the priority for fetches initiated by the element  
+        "link" attribute: fetchpriority
+        Sets the priority for fetches initiated by the element
 
-        :param value: ['auto', 'high', 'low']  
-        :return: An fetchpriority attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['auto', 'high', 'low']
+
+        Returns:
+            An fetchpriority attribute to be added to your element
+
+        """
 
         return BaseAttribute("fetchpriority", value)
 
     @staticmethod
     def href(value) -> BaseAttribute:
         """
-        "link" attribute: href  
-        Address of the hyperlink  
+        "link" attribute: href
+        Address of the hyperlink
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An href attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An href attribute to be added to your element
+
+        """
 
         return BaseAttribute("href", value)
 
     @staticmethod
     def hreflang(value) -> BaseAttribute:
         """
-        "link" attribute: hreflang  
-        Language of the linked resource  
+        "link" attribute: hreflang
+        Language of the linked resource
 
-        :param value: Valid BCP 47 language tag  
-        :return: An hreflang attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid BCP 47 language tag
+
+        Returns:
+            An hreflang attribute to be added to your element
+
+        """
 
         return BaseAttribute("hreflang", value)
 
     @staticmethod
     def imagesizes(value) -> BaseAttribute:
         """
-        "link" attribute: imagesizes  
-        Image sizes for different page layouts (for rel="preload")  
+        "link" attribute: imagesizes
+        Image sizes for different page layouts (for rel="preload")
 
-        :param value: Valid source size list  
-        :return: An imagesizes attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid source size list
+
+        Returns:
+            An imagesizes attribute to be added to your element
+
+        """
 
         return BaseAttribute("imagesizes", value)
 
     @staticmethod
     def imagesrcset(value) -> BaseAttribute:
         """
-        "link" attribute: imagesrcset  
-        Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")  
+        "link" attribute: imagesrcset
+        Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")
 
-        :param value: Comma-separated list of image candidate strings  
-        :return: An imagesrcset attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Comma-separated list of image candidate strings
+
+        Returns:
+            An imagesrcset attribute to be added to your element
+
+        """
 
         return BaseAttribute("imagesrcset", value)
 
     @staticmethod
     def integrity(value: StrLike) -> BaseAttribute:
         """
-        "link" attribute: integrity  
-        Integrity metadata used in Subresource Integrity checks [SRI]  
+        "link" attribute: integrity
+        Integrity metadata used in Subresource Integrity checks [SRI]
 
-        :param value: Text  
-        :return: An integrity attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An integrity attribute to be added to your element
+
+        """
 
         return BaseAttribute("integrity", value)
 
     @staticmethod
     def media(value) -> BaseAttribute:
         """
-        "link" attribute: media  
-        Applicable media  
+        "link" attribute: media
+        Applicable media
 
-        :param value: Valid media query list  
-        :return: An media attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid media query list
+
+        Returns:
+            An media attribute to be added to your element
+
+        """
 
         return BaseAttribute("media", value)
 
     @staticmethod
     def referrerpolicy(value) -> BaseAttribute:
         """
-        "link" attribute: referrerpolicy  
-        Referrer policy for fetches initiated by the element  
+        "link" attribute: referrerpolicy
+        Referrer policy for fetches initiated by the element
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Referrer policy
+
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
 
         return BaseAttribute("referrerpolicy", value)
 
     @staticmethod
     def rel(value: Resolvable) -> BaseAttribute:
         """
-        "link" attribute: rel  
-        Relationship between the document containing the hyperlink and the destination resource  
+        "link" attribute: rel
+        Relationship between the document containing the hyperlink and the destination resource
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An rel attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+
+        Returns:
+            An rel attribute to be added to your element
+
+        """
 
         return BaseAttribute("rel", value)
 
     @staticmethod
     def sizes(value: Resolvable) -> BaseAttribute:
         """
-        "link" attribute: sizes  
-        Sizes of the icons (for rel="icon")  
+        "link" attribute: sizes
+        Sizes of the icons (for rel="icon")
 
-        :param value: Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of sizes*  
-        :return: An sizes attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of sizes*
+
+        Returns:
+            An sizes attribute to be added to your element
+
+        """
 
         return BaseAttribute("sizes", value)
 
     @staticmethod
     def title(value) -> BaseAttribute:
         """
-        "link" attribute: title  
-        Title of the link  OR  CSS style sheet set name  
+        "link" attribute: title
+        Title of the link  OR  CSS style sheet set name
 
-        :param value: Text  OR  Text  
-        :return: An title attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text  OR  Text
+
+        Returns:
+            An title attribute to be added to your element
+
+        """
 
         return BaseAttribute("title", value)
 
     @staticmethod
     def type(value) -> BaseAttribute:
         """
-        "link" attribute: type  
-        Hint for the type of the referenced resource  
+        "link" attribute: type
+        Hint for the type of the referenced resource
 
-        :param value: Valid MIME type string  
-        :return: An type attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid MIME type string
+
+        Returns:
+            An type attribute to be added to your element
+
+        """
 
         return BaseAttribute("type", value)

--- a/src/html_compose/attributes/map_attrs.py
+++ b/src/html_compose/attributes/map_attrs.py
@@ -11,11 +11,16 @@ class MapAttrs:
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "map" attribute: name  
-        Name of image map to reference from the usemap attribute  
+        "map" attribute: name
+        Name of image map to reference from the usemap attribute
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)

--- a/src/html_compose/attributes/meta_attrs.py
+++ b/src/html_compose/attributes/meta_attrs.py
@@ -12,24 +12,34 @@ class MetaAttrs:
     @staticmethod
     def charset(value: Literal["utf-8"]) -> BaseAttribute:
         """
-        "meta" attribute: charset  
-        Character encoding declaration  
+        "meta" attribute: charset
+        Character encoding declaration
 
-        :param value: ['utf-8']  
-        :return: An charset attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['utf-8']
+
+        Returns:
+            An charset attribute to be added to your element
+
+        """
 
         return BaseAttribute("charset", value)
 
     @staticmethod
     def content(value: StrLike) -> BaseAttribute:
         """
-        "meta" attribute: content  
-        Value of the element  
+        "meta" attribute: content
+        Value of the element
 
-        :param value: Text*  
-        :return: An content attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An content attribute to be added to your element
+
+        """
 
         return BaseAttribute("content", value)
 
@@ -44,35 +54,50 @@ class MetaAttrs:
         ],
     ) -> BaseAttribute:
         """
-        "meta" attribute: http-equiv  
-        Pragma directive  
+        "meta" attribute: http-equiv
+        Pragma directive
 
-        :param value: ['content-type', 'default-style', 'refresh', 'x-ua-compatible', 'content-security-policy']  
-        :return: An http-equiv attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['content-type', 'default-style', 'refresh', 'x-ua-compatible', 'content-security-policy']
+
+        Returns:
+            An http-equiv attribute to be added to your element
+
+        """
 
         return BaseAttribute("http-equiv", value)
 
     @staticmethod
     def media(value) -> BaseAttribute:
         """
-        "meta" attribute: media  
-        Applicable media  
+        "meta" attribute: media
+        Applicable media
 
-        :param value: Valid media query list  
-        :return: An media attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid media query list
+
+        Returns:
+            An media attribute to be added to your element
+
+        """
 
         return BaseAttribute("media", value)
 
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "meta" attribute: name  
-        Metadata name  
+        "meta" attribute: name
+        Metadata name
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)

--- a/src/html_compose/attributes/meter_attrs.py
+++ b/src/html_compose/attributes/meter_attrs.py
@@ -10,71 +10,101 @@ class MeterAttrs:
     @staticmethod
     def high(value: float) -> BaseAttribute:
         """
-        "meter" attribute: high  
-        Low limit of high range  
+        "meter" attribute: high
+        Low limit of high range
 
-        :param value: Valid floating-point number*  
-        :return: An high attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+
+        Returns:
+            An high attribute to be added to your element
+
+        """
 
         return BaseAttribute("high", value)
 
     @staticmethod
     def low(value: float) -> BaseAttribute:
         """
-        "meter" attribute: low  
-        High limit of low range  
+        "meter" attribute: low
+        High limit of low range
 
-        :param value: Valid floating-point number*  
-        :return: An low attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+
+        Returns:
+            An low attribute to be added to your element
+
+        """
 
         return BaseAttribute("low", value)
 
     @staticmethod
     def max(value: float) -> BaseAttribute:
         """
-        "meter" attribute: max  
-        Upper bound of range  
+        "meter" attribute: max
+        Upper bound of range
 
-        :param value: Valid floating-point number*  
-        :return: An max attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+
+        Returns:
+            An max attribute to be added to your element
+
+        """
 
         return BaseAttribute("max", value)
 
     @staticmethod
     def min(value: float) -> BaseAttribute:
         """
-        "meter" attribute: min  
-        Lower bound of range  
+        "meter" attribute: min
+        Lower bound of range
 
-        :param value: Valid floating-point number*  
-        :return: An min attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+
+        Returns:
+            An min attribute to be added to your element
+
+        """
 
         return BaseAttribute("min", value)
 
     @staticmethod
     def optimum(value: float) -> BaseAttribute:
         """
-        "meter" attribute: optimum  
-        Optimum value in gauge  
+        "meter" attribute: optimum
+        Optimum value in gauge
 
-        :param value: Valid floating-point number*  
-        :return: An optimum attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+
+        Returns:
+            An optimum attribute to be added to your element
+
+        """
 
         return BaseAttribute("optimum", value)
 
     @staticmethod
     def value(value: float) -> BaseAttribute:
         """
-        "meter" attribute: value  
-        Current value of the element  
+        "meter" attribute: value
+        Current value of the element
 
-        :param value: Valid floating-point number  
-        :return: An value attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid floating-point number
+
+        Returns:
+            An value attribute to be added to your element
+
+        """
 
         return BaseAttribute("value", value)

--- a/src/html_compose/attributes/object_attrs.py
+++ b/src/html_compose/attributes/object_attrs.py
@@ -10,71 +10,101 @@ class ObjectAttrs:
     @staticmethod
     def data(value) -> BaseAttribute:
         """
-        "object" attribute: data  
-        Address of the resource  
+        "object" attribute: data
+        Address of the resource
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An data attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An data attribute to be added to your element
+
+        """
 
         return BaseAttribute("data", value)
 
     @staticmethod
     def form(value) -> BaseAttribute:
         """
-        "object" attribute: form  
-        Associates the element with a form element  
+        "object" attribute: form
+        Associates the element with a form element
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An form attribute to be added to your element
+
+        """
 
         return BaseAttribute("form", value)
 
     @staticmethod
     def height(value: int) -> BaseAttribute:
         """
-        "object" attribute: height  
-        Vertical dimension  
+        "object" attribute: height
+        Vertical dimension
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An height attribute to be added to your element
+
+        """
 
         return BaseAttribute("height", value)
 
     @staticmethod
     def name(value) -> BaseAttribute:
         """
-        "object" attribute: name  
-        Name of content navigable  
+        "object" attribute: name
+        Name of content navigable
 
-        :param value: Valid navigable target name or keyword  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)
 
     @staticmethod
     def type(value) -> BaseAttribute:
         """
-        "object" attribute: type  
-        Type of embedded resource  
+        "object" attribute: type
+        Type of embedded resource
 
-        :param value: Valid MIME type string  
-        :return: An type attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid MIME type string
+
+        Returns:
+            An type attribute to be added to your element
+
+        """
 
         return BaseAttribute("type", value)
 
     @staticmethod
     def width(value: int) -> BaseAttribute:
         """
-        "object" attribute: width  
-        Horizontal dimension  
+        "object" attribute: width
+        Horizontal dimension
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An width attribute to be added to your element
+
+        """
 
         return BaseAttribute("width", value)

--- a/src/html_compose/attributes/ol_attrs.py
+++ b/src/html_compose/attributes/ol_attrs.py
@@ -11,35 +11,50 @@ class OlAttrs:
     @staticmethod
     def reversed(value: bool) -> BaseAttribute:
         """
-        "ol" attribute: reversed  
-        Number the list backwards  
+        "ol" attribute: reversed
+        Number the list backwards
 
-        :param value: Boolean attribute  
-        :return: An reversed attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An reversed attribute to be added to your element
+
+        """
 
         return BaseAttribute("reversed", value)
 
     @staticmethod
     def start(value: int) -> BaseAttribute:
         """
-        "ol" attribute: start  
-        Starting value of the list  
+        "ol" attribute: start
+        Starting value of the list
 
-        :param value: Valid integer  
-        :return: An start attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid integer
+
+        Returns:
+            An start attribute to be added to your element
+
+        """
 
         return BaseAttribute("start", value)
 
     @staticmethod
     def type(value: Literal["1", "a", "A", "i", "I"]) -> BaseAttribute:
         """
-        "ol" attribute: type  
-        Kind of list marker  
+        "ol" attribute: type
+        Kind of list marker
 
-        :param value: ['1', 'a', 'A', 'i', 'I']  
-        :return: An type attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['1', 'a', 'A', 'i', 'I']
+
+        Returns:
+            An type attribute to be added to your element
+
+        """
 
         return BaseAttribute("type", value)

--- a/src/html_compose/attributes/optgroup_attrs.py
+++ b/src/html_compose/attributes/optgroup_attrs.py
@@ -11,23 +11,33 @@ class OptgroupAttrs:
     @staticmethod
     def disabled(value: bool) -> BaseAttribute:
         """
-        "optgroup" attribute: disabled  
-        Whether the form control is disabled  
+        "optgroup" attribute: disabled
+        Whether the form control is disabled
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
 
         return BaseAttribute("disabled", value)
 
     @staticmethod
     def label(value: StrLike) -> BaseAttribute:
         """
-        "optgroup" attribute: label  
-        User-visible label  
+        "optgroup" attribute: label
+        User-visible label
 
-        :param value: Text  
-        :return: An label attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An label attribute to be added to your element
+
+        """
 
         return BaseAttribute("label", value)

--- a/src/html_compose/attributes/option_attrs.py
+++ b/src/html_compose/attributes/option_attrs.py
@@ -11,47 +11,67 @@ class OptionAttrs:
     @staticmethod
     def disabled(value: bool) -> BaseAttribute:
         """
-        "option" attribute: disabled  
-        Whether the form control is disabled  
+        "option" attribute: disabled
+        Whether the form control is disabled
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
 
         return BaseAttribute("disabled", value)
 
     @staticmethod
     def label(value: StrLike) -> BaseAttribute:
         """
-        "option" attribute: label  
-        User-visible label  
+        "option" attribute: label
+        User-visible label
 
-        :param value: Text  
-        :return: An label attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An label attribute to be added to your element
+
+        """
 
         return BaseAttribute("label", value)
 
     @staticmethod
     def selected(value: bool) -> BaseAttribute:
         """
-        "option" attribute: selected  
-        Whether the option is selected by default  
+        "option" attribute: selected
+        Whether the option is selected by default
 
-        :param value: Boolean attribute  
-        :return: An selected attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An selected attribute to be added to your element
+
+        """
 
         return BaseAttribute("selected", value)
 
     @staticmethod
     def value(value: StrLike) -> BaseAttribute:
         """
-        "option" attribute: value  
-        Value to be used for form submission  
+        "option" attribute: value
+        Value to be used for form submission
 
-        :param value: Text  
-        :return: An value attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An value attribute to be added to your element
+
+        """
 
         return BaseAttribute("value", value)

--- a/src/html_compose/attributes/output_attrs.py
+++ b/src/html_compose/attributes/output_attrs.py
@@ -11,35 +11,50 @@ class OutputAttrs:
     @staticmethod
     def for_(value: Resolvable) -> BaseAttribute:
         """
-        "output" attribute: for  
-        Specifies controls from which the output was calculated  
+        "output" attribute: for
+        Specifies controls from which the output was calculated
 
-        :param value: Unordered set of unique space-separated tokens consisting of IDs*  
-        :return: An for attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of IDs*
+
+        Returns:
+            An for attribute to be added to your element
+
+        """
 
         return BaseAttribute("for", value)
 
     @staticmethod
     def form(value) -> BaseAttribute:
         """
-        "output" attribute: form  
-        Associates the element with a form element  
+        "output" attribute: form
+        Associates the element with a form element
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An form attribute to be added to your element
+
+        """
 
         return BaseAttribute("form", value)
 
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "output" attribute: name  
-        Name of the element to use for form submission and in the form.elements API  
+        "output" attribute: name
+        Name of the element to use for form submission and in the form.elements API
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)

--- a/src/html_compose/attributes/progress_attrs.py
+++ b/src/html_compose/attributes/progress_attrs.py
@@ -10,23 +10,33 @@ class ProgressAttrs:
     @staticmethod
     def max(value: float) -> BaseAttribute:
         """
-        "progress" attribute: max  
-        Upper bound of range  
+        "progress" attribute: max
+        Upper bound of range
 
-        :param value: Valid floating-point number*  
-        :return: An max attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+
+        Returns:
+            An max attribute to be added to your element
+
+        """
 
         return BaseAttribute("max", value)
 
     @staticmethod
     def value(value: float) -> BaseAttribute:
         """
-        "progress" attribute: value  
-        Current value of the element  
+        "progress" attribute: value
+        Current value of the element
 
-        :param value: Valid floating-point number  
-        :return: An value attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid floating-point number
+
+        Returns:
+            An value attribute to be added to your element
+
+        """
 
         return BaseAttribute("value", value)

--- a/src/html_compose/attributes/q_attrs.py
+++ b/src/html_compose/attributes/q_attrs.py
@@ -10,11 +10,16 @@ class QAttrs:
     @staticmethod
     def cite(value) -> BaseAttribute:
         """
-        "q" attribute: cite  
-        Link to the source of the quotation or more information about the edit  
+        "q" attribute: cite
+        Link to the source of the quotation or more information about the edit
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An cite attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+
+        Returns:
+            An cite attribute to be added to your element
+
+        """
 
         return BaseAttribute("cite", value)

--- a/src/html_compose/attributes/script_attrs.py
+++ b/src/html_compose/attributes/script_attrs.py
@@ -12,24 +12,34 @@ class ScriptAttrs:
     @staticmethod
     def async_(value: bool) -> BaseAttribute:
         """
-        "script" attribute: async  
-        Execute script when available, without blocking while fetching  
+        "script" attribute: async
+        Execute script when available, without blocking while fetching
 
-        :param value: Boolean attribute  
-        :return: An async attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An async attribute to be added to your element
+
+        """
 
         return BaseAttribute("async", value)
 
     @staticmethod
     def blocking(value: Resolvable) -> BaseAttribute:
         """
-        "script" attribute: blocking  
-        Whether the element is potentially render-blocking  
+        "script" attribute: blocking
+        Whether the element is potentially render-blocking
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An blocking attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+
+        Returns:
+            An blocking attribute to be added to your element
+
+        """
 
         return BaseAttribute("blocking", value)
 
@@ -38,95 +48,135 @@ class ScriptAttrs:
         value: Literal["anonymous", "use-credentials"],
     ) -> BaseAttribute:
         """
-        "script" attribute: crossorigin  
-        How the element handles crossorigin requests  
+        "script" attribute: crossorigin
+        How the element handles crossorigin requests
 
-        :param value: ['anonymous', 'use-credentials']  
-        :return: An crossorigin attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['anonymous', 'use-credentials']
+
+        Returns:
+            An crossorigin attribute to be added to your element
+
+        """
 
         return BaseAttribute("crossorigin", value)
 
     @staticmethod
     def defer(value: bool) -> BaseAttribute:
         """
-        "script" attribute: defer  
-        Defer script execution  
+        "script" attribute: defer
+        Defer script execution
 
-        :param value: Boolean attribute  
-        :return: An defer attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An defer attribute to be added to your element
+
+        """
 
         return BaseAttribute("defer", value)
 
     @staticmethod
     def fetchpriority(value: Literal["auto", "high", "low"]) -> BaseAttribute:
         """
-        "script" attribute: fetchpriority  
-        Sets the priority for fetches initiated by the element  
+        "script" attribute: fetchpriority
+        Sets the priority for fetches initiated by the element
 
-        :param value: ['auto', 'high', 'low']  
-        :return: An fetchpriority attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['auto', 'high', 'low']
+
+        Returns:
+            An fetchpriority attribute to be added to your element
+
+        """
 
         return BaseAttribute("fetchpriority", value)
 
     @staticmethod
     def integrity(value: StrLike) -> BaseAttribute:
         """
-        "script" attribute: integrity  
-        Integrity metadata used in Subresource Integrity checks [SRI]  
+        "script" attribute: integrity
+        Integrity metadata used in Subresource Integrity checks [SRI]
 
-        :param value: Text  
-        :return: An integrity attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An integrity attribute to be added to your element
+
+        """
 
         return BaseAttribute("integrity", value)
 
     @staticmethod
     def nomodule(value: bool) -> BaseAttribute:
         """
-        "script" attribute: nomodule  
-        Prevents execution in user agents that support module scripts  
+        "script" attribute: nomodule
+        Prevents execution in user agents that support module scripts
 
-        :param value: Boolean attribute  
-        :return: An nomodule attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An nomodule attribute to be added to your element
+
+        """
 
         return BaseAttribute("nomodule", value)
 
     @staticmethod
     def referrerpolicy(value) -> BaseAttribute:
         """
-        "script" attribute: referrerpolicy  
-        Referrer policy for fetches initiated by the element  
+        "script" attribute: referrerpolicy
+        Referrer policy for fetches initiated by the element
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Referrer policy
+
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
 
         return BaseAttribute("referrerpolicy", value)
 
     @staticmethod
     def src(value) -> BaseAttribute:
         """
-        "script" attribute: src  
-        Address of the resource  
+        "script" attribute: src
+        Address of the resource
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An src attribute to be added to your element
+
+        """
 
         return BaseAttribute("src", value)
 
     @staticmethod
     def type(value) -> BaseAttribute:
         """
-        "script" attribute: type  
-        Type of script  
+        "script" attribute: type
+        Type of script
 
-        :param value: "module"; a valid MIME type string that is not a JavaScript MIME type essence match  
-        :return: An type attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                "module"; a valid MIME type string that is not a JavaScript MIME type essence match
+
+        Returns:
+            An type attribute to be added to your element
+
+        """
 
         return BaseAttribute("type", value)

--- a/src/html_compose/attributes/select_attrs.py
+++ b/src/html_compose/attributes/select_attrs.py
@@ -11,83 +11,118 @@ class SelectAttrs:
     @staticmethod
     def autocomplete(value) -> BaseAttribute:
         """
-        "select" attribute: autocomplete  
-        Hint for form autofill feature  
+        "select" attribute: autocomplete
+        Hint for form autofill feature
 
-        :param value: Autofill field name and related tokens*  
-        :return: An autocomplete attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Autofill field name and related tokens*
+
+        Returns:
+            An autocomplete attribute to be added to your element
+
+        """
 
         return BaseAttribute("autocomplete", value)
 
     @staticmethod
     def disabled(value: bool) -> BaseAttribute:
         """
-        "select" attribute: disabled  
-        Whether the form control is disabled  
+        "select" attribute: disabled
+        Whether the form control is disabled
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
 
         return BaseAttribute("disabled", value)
 
     @staticmethod
     def form(value) -> BaseAttribute:
         """
-        "select" attribute: form  
-        Associates the element with a form element  
+        "select" attribute: form
+        Associates the element with a form element
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An form attribute to be added to your element
+
+        """
 
         return BaseAttribute("form", value)
 
     @staticmethod
     def multiple(value: bool) -> BaseAttribute:
         """
-        "select" attribute: multiple  
-        Whether to allow multiple values  
+        "select" attribute: multiple
+        Whether to allow multiple values
 
-        :param value: Boolean attribute  
-        :return: An multiple attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An multiple attribute to be added to your element
+
+        """
 
         return BaseAttribute("multiple", value)
 
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "select" attribute: name  
-        Name of the element to use for form submission and in the form.elements API  
+        "select" attribute: name
+        Name of the element to use for form submission and in the form.elements API
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)
 
     @staticmethod
     def required(value: bool) -> BaseAttribute:
         """
-        "select" attribute: required  
-        Whether the control is required for form submission  
+        "select" attribute: required
+        Whether the control is required for form submission
 
-        :param value: Boolean attribute  
-        :return: An required attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An required attribute to be added to your element
+
+        """
 
         return BaseAttribute("required", value)
 
     @staticmethod
     def size(value) -> BaseAttribute:
         """
-        "select" attribute: size  
-        Size of the control  
+        "select" attribute: size
+        Size of the control
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An size attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+
+        Returns:
+            An size attribute to be added to your element
+
+        """
 
         return BaseAttribute("size", value)

--- a/src/html_compose/attributes/slot_attrs.py
+++ b/src/html_compose/attributes/slot_attrs.py
@@ -11,11 +11,16 @@ class SlotAttrs:
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "slot" attribute: name  
-        Name of shadow tree slot  
+        "slot" attribute: name
+        Name of shadow tree slot
 
-        :param value: Text  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)

--- a/src/html_compose/attributes/source_attrs.py
+++ b/src/html_compose/attributes/source_attrs.py
@@ -10,83 +10,118 @@ class SourceAttrs:
     @staticmethod
     def height(value: int) -> BaseAttribute:
         """
-        "source" attribute: height  
-        Vertical dimension  
+        "source" attribute: height
+        Vertical dimension
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An height attribute to be added to your element
+
+        """
 
         return BaseAttribute("height", value)
 
     @staticmethod
     def media(value) -> BaseAttribute:
         """
-        "source" attribute: media  
-        Applicable media  
+        "source" attribute: media
+        Applicable media
 
-        :param value: Valid media query list  
-        :return: An media attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid media query list
+
+        Returns:
+            An media attribute to be added to your element
+
+        """
 
         return BaseAttribute("media", value)
 
     @staticmethod
     def sizes(value) -> BaseAttribute:
         """
-        "source" attribute: sizes  
-        Image sizes for different page layouts  
+        "source" attribute: sizes
+        Image sizes for different page layouts
 
-        :param value: Valid source size list  
-        :return: An sizes attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid source size list
+
+        Returns:
+            An sizes attribute to be added to your element
+
+        """
 
         return BaseAttribute("sizes", value)
 
     @staticmethod
     def src(value) -> BaseAttribute:
         """
-        "source" attribute: src  
-        Address of the resource  
+        "source" attribute: src
+        Address of the resource
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An src attribute to be added to your element
+
+        """
 
         return BaseAttribute("src", value)
 
     @staticmethod
     def srcset(value) -> BaseAttribute:
         """
-        "source" attribute: srcset  
-        Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
+        "source" attribute: srcset
+        Images to use in different situations, e.g., high-resolution displays, small monitors, etc.
 
-        :param value: Comma-separated list of image candidate strings  
-        :return: An srcset attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Comma-separated list of image candidate strings
+
+        Returns:
+            An srcset attribute to be added to your element
+
+        """
 
         return BaseAttribute("srcset", value)
 
     @staticmethod
     def type(value) -> BaseAttribute:
         """
-        "source" attribute: type  
-        Type of embedded resource  
+        "source" attribute: type
+        Type of embedded resource
 
-        :param value: Valid MIME type string  
-        :return: An type attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid MIME type string
+
+        Returns:
+            An type attribute to be added to your element
+
+        """
 
         return BaseAttribute("type", value)
 
     @staticmethod
     def width(value: int) -> BaseAttribute:
         """
-        "source" attribute: width  
-        Horizontal dimension  
+        "source" attribute: width
+        Horizontal dimension
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An width attribute to be added to your element
+
+        """
 
         return BaseAttribute("width", value)

--- a/src/html_compose/attributes/style_attrs.py
+++ b/src/html_compose/attributes/style_attrs.py
@@ -11,35 +11,50 @@ class StyleAttrs:
     @staticmethod
     def blocking(value: Resolvable) -> BaseAttribute:
         """
-        "style" attribute: blocking  
-        Whether the element is potentially render-blocking  
+        "style" attribute: blocking
+        Whether the element is potentially render-blocking
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An blocking attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+
+        Returns:
+            An blocking attribute to be added to your element
+
+        """
 
         return BaseAttribute("blocking", value)
 
     @staticmethod
     def media(value) -> BaseAttribute:
         """
-        "style" attribute: media  
-        Applicable media  
+        "style" attribute: media
+        Applicable media
 
-        :param value: Valid media query list  
-        :return: An media attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid media query list
+
+        Returns:
+            An media attribute to be added to your element
+
+        """
 
         return BaseAttribute("media", value)
 
     @staticmethod
     def title(value: StrLike) -> BaseAttribute:
         """
-        "style" attribute: title  
-        CSS style sheet set name  
+        "style" attribute: title
+        CSS style sheet set name
 
-        :param value: Text  
-        :return: An title attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An title attribute to be added to your element
+
+        """
 
         return BaseAttribute("title", value)

--- a/src/html_compose/attributes/td_attrs.py
+++ b/src/html_compose/attributes/td_attrs.py
@@ -11,35 +11,50 @@ class TdAttrs:
     @staticmethod
     def colspan(value) -> BaseAttribute:
         """
-        "td" attribute: colspan  
-        Number of columns that the cell is to span  
+        "td" attribute: colspan
+        Number of columns that the cell is to span
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An colspan attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+
+        Returns:
+            An colspan attribute to be added to your element
+
+        """
 
         return BaseAttribute("colspan", value)
 
     @staticmethod
     def headers(value: Resolvable) -> BaseAttribute:
         """
-        "td" attribute: headers  
-        The header cells for this cell  
+        "td" attribute: headers
+        The header cells for this cell
 
-        :param value: Unordered set of unique space-separated tokens consisting of IDs*  
-        :return: An headers attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of IDs*
+
+        Returns:
+            An headers attribute to be added to your element
+
+        """
 
         return BaseAttribute("headers", value)
 
     @staticmethod
     def rowspan(value: int) -> BaseAttribute:
         """
-        "td" attribute: rowspan  
-        Number of rows that the cell is to span  
+        "td" attribute: rowspan
+        Number of rows that the cell is to span
 
-        :param value: Valid non-negative integer  
-        :return: An rowspan attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An rowspan attribute to be added to your element
+
+        """
 
         return BaseAttribute("rowspan", value)

--- a/src/html_compose/attributes/template_attrs.py
+++ b/src/html_compose/attributes/template_attrs.py
@@ -11,47 +11,67 @@ class TemplateAttrs:
     @staticmethod
     def shadowrootclonable(value: bool) -> BaseAttribute:
         """
-        "template" attribute: shadowrootclonable  
-        Sets clonable on a declarative shadow root  
+        "template" attribute: shadowrootclonable
+        Sets clonable on a declarative shadow root
 
-        :param value: Boolean attribute  
-        :return: An shadowrootclonable attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An shadowrootclonable attribute to be added to your element
+
+        """
 
         return BaseAttribute("shadowrootclonable", value)
 
     @staticmethod
     def shadowrootdelegatesfocus(value: bool) -> BaseAttribute:
         """
-        "template" attribute: shadowrootdelegatesfocus  
-        Sets delegates focus on a declarative shadow root  
+        "template" attribute: shadowrootdelegatesfocus
+        Sets delegates focus on a declarative shadow root
 
-        :param value: Boolean attribute  
-        :return: An shadowrootdelegatesfocus attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An shadowrootdelegatesfocus attribute to be added to your element
+
+        """
 
         return BaseAttribute("shadowrootdelegatesfocus", value)
 
     @staticmethod
     def shadowrootmode(value: Literal["open", "closed"]) -> BaseAttribute:
         """
-        "template" attribute: shadowrootmode  
-        Enables streaming declarative shadow roots  
+        "template" attribute: shadowrootmode
+        Enables streaming declarative shadow roots
 
-        :param value: ['open', 'closed']  
-        :return: An shadowrootmode attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['open', 'closed']
+
+        Returns:
+            An shadowrootmode attribute to be added to your element
+
+        """
 
         return BaseAttribute("shadowrootmode", value)
 
     @staticmethod
     def shadowrootserializable(value: bool) -> BaseAttribute:
         """
-        "template" attribute: shadowrootserializable  
-        Sets serializable on a declarative shadow root  
+        "template" attribute: shadowrootserializable
+        Sets serializable on a declarative shadow root
 
-        :param value: Boolean attribute  
-        :return: An shadowrootserializable attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An shadowrootserializable attribute to be added to your element
+
+        """
 
         return BaseAttribute("shadowrootserializable", value)

--- a/src/html_compose/attributes/textarea_attrs.py
+++ b/src/html_compose/attributes/textarea_attrs.py
@@ -12,155 +12,220 @@ class TextareaAttrs:
     @staticmethod
     def autocomplete(value) -> BaseAttribute:
         """
-        "textarea" attribute: autocomplete  
-        Hint for form autofill feature  
+        "textarea" attribute: autocomplete
+        Hint for form autofill feature
 
-        :param value: Autofill field name and related tokens*  
-        :return: An autocomplete attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Autofill field name and related tokens*
+
+        Returns:
+            An autocomplete attribute to be added to your element
+
+        """
 
         return BaseAttribute("autocomplete", value)
 
     @staticmethod
     def cols(value) -> BaseAttribute:
         """
-        "textarea" attribute: cols  
-        Maximum number of characters per line  
+        "textarea" attribute: cols
+        Maximum number of characters per line
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An cols attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+
+        Returns:
+            An cols attribute to be added to your element
+
+        """
 
         return BaseAttribute("cols", value)
 
     @staticmethod
     def dirname(value: StrLike) -> BaseAttribute:
         """
-        "textarea" attribute: dirname  
-        Name of form control to use for sending the element's directionality in form submission  
+        "textarea" attribute: dirname
+        Name of form control to use for sending the element's directionality in form submission
 
-        :param value: Text*  
-        :return: An dirname attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An dirname attribute to be added to your element
+
+        """
 
         return BaseAttribute("dirname", value)
 
     @staticmethod
     def disabled(value: bool) -> BaseAttribute:
         """
-        "textarea" attribute: disabled  
-        Whether the form control is disabled  
+        "textarea" attribute: disabled
+        Whether the form control is disabled
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
 
         return BaseAttribute("disabled", value)
 
     @staticmethod
     def form(value) -> BaseAttribute:
         """
-        "textarea" attribute: form  
-        Associates the element with a form element  
+        "textarea" attribute: form
+        Associates the element with a form element
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ID*
+
+        Returns:
+            An form attribute to be added to your element
+
+        """
 
         return BaseAttribute("form", value)
 
     @staticmethod
     def maxlength(value: int) -> BaseAttribute:
         """
-        "textarea" attribute: maxlength  
-        Maximum length of value  
+        "textarea" attribute: maxlength
+        Maximum length of value
 
-        :param value: Valid non-negative integer  
-        :return: An maxlength attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An maxlength attribute to be added to your element
+
+        """
 
         return BaseAttribute("maxlength", value)
 
     @staticmethod
     def minlength(value: int) -> BaseAttribute:
         """
-        "textarea" attribute: minlength  
-        Minimum length of value  
+        "textarea" attribute: minlength
+        Minimum length of value
 
-        :param value: Valid non-negative integer  
-        :return: An minlength attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An minlength attribute to be added to your element
+
+        """
 
         return BaseAttribute("minlength", value)
 
     @staticmethod
     def name(value: StrLike) -> BaseAttribute:
         """
-        "textarea" attribute: name  
-        Name of the element to use for form submission and in the form.elements API  
+        "textarea" attribute: name
+        Name of the element to use for form submission and in the form.elements API
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An name attribute to be added to your element
+
+        """
 
         return BaseAttribute("name", value)
 
     @staticmethod
     def placeholder(value: StrLike) -> BaseAttribute:
         """
-        "textarea" attribute: placeholder  
-        User-visible label to be placed within the form control  
+        "textarea" attribute: placeholder
+        User-visible label to be placed within the form control
 
-        :param value: Text*  
-        :return: An placeholder attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An placeholder attribute to be added to your element
+
+        """
 
         return BaseAttribute("placeholder", value)
 
     @staticmethod
     def readonly(value: bool) -> BaseAttribute:
         """
-        "textarea" attribute: readonly  
-        Whether to allow the value to be edited by the user  
+        "textarea" attribute: readonly
+        Whether to allow the value to be edited by the user
 
-        :param value: Boolean attribute  
-        :return: An readonly attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An readonly attribute to be added to your element
+
+        """
 
         return BaseAttribute("readonly", value)
 
     @staticmethod
     def required(value: bool) -> BaseAttribute:
         """
-        "textarea" attribute: required  
-        Whether the control is required for form submission  
+        "textarea" attribute: required
+        Whether the control is required for form submission
 
-        :param value: Boolean attribute  
-        :return: An required attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An required attribute to be added to your element
+
+        """
 
         return BaseAttribute("required", value)
 
     @staticmethod
     def rows(value) -> BaseAttribute:
         """
-        "textarea" attribute: rows  
-        Number of lines to show  
+        "textarea" attribute: rows
+        Number of lines to show
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An rows attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+
+        Returns:
+            An rows attribute to be added to your element
+
+        """
 
         return BaseAttribute("rows", value)
 
     @staticmethod
     def wrap(value: Literal["soft", "hard"]) -> BaseAttribute:
         """
-        "textarea" attribute: wrap  
-        How the value of the form control is to be wrapped for form submission  
+        "textarea" attribute: wrap
+        How the value of the form control is to be wrapped for form submission
 
-        :param value: ['soft', 'hard']  
-        :return: An wrap attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['soft', 'hard']
+
+        Returns:
+            An wrap attribute to be added to your element
+
+        """
 
         return BaseAttribute("wrap", value)

--- a/src/html_compose/attributes/th_attrs.py
+++ b/src/html_compose/attributes/th_attrs.py
@@ -12,48 +12,68 @@ class ThAttrs:
     @staticmethod
     def abbr(value: StrLike) -> BaseAttribute:
         """
-        "th" attribute: abbr  
-        Alternative label to use for the header cell when referencing the cell in other contexts  
+        "th" attribute: abbr
+        Alternative label to use for the header cell when referencing the cell in other contexts
 
-        :param value: Text*  
-        :return: An abbr attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text*
+
+        Returns:
+            An abbr attribute to be added to your element
+
+        """
 
         return BaseAttribute("abbr", value)
 
     @staticmethod
     def colspan(value) -> BaseAttribute:
         """
-        "th" attribute: colspan  
-        Number of columns that the cell is to span  
+        "th" attribute: colspan
+        Number of columns that the cell is to span
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An colspan attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+
+        Returns:
+            An colspan attribute to be added to your element
+
+        """
 
         return BaseAttribute("colspan", value)
 
     @staticmethod
     def headers(value: Resolvable) -> BaseAttribute:
         """
-        "th" attribute: headers  
-        The header cells for this cell  
+        "th" attribute: headers
+        The header cells for this cell
 
-        :param value: Unordered set of unique space-separated tokens consisting of IDs*  
-        :return: An headers attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of IDs*
+
+        Returns:
+            An headers attribute to be added to your element
+
+        """
 
         return BaseAttribute("headers", value)
 
     @staticmethod
     def rowspan(value: int) -> BaseAttribute:
         """
-        "th" attribute: rowspan  
-        Number of rows that the cell is to span  
+        "th" attribute: rowspan
+        Number of rows that the cell is to span
 
-        :param value: Valid non-negative integer  
-        :return: An rowspan attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An rowspan attribute to be added to your element
+
+        """
 
         return BaseAttribute("rowspan", value)
 
@@ -62,11 +82,16 @@ class ThAttrs:
         value: Literal["row", "col", "rowgroup", "colgroup"],
     ) -> BaseAttribute:
         """
-        "th" attribute: scope  
-        Specifies which cells the header cell applies to  
+        "th" attribute: scope
+        Specifies which cells the header cell applies to
 
-        :param value: ['row', 'col', 'rowgroup', 'colgroup']  
-        :return: An scope attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['row', 'col', 'rowgroup', 'colgroup']
+
+        Returns:
+            An scope attribute to be added to your element
+
+        """
 
         return BaseAttribute("scope", value)

--- a/src/html_compose/attributes/time_attrs.py
+++ b/src/html_compose/attributes/time_attrs.py
@@ -10,11 +10,16 @@ class TimeAttrs:
     @staticmethod
     def datetime(value) -> BaseAttribute:
         """
-        "time" attribute: datetime  
-        Machine-readable value  
+        "time" attribute: datetime
+        Machine-readable value
 
-        :param value: Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string  
-        :return: An datetime attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
+
+        Returns:
+            An datetime attribute to be added to your element
+
+        """
 
         return BaseAttribute("datetime", value)

--- a/src/html_compose/attributes/track_attrs.py
+++ b/src/html_compose/attributes/track_attrs.py
@@ -12,12 +12,17 @@ class TrackAttrs:
     @staticmethod
     def default(value: bool) -> BaseAttribute:
         """
-        "track" attribute: default  
-        Enable the track if no other text track is more suitable  
+        "track" attribute: default
+        Enable the track if no other text track is more suitable
 
-        :param value: Boolean attribute  
-        :return: An default attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An default attribute to be added to your element
+
+        """
 
         return BaseAttribute("default", value)
 
@@ -28,47 +33,67 @@ class TrackAttrs:
         ],
     ) -> BaseAttribute:
         """
-        "track" attribute: kind  
-        The type of text track  
+        "track" attribute: kind
+        The type of text track
 
-        :param value: ['subtitles', 'captions', 'descriptions', 'chapters', 'metadata']  
-        :return: An kind attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['subtitles', 'captions', 'descriptions', 'chapters', 'metadata']
+
+        Returns:
+            An kind attribute to be added to your element
+
+        """
 
         return BaseAttribute("kind", value)
 
     @staticmethod
     def label(value: StrLike) -> BaseAttribute:
         """
-        "track" attribute: label  
-        User-visible label  
+        "track" attribute: label
+        User-visible label
 
-        :param value: Text  
-        :return: An label attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Text
+
+        Returns:
+            An label attribute to be added to your element
+
+        """
 
         return BaseAttribute("label", value)
 
     @staticmethod
     def src(value) -> BaseAttribute:
         """
-        "track" attribute: src  
-        Address of the resource  
+        "track" attribute: src
+        Address of the resource
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An src attribute to be added to your element
+
+        """
 
         return BaseAttribute("src", value)
 
     @staticmethod
     def srclang(value) -> BaseAttribute:
         """
-        "track" attribute: srclang  
-        Language of the text track  
+        "track" attribute: srclang
+        Language of the text track
 
-        :param value: Valid BCP 47 language tag  
-        :return: An srclang attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid BCP 47 language tag
+
+        Returns:
+            An srclang attribute to be added to your element
+
+        """
 
         return BaseAttribute("srclang", value)

--- a/src/html_compose/attributes/video_attrs.py
+++ b/src/html_compose/attributes/video_attrs.py
@@ -11,24 +11,34 @@ class VideoAttrs:
     @staticmethod
     def autoplay(value: bool) -> BaseAttribute:
         """
-        "video" attribute: autoplay  
-        Hint that the media resource can be started automatically when the page is loaded  
+        "video" attribute: autoplay
+        Hint that the media resource can be started automatically when the page is loaded
 
-        :param value: Boolean attribute  
-        :return: An autoplay attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An autoplay attribute to be added to your element
+
+        """
 
         return BaseAttribute("autoplay", value)
 
     @staticmethod
     def controls(value: bool) -> BaseAttribute:
         """
-        "video" attribute: controls  
-        Show user agent controls  
+        "video" attribute: controls
+        Show user agent controls
 
-        :param value: Boolean attribute  
-        :return: An controls attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An controls attribute to be added to your element
+
+        """
 
         return BaseAttribute("controls", value)
 
@@ -37,107 +47,152 @@ class VideoAttrs:
         value: Literal["anonymous", "use-credentials"],
     ) -> BaseAttribute:
         """
-        "video" attribute: crossorigin  
-        How the element handles crossorigin requests  
+        "video" attribute: crossorigin
+        How the element handles crossorigin requests
 
-        :param value: ['anonymous', 'use-credentials']  
-        :return: An crossorigin attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['anonymous', 'use-credentials']
+
+        Returns:
+            An crossorigin attribute to be added to your element
+
+        """
 
         return BaseAttribute("crossorigin", value)
 
     @staticmethod
     def height(value: int) -> BaseAttribute:
         """
-        "video" attribute: height  
-        Vertical dimension  
+        "video" attribute: height
+        Vertical dimension
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An height attribute to be added to your element
+
+        """
 
         return BaseAttribute("height", value)
 
     @staticmethod
     def loop(value: bool) -> BaseAttribute:
         """
-        "video" attribute: loop  
-        Whether to loop the media resource  
+        "video" attribute: loop
+        Whether to loop the media resource
 
-        :param value: Boolean attribute  
-        :return: An loop attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An loop attribute to be added to your element
+
+        """
 
         return BaseAttribute("loop", value)
 
     @staticmethod
     def muted(value: bool) -> BaseAttribute:
         """
-        "video" attribute: muted  
-        Whether to mute the media resource by default  
+        "video" attribute: muted
+        Whether to mute the media resource by default
 
-        :param value: Boolean attribute  
-        :return: An muted attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An muted attribute to be added to your element
+
+        """
 
         return BaseAttribute("muted", value)
 
     @staticmethod
     def playsinline(value: bool) -> BaseAttribute:
         """
-        "video" attribute: playsinline  
-        Encourage the user agent to display video content within the element's playback area  
+        "video" attribute: playsinline
+        Encourage the user agent to display video content within the element's playback area
 
-        :param value: Boolean attribute  
-        :return: An playsinline attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+
+        Returns:
+            An playsinline attribute to be added to your element
+
+        """
 
         return BaseAttribute("playsinline", value)
 
     @staticmethod
     def poster(value) -> BaseAttribute:
         """
-        "video" attribute: poster  
-        Poster frame to show prior to video playback  
+        "video" attribute: poster
+        Poster frame to show prior to video playback
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An poster attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An poster attribute to be added to your element
+
+        """
 
         return BaseAttribute("poster", value)
 
     @staticmethod
     def preload(value: Literal["none", "metadata", "auto"]) -> BaseAttribute:
         """
-        "video" attribute: preload  
-        Hints how much buffering the media resource will likely need  
+        "video" attribute: preload
+        Hints how much buffering the media resource will likely need
 
-        :param value: ['none', 'metadata', 'auto']  
-        :return: An preload attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                ['none', 'metadata', 'auto']
+
+        Returns:
+            An preload attribute to be added to your element
+
+        """
 
         return BaseAttribute("preload", value)
 
     @staticmethod
     def src(value) -> BaseAttribute:
         """
-        "video" attribute: src  
-        Address of the resource  
+        "video" attribute: src
+        Address of the resource
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+
+        Returns:
+            An src attribute to be added to your element
+
+        """
 
         return BaseAttribute("src", value)
 
     @staticmethod
     def width(value: int) -> BaseAttribute:
         """
-        "video" attribute: width  
-        Horizontal dimension  
+        "video" attribute: width
+        Horizontal dimension
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """  # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+
+        Returns:
+            An width attribute to be added to your element
+
+        """
 
         return BaseAttribute("width", value)

--- a/src/html_compose/base_attribute.py
+++ b/src/html_compose/base_attribute.py
@@ -88,11 +88,6 @@ class BaseAttribute:
         if isinstance(data, int):
             return str(data)
 
-        # Just a bool that needs to be marshalled to a string
-        # evaluate normally blocks this
-        if isinstance(data, bool):
-            return "true" if data else "false"
-
         if data is None:
             return None
 

--- a/src/html_compose/base_attribute.py
+++ b/src/html_compose/base_attribute.py
@@ -83,6 +83,15 @@ class BaseAttribute:
             return "true"
 
         if data is False:
+            warn(
+                f"Attribute fired with data set to False. "
+                f"We will emit {self.name}=false, but in general HTML treats "
+                'attrname="any value" as true. '
+                "If you are sure about this, ignore this warning with "
+                "warnings.filterwarnings('ignore', '"
+                "Attribute fired with data set to False')",
+                stacklevel=2,
+            )
             return "false"
         # Just a string
         if isinstance(data, str):

--- a/src/html_compose/base_attribute.py
+++ b/src/html_compose/base_attribute.py
@@ -1,5 +1,4 @@
 from typing import Iterable, Tuple
-from warnings import warn
 
 from markupsafe import Markup
 
@@ -82,17 +81,6 @@ class BaseAttribute:
         if data is True:
             return "true"
 
-        if data is False:
-            warn(
-                f"Attribute fired with data set to False. "
-                f"We will emit {self.name}=false, but in general HTML treats "
-                'attrname="any value" as true. '
-                "If you are sure about this, ignore this warning with "
-                "warnings.filterwarnings('ignore', '"
-                "Attribute fired with data set to False')",
-                stacklevel=2,
-            )
-            return "false"
         # Just a string
         if isinstance(data, str):
             return data

--- a/src/html_compose/base_attribute.py
+++ b/src/html_compose/base_attribute.py
@@ -1,4 +1,5 @@
 from typing import Iterable, Tuple
+from warnings import warn
 
 from markupsafe import Markup
 
@@ -77,6 +78,12 @@ class BaseAttribute:
         """
 
         data = self.data
+
+        if data is True:
+            return "true"
+
+        if data is False:
+            return "false"
         # Just a string
         if isinstance(data, str):
             return data

--- a/src/html_compose/base_element.py
+++ b/src/html_compose/base_element.py
@@ -376,7 +376,7 @@ class BaseElement(ElementBase, metaclass=ElementMeta):
 
     def deferred_resolve(
         self, parent: ElementBase | None = None
-    ) -> Generator[str, None, None]:
+    ) -> Generator[Node, None, None]:
         """
         Resolve all attributes and children of the HTML element, except for callable children.
 

--- a/src/html_compose/base_element.py
+++ b/src/html_compose/base_element.py
@@ -94,6 +94,9 @@ class BaseElement(ElementBase, metaclass=ElementMeta):
         if isinstance(other, self.__class__):
             return self.render() == other.render()
 
+        if isinstance(other, str):
+            return self.render() == other
+
         return False
 
     def _process_attr(

--- a/src/html_compose/base_element.py
+++ b/src/html_compose/base_element.py
@@ -428,8 +428,8 @@ class BaseElement(ElementBase, metaclass=ElementMeta):
                 yield f"<{self.tag} {attr_string}>"
             else:
                 yield f"<{self.tag}>"
-
-            yield from children  # type: ignore[misc] # pyright: ignore[reportReturnType,reportOptionalIterable]
+            if children is not None:
+                yield from children
             yield f"</{self.tag}>"
 
     def resolve(

--- a/src/html_compose/base_element.py
+++ b/src/html_compose/base_element.py
@@ -446,7 +446,7 @@ class BaseElement(ElementBase, metaclass=ElementMeta):
                     element, call_callables=True, parent=parent
                 )
             else:
-                yield element
+                yield cast(str, element)
 
     def render(self, parent: ElementBase | None = None) -> str:
         """

--- a/src/html_compose/base_element.py
+++ b/src/html_compose/base_element.py
@@ -183,7 +183,7 @@ class BaseElement(ElementBase, metaclass=ElementMeta):
                     # no runtime checking here, but hint the type checker
                     item = cast(Mapping[str, Resolvable], item)
 
-                    for key, value in item.items():
+                    for key, value in item.items():  # type: ignore[assignment]
                         attr = BaseAttribute(key, value).evaluate()
                         if not attr:
                             continue
@@ -198,7 +198,7 @@ class BaseElement(ElementBase, metaclass=ElementMeta):
             # hint the type checker
             attrs = cast(Mapping[str, Resolvable], attrs)
 
-            for key, value in attrs.items():
+            for key, value in attrs.items():  # type: ignore[assignment]
                 attr = BaseAttribute(key, value).evaluate()
                 if attr:
                     a_name, a_value = attr

--- a/src/html_compose/base_element.py
+++ b/src/html_compose/base_element.py
@@ -264,8 +264,12 @@ class BaseElement(ElementBase, metaclass=ElementMeta):
             # Recursively resolve the element tree
             yield from child.resolve(self)
 
+        elif isinstance(child, ElementMeta) and not hasattr(child, "__self__"):
+            # This is an uninstantiated class-based element like elements.br
+            inst: BaseElement = child()
+            yield from inst.resolve()
+
         elif isinstance(child, _HasHtml):
-            # Fetch raw HTML from object
             yield unsafe_text(child.__html__())
 
         elif isinstance(child, str):

--- a/src/html_compose/base_types.py
+++ b/src/html_compose/base_types.py
@@ -14,13 +14,13 @@ class _HasHtml(typing.Protocol):
         ...
 
 
-class ElementBase(_HasHtml):
+class ElementBase:
     """
     Base class for all HTML elements
 
     Defined here to avoid circular imports for Node definition
 
-    Implementers define: __init__, render, context, __html__
+    Implementers define: __init__, render, __html__
 
     See: BaseElement
     """

--- a/src/html_compose/document.py
+++ b/src/html_compose/document.py
@@ -1,13 +1,169 @@
-from . import base_types, doctype, pretty_print, unsafe_text
+from typing import Any, Generator, Iterable, Literal
+from urllib.parse import urlencode
+
+from . import base_types, doctype, pretty_print, resource, unsafe_text
 from . import elements as el
 from .util_funcs import get_livereload_env
+
+
+def document_streamer(
+    title: str | None = None,
+    lang: str | None = None,
+    js: Iterable[str | resource.js_import] | None = None,
+    css: Iterable[str | resource.css_import] | None = None,
+    fonts: Iterable[resource.font_import_manual | resource.font_import_provider]
+    | None = None,
+    head_extra: Iterable[base_types.Node] | None = None,
+    body_content: Iterable[base_types.Node] | el.body | None = None,
+    stream_mode: Literal["head_only", "full"] = "head_only",
+) -> Generator[str, Any, None]:
+    """
+    A convenience function to generate a full HTML5 document.
+
+    This is a higher-level function that wraps around HTML5Document,
+    allowing you to specify common elements like JavaScript and CSS imports,
+    as well as additional head content.
+
+    :param title: The title of the document
+    :param lang: The language of the document.
+                 English is "en", or consult HTML documentation
+    :param js: A list of javascript imports to include in the head
+    :param css: A list of CSS imports to include in the head
+    :param head_extra: Additional elements to include in the head
+    :param body_content: A 'body' element or a list of children to add to the 'body' element
+    :param stream_mode: If set, return a generator that yields parts of the document.
+                        "head_only" yields the head, then full body,
+                        "full" yields the entire document in parts.
+    :return: A complete HTML5 document as a string generator
+    """
+    head_elements: list[base_types.Node] = resource.to_elements(js, css, fonts)
+    if head_extra:
+        head_elements.extend(head_extra)
+    return HTML5Stream(
+        title=title,
+        lang=lang,
+        head=head_elements,
+        body=body_content,
+        stream_mode=stream_mode,
+    )
+
+
+def document_generator(
+    title: str | None = None,
+    lang: str | None = None,
+    js: Iterable[str | resource.js_import] | None = None,
+    css: Iterable[str | resource.css_import] | None = None,
+    fonts: Iterable[resource.font_import_manual | resource.font_import_provider]
+    | None = None,
+    head_extra: Iterable[base_types.Node] | None = None,
+    body_content: Iterable[base_types.Node] | el.body | None = None,
+) -> str:
+    """
+    A convenience function to generate a full HTML5 document.
+
+    This is a higher-level function that wraps around HTML5Document,
+    allowing you to specify common elements like JavaScript and CSS imports,
+    as well as additional head content.
+
+    :param title: The title of the document
+    :param lang: The language of the document.
+                 English is "en", or consult HTML documentation
+    :param js: A list of javascript imports to include in the head
+    :param css: A list of CSS imports to include in the head
+    :param head_extra: Additional elements to include in the head
+    :param body_content: A 'body' element or a list of children to add to the 'body' element
+    :return: A complete HTML5 document as a string
+    """
+    return "".join(
+        document_streamer(
+            title=title,
+            lang=lang,
+            js=js,
+            css=css,
+            fonts=fonts,
+            head_extra=head_extra,
+            body_content=body_content,
+            stream_mode="full",
+        )
+    )
+
+
+def HTML5Stream(
+    title: str | None = None,
+    lang: str | None = None,
+    head: list | None = None,
+    body: Iterable[base_types.Node] | el.body | None = None,
+    stream_mode: Literal["head_only", "full"] = "head_only",
+) -> Generator[str, Any, None]:
+    """
+    A streaming version of HTML5Document.
+
+    tldr:
+    ```
+      doctype("html")
+      html(lang=lang)[
+        head[
+          meta(name="viewport", content="width=device-width, initial-scale=1.0")
+          title(title)
+        ]
+        body[body]]
+    ```
+
+    When using livereload, an environment variable is set which adds
+    livereload-js to the head of the document.
+
+    :param title: The title of the document
+    :param lang: The language of the document.
+                 English is "en", or consult HTML documentation
+    :param head: Children to add to the <head> element,
+                 which already defines viewport and title
+    :param body: A 'body' element or a list of children to add to the 'body' element
+    :param stream_mode: If set, return a generator that yields parts of the document.
+                        "head_only" yields the head, then full body,
+                        "full" yields the entire document in parts.
+
+    :return: A generator that yields parts of the HTML5 document as strings
+    """
+    # Enable HTML5 and prevent quirks mode
+    header = doctype("html")
+
+    head_el = el.head()[
+        el.meta(  # enable mobile rendering
+            name="viewport", content="width=device-width, initial-scale=1.0"
+        ),
+        el.title()[title] if title else None,
+        head if head else None,
+    ]
+    # None if disabled
+    live_reload_flags = get_livereload_env()
+    # Feature: Live reloading for development
+    # Fires when HTMLCOMPOSE_LIVERELOAD=1
+    if live_reload_flags:
+        head_el.append(_livereload_script_tag(live_reload_flags))
+    html_el = el.html(lang=lang).resolve()
+    html_el_start = next(html_el)
+    html_el_end = next(html_el)
+    yield f"{header}\n{html_el_start}\n{head_el.render()}\n\n"
+    if isinstance(body, el.body):
+        body_el = body
+    else:
+        body_el = el.body()[body]
+    if stream_mode == "full":
+        for body_part in body_el.resolve():
+            yield body_part
+        yield "\n"
+        yield html_el_end
+    elif stream_mode == "head_only":
+        yield f"{body_el.render()}\n{html_el_end}"
+    else:
+        raise ValueError("stream_mode must be 'head_only' or 'full'")
 
 
 def HTML5Document(
     title: str | None = None,
     lang: str | None = None,
     head: list | None = None,
-    body: list[base_types.Node] | el.body | None = None,
+    body: Iterable[base_types.Node] | el.body | None = None,
     prettify: bool | str = False,
 ) -> str:
     """
@@ -38,28 +194,11 @@ def HTML5Document(
                      If the value is a string, use that parser for BeautifulSoup
     """
     # Enable HTML5 and prevent quirks mode
-    header = doctype("html")
-
-    head_el = el.head()[
-        el.meta(  # enable mobile rendering
-            name="viewport", content="width=device-width, initial-scale=1.0"
-        ),
-        el.title()[title] if title else None,
-        head if head else None,
-    ]
-    # None if disabled
-    live_reload_flags = get_livereload_env()
-    # Feature: Live reloading for development
-    # Fires when HTMLCOMPOSE_LIVERELOAD=1
-    if live_reload_flags:
-        head_el.append(_livereload_script_tag(live_reload_flags))
-
-    if isinstance(body, el.body):
-        body_el = body
-    else:
-        body_el = el.body()[body]
-    html = el.html(lang=lang)[head_el, body_el]
-    result = f"{header}\n{html.render()}"
+    result = "".join(
+        HTML5Stream(
+            title=title, lang=lang, head=head, body=body, stream_mode="full"
+        )
+    )
     if prettify:
         if prettify is True:
             return pretty_print(result)
@@ -98,12 +237,12 @@ def _livereload_script_tag(live_reload_settings):
         # Port isn't important for these but the URI is
         if proxy_uri.startswith("/"):
             proxy_uri = proxy_uri.lstrip("/")
-        uri_encoded_flags = f"host={proxy_host}&path={proxy_uri}"
+        uri_encoded_flags = urlencode({"host": proxy_host, "path": proxy_uri})
     else:
         # Regular development enviroment with no proxy. host:port will do.
         host = live_reload_settings["host"]
         port = live_reload_settings["port"]
-        uri_encoded_flags = f"host={host}&port={port}"
+        uri_encoded_flags = urlencode({"host": host, "port": port})
 
     # This scriptlet auto-inserts the livereload script and detects protocol
     return el.script()[

--- a/src/html_compose/elements/__init__.py
+++ b/src/html_compose/elements/__init__.py
@@ -81,7 +81,7 @@ class htmx:
     '''
 
     @staticmethod
-    def hx_get(value: str) -> BaseAttribute:
+    def get(value: str) -> BaseAttribute:
         '''
         htmx attribute: hx-get
             The hx-get attribute will cause an element to issue a
@@ -94,7 +94,7 @@ class htmx:
 
         return BaseAttribute("hx-get", value)
 
-btn = button([htmx.hx_get("/api/data")])["Click me!"]
+btn = button([htmx.get("/api/data")])["Click me!"]
 btn.render()  # '<button hx-get="/api/data">Click me!</button>'
 ```
 

--- a/src/html_compose/elements/__init__.py
+++ b/src/html_compose/elements/__init__.py
@@ -44,9 +44,6 @@ link = a(href="https://example.com", target="_blank")["Click here"]
 link.render()  # '<a href="https://example.com" target="_blank">Click here</a>'
 ```
 #### Attributes that aren't in the constructor signature
-**Note that events like .onclick are _not_ available in the constructor.**
-
-We do however provide the type hint via `<element>.hint`
 
 The first positional argument is `attrs=` which can be a list of attributes.
 We generate many of these for type hints under `<element>.hint or `<element>._`

--- a/src/html_compose/elements/__init__.py
+++ b/src/html_compose/elements/__init__.py
@@ -102,119 +102,119 @@ Publish your own to make someone elses development experience better!
 
 """
 
-from .a_element import a
-from .abbr_element import abbr
-from .address_element import address
-from .area_element import area
-from .article_element import article
-from .aside_element import aside
-from .audio_element import audio
-from .b_element import b
-from .base_element import base
-from .bdi_element import bdi
-from .bdo_element import bdo
-from .blockquote_element import blockquote
-from .body_element import body
-from .br_element import br
-from .button_element import button
-from .canvas_element import canvas
-from .caption_element import caption
-from .cite_element import cite
-from .code_element import code
-from .col_element import col
-from .colgroup_element import colgroup
-from .data_element import data
-from .datalist_element import datalist
-from .dd_element import dd
-from .del__element import del_
-from .details_element import details
-from .dfn_element import dfn
-from .dialog_element import dialog
-from .div_element import div
-from .dl_element import dl
-from .dt_element import dt
-from .em_element import em
-from .embed_element import embed
-from .fieldset_element import fieldset
-from .figcaption_element import figcaption
-from .figure_element import figure
-from .footer_element import footer
-from .form_element import form
-from .h1_element import h1
-from .h2_element import h2
-from .h3_element import h3
-from .h4_element import h4
-from .h5_element import h5
-from .h6_element import h6
-from .head_element import head
-from .header_element import header
-from .hgroup_element import hgroup
-from .hr_element import hr
-from .html_element import html
-from .i_element import i
-from .iframe_element import iframe
-from .img_element import img
-from .input_element import input
-from .ins_element import ins
-from .kbd_element import kbd
-from .label_element import label
-from .legend_element import legend
-from .li_element import li
-from .link_element import link
-from .main_element import main
-from .map_element import map
-from .mark_element import mark
-from .menu_element import menu
-from .meta_element import meta
-from .meter_element import meter
-from .nav_element import nav
-from .noscript_element import noscript
-from .object_element import object
-from .ol_element import ol
-from .optgroup_element import optgroup
-from .option_element import option
-from .output_element import output
-from .p_element import p
-from .picture_element import picture
-from .pre_element import pre
-from .progress_element import progress
-from .q_element import q
-from .rp_element import rp
-from .rt_element import rt
-from .ruby_element import ruby
-from .s_element import s
-from .samp_element import samp
-from .script_element import script
-from .search_element import search
-from .section_element import section
-from .select_element import select
-from .slot_element import slot
-from .small_element import small
-from .source_element import source
-from .span_element import span
-from .strong_element import strong
-from .style_element import style
-from .sub_element import sub
-from .summary_element import summary
-from .sup_element import sup
-from .svg_element import svg
-from .table_element import table
-from .tbody_element import tbody
-from .td_element import td
-from .template_element import template
-from .textarea_element import textarea
-from .tfoot_element import tfoot
-from .th_element import th
-from .thead_element import thead
-from .time_element import time
-from .title_element import title
-from .tr_element import tr
-from .track_element import track
-from .u_element import u
-from .ul_element import ul
-from .var_element import var
-from .video_element import video
-from .wbr_element import wbr
+from .a_element import a as a
+from .abbr_element import abbr as abbr
+from .address_element import address as address
+from .area_element import area as area
+from .article_element import article as article
+from .aside_element import aside as aside
+from .audio_element import audio as audio
+from .b_element import b as b
+from .base_element import base as base
+from .bdi_element import bdi as bdi
+from .bdo_element import bdo as bdo
+from .blockquote_element import blockquote as blockquote
+from .body_element import body as body
+from .br_element import br as br
+from .button_element import button as button
+from .canvas_element import canvas as canvas
+from .caption_element import caption as caption
+from .cite_element import cite as cite
+from .code_element import code as code
+from .col_element import col as col
+from .colgroup_element import colgroup as colgroup
+from .data_element import data as data
+from .datalist_element import datalist as datalist
+from .dd_element import dd as dd
+from .del__element import del_ as del_
+from .details_element import details as details
+from .dfn_element import dfn as dfn
+from .dialog_element import dialog as dialog
+from .div_element import div as div
+from .dl_element import dl as dl
+from .dt_element import dt as dt
+from .em_element import em as em
+from .embed_element import embed as embed
+from .fieldset_element import fieldset as fieldset
+from .figcaption_element import figcaption as figcaption
+from .figure_element import figure as figure
+from .footer_element import footer as footer
+from .form_element import form as form
+from .h1_element import h1 as h1
+from .h2_element import h2 as h2
+from .h3_element import h3 as h3
+from .h4_element import h4 as h4
+from .h5_element import h5 as h5
+from .h6_element import h6 as h6
+from .head_element import head as head
+from .header_element import header as header
+from .hgroup_element import hgroup as hgroup
+from .hr_element import hr as hr
+from .html_element import html as html
+from .i_element import i as i
+from .iframe_element import iframe as iframe
+from .img_element import img as img
+from .input_element import input as input
+from .ins_element import ins as ins
+from .kbd_element import kbd as kbd
+from .label_element import label as label
+from .legend_element import legend as legend
+from .li_element import li as li
+from .link_element import link as link
+from .main_element import main as main
+from .map_element import map as map
+from .mark_element import mark as mark
+from .menu_element import menu as menu
+from .meta_element import meta as meta
+from .meter_element import meter as meter
+from .nav_element import nav as nav
+from .noscript_element import noscript as noscript
+from .object_element import object as object
+from .ol_element import ol as ol
+from .optgroup_element import optgroup as optgroup
+from .option_element import option as option
+from .output_element import output as output
+from .p_element import p as p
+from .picture_element import picture as picture
+from .pre_element import pre as pre
+from .progress_element import progress as progress
+from .q_element import q as q
+from .rp_element import rp as rp
+from .rt_element import rt as rt
+from .ruby_element import ruby as ruby
+from .s_element import s as s
+from .samp_element import samp as samp
+from .script_element import script as script
+from .search_element import search as search
+from .section_element import section as section
+from .select_element import select as select
+from .slot_element import slot as slot
+from .small_element import small as small
+from .source_element import source as source
+from .span_element import span as span
+from .strong_element import strong as strong
+from .style_element import style as style
+from .sub_element import sub as sub
+from .summary_element import summary as summary
+from .sup_element import sup as sup
+from .svg_element import svg as svg
+from .table_element import table as table
+from .tbody_element import tbody as tbody
+from .td_element import td as td
+from .template_element import template as template
+from .textarea_element import textarea as textarea
+from .tfoot_element import tfoot as tfoot
+from .th_element import th as th
+from .thead_element import thead as thead
+from .time_element import time as time
+from .title_element import title as title
+from .tr_element import tr as tr
+from .track_element import track as track
+from .u_element import u as u
+from .ul_element import ul as ul
+from .var_element import var as var
+from .video_element import video as video
+from .wbr_element import wbr as wbr
 
 import os
 

--- a/src/html_compose/elements/a_element.py
+++ b/src/html_compose/elements/a_element.py
@@ -177,411 +177,410 @@ class a(BaseElement):
         Initialize 'a' (Hyperlink) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `download` :
-            Whether to download the resource instead of navigating to it, and its filename if so
-        
-        `href` :
-            Address of the hyperlink  
-            Valid URL potentially surrounded by spaces
-        
-        `hreflang` :
-            Language of the linked resource  
-            Valid BCP 47 language tag
-        
-        `ping` :
-            URLs to ping
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `rel` :
-            Relationship between the location in the document containing the hyperlink and the destination resource
-        
-        `target` :
-            Navigable for hyperlink navigation  
-            Valid navigable target name or keyword
-        
-        `type` :
-            Hint for the type of the referenced resource  
-            Valid MIME type string
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            download:
+                Whether to download the resource instead of navigating to it, and its filename if so
+            
+            href:
+                Address of the hyperlink.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            hreflang:
+                Language of the linked resource.  
+                Value hint: Valid BCP 47 language tag
+            
+            ping:
+                URLs to ping
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            rel:
+                Relationship between the location in the document containing the hyperlink and the destination resource
+            
+            target:
+                Navigable for hyperlink navigation.  
+                Value hint: Valid navigable target name or keyword
+            
+            type:
+                Hint for the type of the referenced resource.  
+                Value hint: Valid MIME type string
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "a", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/abbr_element.py
+++ b/src/html_compose/elements/abbr_element.py
@@ -169,382 +169,381 @@ class abbr(BaseElement):
         Initialize 'abbr' (Abbreviation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "abbr", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/address_element.py
+++ b/src/html_compose/elements/address_element.py
@@ -169,382 +169,381 @@ class address(BaseElement):
         Initialize 'address' (Contact information for a page or article element) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "address", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/area_element.py
+++ b/src/html_compose/elements/area_element.py
@@ -180,413 +180,412 @@ class area(BaseElement):
         Initialize 'area' (Hyperlink or dead area on an image map) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `alt` :
-            Replacement text for use when images are not available
-        
-        `coords` :
-            Coordinates for the shape to be created in an image map  
-            Valid list of floating-point numbers*
-        
-        `download` :
-            Whether to download the resource instead of navigating to it, and its filename if so
-        
-        `href` :
-            Address of the hyperlink  
-            Valid URL potentially surrounded by spaces
-        
-        `ping` :
-            URLs to ping
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `rel` :
-            Relationship between the location in the document containing the hyperlink and the destination resource
-        
-        `shape` :
-            The kind of shape to be created in an image map
-        
-        `target` :
-            Navigable for hyperlink navigation  
-            Valid navigable target name or keyword
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            alt:
+                Replacement text for use when images are not available
+            
+            coords:
+                Coordinates for the shape to be created in an image map.  
+                Value hint: Valid list of floating-point numbers*
+            
+            download:
+                Whether to download the resource instead of navigating to it, and its filename if so
+            
+            href:
+                Address of the hyperlink.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            ping:
+                URLs to ping
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            rel:
+                Relationship between the location in the document containing the hyperlink and the destination resource
+            
+            shape:
+                The kind of shape to be created in an image map
+            
+            target:
+                Navigable for hyperlink navigation.  
+                Value hint: Valid navigable target name or keyword
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "area", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/article_element.py
+++ b/src/html_compose/elements/article_element.py
@@ -169,382 +169,381 @@ class article(BaseElement):
         Initialize 'article' (Self-contained syndicatable or reusable composition) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "article", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/aside_element.py
+++ b/src/html_compose/elements/aside_element.py
@@ -169,382 +169,381 @@ class aside(BaseElement):
         Initialize 'aside' (Sidebar for tangentially related content) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "aside", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/audio_element.py
+++ b/src/html_compose/elements/audio_element.py
@@ -178,404 +178,403 @@ class audio(BaseElement):
         Initialize 'audio' (Audio player) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `autoplay` :
-            Hint that the media resource can be started automatically when the page is loaded
-        
-        `controls` :
-            Show user agent controls
-        
-        `crossorigin` :
-            How the element handles crossorigin requests
-        
-        `loop` :
-            Whether to loop the media resource
-        
-        `muted` :
-            Whether to mute the media resource by default
-        
-        `preload` :
-            Hints how much buffering the media resource will likely need
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            autoplay:
+                Hint that the media resource can be started automatically when the page is loaded
+            
+            controls:
+                Show user agent controls
+            
+            crossorigin:
+                How the element handles crossorigin requests
+            
+            loop:
+                Whether to loop the media resource
+            
+            muted:
+                Whether to mute the media resource by default
+            
+            preload:
+                Hints how much buffering the media resource will likely need
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "audio", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/b_element.py
+++ b/src/html_compose/elements/b_element.py
@@ -169,382 +169,381 @@ class b(BaseElement):
         Initialize 'b' (Keywords) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "b", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/base_element.py
+++ b/src/html_compose/elements/base_element.py
@@ -171,390 +171,389 @@ class base(BaseElement):
         Initialize 'base' (Base URL and default target navigable for hyperlinks and forms) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `href` :
-            Document base URL  
-            Valid URL potentially surrounded by spaces
-        
-        `target` :
-            Default navigable for hyperlink navigation and form submission  
-            Valid navigable target name or keyword
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            href:
+                Document base URL.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            target:
+                Default navigable for hyperlink navigation and form submission.  
+                Value hint: Valid navigable target name or keyword
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "base", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/bdi_element.py
+++ b/src/html_compose/elements/bdi_element.py
@@ -169,382 +169,381 @@ class bdi(BaseElement):
         Initialize 'bdi' (Text directionality isolation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "bdi", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/bdo_element.py
+++ b/src/html_compose/elements/bdo_element.py
@@ -169,382 +169,381 @@ class bdo(BaseElement):
         Initialize 'bdo' (Text directionality formatting) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "bdo", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/blockquote_element.py
+++ b/src/html_compose/elements/blockquote_element.py
@@ -170,386 +170,385 @@ class blockquote(BaseElement):
         Initialize 'blockquote' (A section quoted from another source) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `cite` :
-            Link to the source of the quotation or more information about the edit  
-            Valid URL potentially surrounded by spaces
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            cite:
+                Link to the source of the quotation or more information about the edit.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "blockquote", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/body_element.py
+++ b/src/html_compose/elements/body_element.py
@@ -187,454 +187,453 @@ class body(BaseElement):
         Initialize 'body' (Document body) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `onafterprint` :
-            afterprint event handler for Window object  
-            Event handler content attribute
-        
-        `onbeforeprint` :
-            beforeprint event handler for Window object  
-            Event handler content attribute
-        
-        `onbeforeunload` :
-            beforeunload event handler for Window object  
-            Event handler content attribute
-        
-        `onhashchange` :
-            hashchange event handler for Window object  
-            Event handler content attribute
-        
-        `onlanguagechange` :
-            languagechange event handler for Window object  
-            Event handler content attribute
-        
-        `onmessage` :
-            message event handler for Window object  
-            Event handler content attribute
-        
-        `onmessageerror` :
-            messageerror event handler for Window object  
-            Event handler content attribute
-        
-        `onoffline` :
-            offline event handler for Window object  
-            Event handler content attribute
-        
-        `ononline` :
-            online event handler for Window object  
-            Event handler content attribute
-        
-        `onpagehide` :
-            pagehide event handler for Window object  
-            Event handler content attribute
-        
-        `onpagereveal` :
-            pagereveal event handler for Window object  
-            Event handler content attribute
-        
-        `onpageshow` :
-            pageshow event handler for Window object  
-            Event handler content attribute
-        
-        `onpageswap` :
-            pageswap event handler for Window object  
-            Event handler content attribute
-        
-        `onpopstate` :
-            popstate event handler for Window object  
-            Event handler content attribute
-        
-        `onrejectionhandled` :
-            rejectionhandled event handler for Window object  
-            Event handler content attribute
-        
-        `onstorage` :
-            storage event handler for Window object  
-            Event handler content attribute
-        
-        `onunhandledrejection` :
-            unhandledrejection event handler for Window object  
-            Event handler content attribute
-        
-        `onunload` :
-            unload event handler for Window object  
-            Event handler content attribute
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            onafterprint:
+                afterprint event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onbeforeprint:
+                beforeprint event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onbeforeunload:
+                beforeunload event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onhashchange:
+                hashchange event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onlanguagechange:
+                languagechange event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onmessage:
+                message event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onmessageerror:
+                messageerror event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onoffline:
+                offline event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            ononline:
+                online event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onpagehide:
+                pagehide event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onpagereveal:
+                pagereveal event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onpageshow:
+                pageshow event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onpageswap:
+                pageswap event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onpopstate:
+                popstate event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onrejectionhandled:
+                rejectionhandled event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onstorage:
+                storage event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onunhandledrejection:
+                unhandledrejection event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onunload:
+                unload event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "body", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/br_element.py
+++ b/src/html_compose/elements/br_element.py
@@ -169,382 +169,381 @@ class br(BaseElement):
         Initialize 'br' (Line break, e.g. in poem or postal address) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "br", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/button_element.py
+++ b/src/html_compose/elements/button_element.py
@@ -198,422 +198,421 @@ class button(BaseElement):
         Initialize 'button' (Button control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `formaction` :
-            URL to use for form submission  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `formenctype` :
-            Entry list encoding type to use for form submission
-        
-        `formmethod` :
-            Variant to use for form submission
-        
-        `formnovalidate` :
-            Bypass form control validation for form submission
-        
-        `formtarget` :
-            Navigable for form submission  
-            Valid navigable target name or keyword
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `popovertarget` :
-            Targets a popover element to toggle, show, or hide  
-            ID*
-        
-        `popovertargetaction` :
-            Indicates whether a targeted popover element is to be toggled, shown, or hidden
-        
-        `type` :
-            Type of button
-        
-        `value` :
-            Value to be used for form submission
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            disabled:
+                Whether the form control is disabled
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            formaction:
+                URL to use for form submission.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            formenctype:
+                Entry list encoding type to use for form submission
+            
+            formmethod:
+                Variant to use for form submission
+            
+            formnovalidate:
+                Bypass form control validation for form submission
+            
+            formtarget:
+                Navigable for form submission.  
+                Value hint: Valid navigable target name or keyword
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            popovertarget:
+                Targets a popover element to toggle, show, or hide.  
+                Value hint: ID*
+            
+            popovertargetaction:
+                Indicates whether a targeted popover element is to be toggled, shown, or hidden
+            
+            type:
+                Type of button
+            
+            value:
+                Value to be used for form submission
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "button", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/canvas_element.py
+++ b/src/html_compose/elements/canvas_element.py
@@ -171,388 +171,387 @@ class canvas(BaseElement):
         Initialize 'canvas' (Scriptable bitmap canvas) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `height` :
-            Vertical dimension
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            height:
+                Vertical dimension
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "canvas", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/caption_element.py
+++ b/src/html_compose/elements/caption_element.py
@@ -169,382 +169,381 @@ class caption(BaseElement):
         Initialize 'caption' (Table caption) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "caption", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/cite_element.py
+++ b/src/html_compose/elements/cite_element.py
@@ -169,382 +169,381 @@ class cite(BaseElement):
         Initialize 'cite' (Title of a work) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "cite", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/code_element.py
+++ b/src/html_compose/elements/code_element.py
@@ -169,382 +169,381 @@ class code(BaseElement):
         Initialize 'code' (Computer code) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "code", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/col_element.py
+++ b/src/html_compose/elements/col_element.py
@@ -170,386 +170,385 @@ class col(BaseElement):
         Initialize 'col' (Table column) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `span` :
-            Number of columns spanned by the element  
-            Valid non-negative integer greater than zero
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            span:
+                Number of columns spanned by the element.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "col", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/colgroup_element.py
+++ b/src/html_compose/elements/colgroup_element.py
@@ -170,386 +170,385 @@ class colgroup(BaseElement):
         Initialize 'colgroup' (Group of columns in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `span` :
-            Number of columns spanned by the element  
-            Valid non-negative integer greater than zero
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            span:
+                Number of columns spanned by the element.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "colgroup", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/data_element.py
+++ b/src/html_compose/elements/data_element.py
@@ -170,385 +170,384 @@ class data(BaseElement):
         Initialize 'data' (Machine-readable equivalent) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `value` :
-            Machine-readable value
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            value:
+                Machine-readable value
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "data", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/datalist_element.py
+++ b/src/html_compose/elements/datalist_element.py
@@ -169,382 +169,381 @@ class datalist(BaseElement):
         Initialize 'datalist' (Container for options for combo box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "datalist", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/dd_element.py
+++ b/src/html_compose/elements/dd_element.py
@@ -169,382 +169,381 @@ class dd(BaseElement):
         Initialize 'dd' (Content for corresponding dt element(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "dd", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/del__element.py
+++ b/src/html_compose/elements/del__element.py
@@ -171,390 +171,389 @@ class del_(BaseElement):
         Initialize 'del' (A removal from the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `cite` :
-            Link to the source of the quotation or more information about the edit  
-            Valid URL potentially surrounded by spaces
-        
-        `datetime` :
-            Date and (optionally) time of the change  
-            Valid date string with optional time
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            cite:
+                Link to the source of the quotation or more information about the edit.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            datetime:
+                Date and (optionally) time of the change.  
+                Value hint: Valid date string with optional time
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "del", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/details_element.py
+++ b/src/html_compose/elements/details_element.py
@@ -171,388 +171,387 @@ class details(BaseElement):
         Initialize 'details' (Disclosure control for hiding details) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `name` :
-            Name of group of mutually-exclusive details elements
-        
-        `open` :
-            Whether the details are visible
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            name:
+                Name of group of mutually-exclusive details elements
+            
+            open:
+                Whether the details are visible
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "details", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/dfn_element.py
+++ b/src/html_compose/elements/dfn_element.py
@@ -169,382 +169,381 @@ class dfn(BaseElement):
         Initialize 'dfn' (Defining instance) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "dfn", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/dialog_element.py
+++ b/src/html_compose/elements/dialog_element.py
@@ -170,385 +170,384 @@ class dialog(BaseElement):
         Initialize 'dialog' (Dialog box or window) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `open` :
-            Whether the dialog box is showing
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            open:
+                Whether the dialog box is showing
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "dialog", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/div_element.py
+++ b/src/html_compose/elements/div_element.py
@@ -169,382 +169,381 @@ class div(BaseElement):
         Initialize 'div' (Generic flow container, or container for name-value groups in dl elements) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "div", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/dl_element.py
+++ b/src/html_compose/elements/dl_element.py
@@ -169,382 +169,381 @@ class dl(BaseElement):
         Initialize 'dl' (Association list consisting of zero or more name-value groups) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "dl", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/dt_element.py
+++ b/src/html_compose/elements/dt_element.py
@@ -169,382 +169,381 @@ class dt(BaseElement):
         Initialize 'dt' (Legend for corresponding dd element(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "dt", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/em_element.py
+++ b/src/html_compose/elements/em_element.py
@@ -169,382 +169,381 @@ class em(BaseElement):
         Initialize 'em' (Stress emphasis) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "em", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/embed_element.py
+++ b/src/html_compose/elements/embed_element.py
@@ -173,396 +173,395 @@ class embed(BaseElement):
         Initialize 'embed' (Plugin) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `height` :
-            Vertical dimension
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `type` :
-            Type of embedded resource  
-            Valid MIME type string
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            height:
+                Vertical dimension
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            type:
+                Type of embedded resource.  
+                Value hint: Valid MIME type string
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "embed", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/fieldset_element.py
+++ b/src/html_compose/elements/fieldset_element.py
@@ -172,392 +172,391 @@ class fieldset(BaseElement):
         Initialize 'fieldset' (Group of form controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `disabled` :
-            Whether the descendant form controls, except any inside legend, are disabled
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            disabled:
+                Whether the descendant form controls, except any inside legend, are disabled
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "fieldset", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/figcaption_element.py
+++ b/src/html_compose/elements/figcaption_element.py
@@ -169,382 +169,381 @@ class figcaption(BaseElement):
         Initialize 'figcaption' (Caption for figure) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "figcaption", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/figure_element.py
+++ b/src/html_compose/elements/figure_element.py
@@ -169,382 +169,381 @@ class figure(BaseElement):
         Initialize 'figure' (Figure with optional caption) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "figure", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/footer_element.py
+++ b/src/html_compose/elements/footer_element.py
@@ -169,382 +169,381 @@ class footer(BaseElement):
         Initialize 'footer' (Footer for a page or section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "footer", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/form_element.py
+++ b/src/html_compose/elements/form_element.py
@@ -183,409 +183,408 @@ class form(BaseElement):
         Initialize 'form' (User-submittable form) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accept_charset` :
-            Character encodings to use for form submission  
-            ASCII case-insensitive match for "UTF-8"
-        
-        `action` :
-            URL to use for form submission  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `autocomplete` :
-            Default setting for autofill feature for controls in the form
-        
-        `enctype` :
-            Entry list encoding type to use for form submission
-        
-        `method` :
-            Variant to use for form submission
-        
-        `name` :
-            Name of form to use in the document.forms API
-        
-        `novalidate` :
-            Bypass form control validation for form submission
-        
-        `target` :
-            Navigable for form submission  
-            Valid navigable target name or keyword
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accept_charset:
+                Character encodings to use for form submission.  
+                Value hint: ASCII case-insensitive match for "UTF-8"
+            
+            action:
+                URL to use for form submission.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            autocomplete:
+                Default setting for autofill feature for controls in the form
+            
+            enctype:
+                Entry list encoding type to use for form submission
+            
+            method:
+                Variant to use for form submission
+            
+            name:
+                Name of form to use in the document.forms API
+            
+            novalidate:
+                Bypass form control validation for form submission
+            
+            target:
+                Navigable for form submission.  
+                Value hint: Valid navigable target name or keyword
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "form", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/h1_element.py
+++ b/src/html_compose/elements/h1_element.py
@@ -169,382 +169,381 @@ class h1(BaseElement):
         Initialize 'h1' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "h1", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/h2_element.py
+++ b/src/html_compose/elements/h2_element.py
@@ -169,382 +169,381 @@ class h2(BaseElement):
         Initialize 'h2' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "h2", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/h3_element.py
+++ b/src/html_compose/elements/h3_element.py
@@ -169,382 +169,381 @@ class h3(BaseElement):
         Initialize 'h3' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "h3", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/h4_element.py
+++ b/src/html_compose/elements/h4_element.py
@@ -169,382 +169,381 @@ class h4(BaseElement):
         Initialize 'h4' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "h4", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/h5_element.py
+++ b/src/html_compose/elements/h5_element.py
@@ -169,382 +169,381 @@ class h5(BaseElement):
         Initialize 'h5' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "h5", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/h6_element.py
+++ b/src/html_compose/elements/h6_element.py
@@ -169,382 +169,381 @@ class h6(BaseElement):
         Initialize 'h6' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "h6", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/head_element.py
+++ b/src/html_compose/elements/head_element.py
@@ -169,382 +169,381 @@ class head(BaseElement):
         Initialize 'head' (Container for document metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "head", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/header_element.py
+++ b/src/html_compose/elements/header_element.py
@@ -169,382 +169,381 @@ class header(BaseElement):
         Initialize 'header' (Introductory or navigational aids for a page or section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "header", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/hgroup_element.py
+++ b/src/html_compose/elements/hgroup_element.py
@@ -169,382 +169,381 @@ class hgroup(BaseElement):
         Initialize 'hgroup' (Heading container) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "hgroup", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/hr_element.py
+++ b/src/html_compose/elements/hr_element.py
@@ -169,382 +169,381 @@ class hr(BaseElement):
         Initialize 'hr' (Thematic break) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "hr", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/html_element.py
+++ b/src/html_compose/elements/html_element.py
@@ -169,382 +169,381 @@ class html(BaseElement):
         Initialize 'html' (Root element) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "html", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/i_element.py
+++ b/src/html_compose/elements/i_element.py
@@ -169,382 +169,381 @@ class i(BaseElement):
         Initialize 'i' (Alternate voice) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "i", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/iframe_element.py
+++ b/src/html_compose/elements/iframe_element.py
@@ -179,417 +179,416 @@ class iframe(BaseElement):
         Initialize 'iframe' (Child navigable) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `allow` :
-            Permissions policy to be applied to the iframe's contents  
-            Serialized permissions policy
-        
-        `allowfullscreen` :
-            Whether to allow the iframe's contents to use requestFullscreen()
-        
-        `height` :
-            Vertical dimension
-        
-        `loading` :
-            Used when determining loading deferral
-        
-        `name` :
-            Name of content navigable  
-            Valid navigable target name or keyword
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `sandbox` :
-            Security rules for nested content
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `srcdoc` :
-            A document to render in the iframe  
-            The source of an iframe srcdoc document*
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            allow:
+                Permissions policy to be applied to the iframe's contents.  
+                Value hint: Serialized permissions policy
+            
+            allowfullscreen:
+                Whether to allow the iframe's contents to use requestFullscreen()
+            
+            height:
+                Vertical dimension
+            
+            loading:
+                Used when determining loading deferral
+            
+            name:
+                Name of content navigable.  
+                Value hint: Valid navigable target name or keyword
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            sandbox:
+                Security rules for nested content
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            srcdoc:
+                A document to render in the iframe.  
+                Value hint: The source of an iframe srcdoc document*
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "iframe", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/img_element.py
+++ b/src/html_compose/elements/img_element.py
@@ -191,426 +191,425 @@ class img(BaseElement):
         Initialize 'img' (Image) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `alt` :
-            Replacement text for use when images are not available
-        
-        `crossorigin` :
-            How the element handles crossorigin requests
-        
-        `decoding` :
-            Decoding hint to use when processing this image for presentation
-        
-        `fetchpriority` :
-            Sets the priority for fetches initiated by the element
-        
-        `height` :
-            Vertical dimension
-        
-        `ismap` :
-            Whether the image is a server-side image map
-        
-        `loading` :
-            Used when determining loading deferral
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `sizes` :
-            Image sizes for different page layouts  
-            Valid source size list
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `srcset` :
-            Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
-            Comma-separated list of image candidate strings
-        
-        `usemap` :
-            Name of image map to use  
-            Valid hash-name reference*
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            alt:
+                Replacement text for use when images are not available
+            
+            crossorigin:
+                How the element handles crossorigin requests
+            
+            decoding:
+                Decoding hint to use when processing this image for presentation
+            
+            fetchpriority:
+                Sets the priority for fetches initiated by the element
+            
+            height:
+                Vertical dimension
+            
+            ismap:
+                Whether the image is a server-side image map
+            
+            loading:
+                Used when determining loading deferral
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            sizes:
+                Image sizes for different page layouts.  
+                Value hint: Valid source size list
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            srcset:
+                Images to use in different situations, e.g., high-resolution displays, small monitors, etc..  
+                Value hint: Comma-separated list of image candidate strings
+            
+            usemap:
+                Name of image map to use.  
+                Value hint: Valid hash-name reference*
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "img", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/input_element.py
+++ b/src/html_compose/elements/input_element.py
@@ -223,498 +223,497 @@ class input(BaseElement):  # type: ignore[misc]
         Initialize 'input' (Form control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accept` :
-            Hint for expected file type in file upload controls  
-            Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*
-        
-        `alpha` :
-            Allow the color's alpha component to be set
-        
-        `alt` :
-            Replacement text for use when images are not available
-        
-        `autocomplete` :
-            Hint for form autofill feature  
-            Autofill field name and related tokens*
-        
-        `checked` :
-            Whether the control is checked
-        
-        `colorspace` :
-            The color space of the serialized color
-        
-        `dirname` :
-            Name of form control to use for sending the element's directionality in form submission
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `formaction` :
-            URL to use for form submission  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `formenctype` :
-            Entry list encoding type to use for form submission
-        
-        `formmethod` :
-            Variant to use for form submission
-        
-        `formnovalidate` :
-            Bypass form control validation for form submission
-        
-        `formtarget` :
-            Navigable for form submission  
-            Valid navigable target name or keyword
-        
-        `height` :
-            Vertical dimension
-        
-        `list` :
-            List of autocomplete options  
-            ID*
-        
-        `max` :
-            Maximum value  
-            Varies*
-        
-        `maxlength` :
-            Maximum length of value
-        
-        `min` :
-            Minimum value  
-            Varies*
-        
-        `minlength` :
-            Minimum length of value
-        
-        `multiple` :
-            Whether to allow multiple values
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `pattern` :
-            Pattern to be matched by the form control's value  
-            Regular expression matching the JavaScript Pattern production
-        
-        `placeholder` :
-            User-visible label to be placed within the form control
-        
-        `popovertarget` :
-            Targets a popover element to toggle, show, or hide  
-            ID*
-        
-        `popovertargetaction` :
-            Indicates whether a targeted popover element is to be toggled, shown, or hidden
-        
-        `readonly` :
-            Whether to allow the value to be edited by the user
-        
-        `required` :
-            Whether the control is required for form submission
-        
-        `size` :
-            Size of the control  
-            Valid non-negative integer greater than zero
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `step` :
-            Granularity to be matched by the form control's value
-        
-        `title` :
-            Description of pattern (when used with pattern attribute)
-        
-        `type` :
-            Type of form control  
-            input type keyword
-        
-        `value` :
-            Value of the form control  
-            Varies*
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accept:
+                Hint for expected file type in file upload controls.  
+                Value hint: Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*
+            
+            alpha:
+                Allow the color's alpha component to be set
+            
+            alt:
+                Replacement text for use when images are not available
+            
+            autocomplete:
+                Hint for form autofill feature.  
+                Value hint: Autofill field name and related tokens*
+            
+            checked:
+                Whether the control is checked
+            
+            colorspace:
+                The color space of the serialized color
+            
+            dirname:
+                Name of form control to use for sending the element's directionality in form submission
+            
+            disabled:
+                Whether the form control is disabled
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            formaction:
+                URL to use for form submission.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            formenctype:
+                Entry list encoding type to use for form submission
+            
+            formmethod:
+                Variant to use for form submission
+            
+            formnovalidate:
+                Bypass form control validation for form submission
+            
+            formtarget:
+                Navigable for form submission.  
+                Value hint: Valid navigable target name or keyword
+            
+            height:
+                Vertical dimension
+            
+            list:
+                List of autocomplete options.  
+                Value hint: ID*
+            
+            max:
+                Maximum value.  
+                Value hint: Varies*
+            
+            maxlength:
+                Maximum length of value
+            
+            min:
+                Minimum value.  
+                Value hint: Varies*
+            
+            minlength:
+                Minimum length of value
+            
+            multiple:
+                Whether to allow multiple values
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            pattern:
+                Pattern to be matched by the form control's value.  
+                Value hint: Regular expression matching the JavaScript Pattern production
+            
+            placeholder:
+                User-visible label to be placed within the form control
+            
+            popovertarget:
+                Targets a popover element to toggle, show, or hide.  
+                Value hint: ID*
+            
+            popovertargetaction:
+                Indicates whether a targeted popover element is to be toggled, shown, or hidden
+            
+            readonly:
+                Whether to allow the value to be edited by the user
+            
+            required:
+                Whether the control is required for form submission
+            
+            size:
+                Size of the control.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            step:
+                Granularity to be matched by the form control's value
+            
+            title:
+                Description of pattern (when used with pattern attribute)
+            
+            type:
+                Type of form control.  
+                Value hint: input type keyword
+            
+            value:
+                Value of the form control.  
+                Value hint: Varies*
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "input", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/ins_element.py
+++ b/src/html_compose/elements/ins_element.py
@@ -171,390 +171,389 @@ class ins(BaseElement):
         Initialize 'ins' (An addition to the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `cite` :
-            Link to the source of the quotation or more information about the edit  
-            Valid URL potentially surrounded by spaces
-        
-        `datetime` :
-            Date and (optionally) time of the change  
-            Valid date string with optional time
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            cite:
+                Link to the source of the quotation or more information about the edit.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            datetime:
+                Date and (optionally) time of the change.  
+                Value hint: Valid date string with optional time
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "ins", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/kbd_element.py
+++ b/src/html_compose/elements/kbd_element.py
@@ -169,382 +169,381 @@ class kbd(BaseElement):
         Initialize 'kbd' (User input) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "kbd", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/label_element.py
+++ b/src/html_compose/elements/label_element.py
@@ -170,386 +170,385 @@ class label(BaseElement):
         Initialize 'label' (Caption for a form control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `for_` :
-            Associate the label with form control  
-            ID*
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            for_:
+                Associate the label with form control.  
+                Value hint: ID*
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "label", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/legend_element.py
+++ b/src/html_compose/elements/legend_element.py
@@ -169,382 +169,381 @@ class legend(BaseElement):
         Initialize 'legend' (Caption for fieldset) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "legend", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/li_element.py
+++ b/src/html_compose/elements/li_element.py
@@ -170,385 +170,384 @@ class li(BaseElement):
         Initialize 'li' (List item) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `value` :
-            Ordinal value of the list item
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            value:
+                Ordinal value of the list item
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "li", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/link_element.py
+++ b/src/html_compose/elements/link_element.py
@@ -187,441 +187,440 @@ class link(BaseElement):  # type: ignore[misc]
         Initialize 'link' (Link metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `as_` :
-            Potential destination for a preload request (for rel="preload" and rel="modulepreload")  
-            Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
-        
-        `blocking` :
-            Whether the element is potentially render-blocking
-        
-        `color` :
-            Color to use when customizing a site's icon (for rel="mask-icon")  
-            CSS <color>
-        
-        `crossorigin` :
-            How the element handles crossorigin requests
-        
-        `disabled` :
-            Whether the link is disabled
-        
-        `fetchpriority` :
-            Sets the priority for fetches initiated by the element
-        
-        `href` :
-            Address of the hyperlink  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `hreflang` :
-            Language of the linked resource  
-            Valid BCP 47 language tag
-        
-        `imagesizes` :
-            Image sizes for different page layouts (for rel="preload")  
-            Valid source size list
-        
-        `imagesrcset` :
-            Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")  
-            Comma-separated list of image candidate strings
-        
-        `integrity` :
-            Integrity metadata used in Subresource Integrity checks [SRI]
-        
-        `media` :
-            Applicable media  
-            Valid media query list
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `rel` :
-            Relationship between the document containing the hyperlink and the destination resource
-        
-        `sizes` :
-            Sizes of the icons (for rel="icon")
-        
-        `title` :
-            CSS style sheet set name
-        `title` :
-            Title of the link
-        
-        `type` :
-            Hint for the type of the referenced resource  
-            Valid MIME type string
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            as_:
+                Potential destination for a preload request (for rel="preload" and rel="modulepreload").  
+                Value hint: Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
+            
+            blocking:
+                Whether the element is potentially render-blocking
+            
+            color:
+                Color to use when customizing a site's icon (for rel="mask-icon").  
+                Value hint: CSS <color>
+            
+            crossorigin:
+                How the element handles crossorigin requests
+            
+            disabled:
+                Whether the link is disabled
+            
+            fetchpriority:
+                Sets the priority for fetches initiated by the element
+            
+            href:
+                Address of the hyperlink.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            hreflang:
+                Language of the linked resource.  
+                Value hint: Valid BCP 47 language tag
+            
+            imagesizes:
+                Image sizes for different page layouts (for rel="preload").  
+                Value hint: Valid source size list
+            
+            imagesrcset:
+                Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload").  
+                Value hint: Comma-separated list of image candidate strings
+            
+            integrity:
+                Integrity metadata used in Subresource Integrity checks [SRI]
+            
+            media:
+                Applicable media.  
+                Value hint: Valid media query list
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            rel:
+                Relationship between the document containing the hyperlink and the destination resource
+            
+            sizes:
+                Sizes of the icons (for rel="icon")
+            
+            title:
+                CSS style sheet set name
+            title:
+                Title of the link
+            
+            type:
+                Hint for the type of the referenced resource.  
+                Value hint: Valid MIME type string
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "link", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/main_element.py
+++ b/src/html_compose/elements/main_element.py
@@ -169,382 +169,381 @@ class main(BaseElement):
         Initialize 'main' (Container for the dominant contents of the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "main", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/map_element.py
+++ b/src/html_compose/elements/map_element.py
@@ -170,385 +170,384 @@ class map(BaseElement):
         Initialize 'map' (Image map) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `name` :
-            Name of image map to reference from the usemap attribute
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            name:
+                Name of image map to reference from the usemap attribute
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "map", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/mark_element.py
+++ b/src/html_compose/elements/mark_element.py
@@ -169,382 +169,381 @@ class mark(BaseElement):
         Initialize 'mark' (Highlight) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "mark", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/menu_element.py
+++ b/src/html_compose/elements/menu_element.py
@@ -169,382 +169,381 @@ class menu(BaseElement):
         Initialize 'menu' (Menu of commands) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "menu", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/meta_element.py
+++ b/src/html_compose/elements/meta_element.py
@@ -182,398 +182,397 @@ class meta(BaseElement):
         Initialize 'meta' (Text metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `charset` :
-            Character encoding declaration
-        
-        `content` :
-            Value of the element
-        
-        `http_equiv` :
-            Pragma directive
-        
-        `media` :
-            Applicable media  
-            Valid media query list
-        
-        `name` :
-            Metadata name
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            charset:
+                Character encoding declaration
+            
+            content:
+                Value of the element
+            
+            http_equiv:
+                Pragma directive
+            
+            media:
+                Applicable media.  
+                Value hint: Valid media query list
+            
+            name:
+                Metadata name
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "meta", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/meter_element.py
+++ b/src/html_compose/elements/meter_element.py
@@ -175,400 +175,399 @@ class meter(BaseElement):
         Initialize 'meter' (Gauge) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `high` :
-            Low limit of high range
-        
-        `low` :
-            High limit of low range
-        
-        `max` :
-            Upper bound of range
-        
-        `min` :
-            Lower bound of range
-        
-        `optimum` :
-            Optimum value in gauge
-        
-        `value` :
-            Current value of the element
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            high:
+                Low limit of high range
+            
+            low:
+                High limit of low range
+            
+            max:
+                Upper bound of range
+            
+            min:
+                Lower bound of range
+            
+            optimum:
+                Optimum value in gauge
+            
+            value:
+                Current value of the element
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "meter", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/nav_element.py
+++ b/src/html_compose/elements/nav_element.py
@@ -169,382 +169,381 @@ class nav(BaseElement):
         Initialize 'nav' (Section with navigational links) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "nav", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/noscript_element.py
+++ b/src/html_compose/elements/noscript_element.py
@@ -169,382 +169,381 @@ class noscript(BaseElement):
         Initialize 'noscript' (Fallback content for script) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "noscript", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/object_element.py
+++ b/src/html_compose/elements/object_element.py
@@ -183,404 +183,403 @@ class object(BaseElement):
         Initialize 'object' (Image, child navigable, or plugin) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `data` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `height` :
-            Vertical dimension
-        
-        `name` :
-            Name of content navigable  
-            Valid navigable target name or keyword
-        
-        `type` :
-            Type of embedded resource  
-            Valid MIME type string
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            data:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            height:
+                Vertical dimension
+            
+            name:
+                Name of content navigable.  
+                Value hint: Valid navigable target name or keyword
+            
+            type:
+                Type of embedded resource.  
+                Value hint: Valid MIME type string
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "object", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/ol_element.py
+++ b/src/html_compose/elements/ol_element.py
@@ -172,391 +172,390 @@ class ol(BaseElement):
         Initialize 'ol' (Ordered list) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `reversed` :
-            Number the list backwards
-        
-        `start` :
-            Starting value of the list
-        
-        `type` :
-            Kind of list marker
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            reversed:
+                Number the list backwards
+            
+            start:
+                Starting value of the list
+            
+            type:
+                Kind of list marker
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "ol", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/optgroup_element.py
+++ b/src/html_compose/elements/optgroup_element.py
@@ -171,388 +171,387 @@ class optgroup(BaseElement):
         Initialize 'optgroup' (Group of options in a list box) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `label` :
-            User-visible label
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            disabled:
+                Whether the form control is disabled
+            
+            label:
+                User-visible label
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "optgroup", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/option_element.py
+++ b/src/html_compose/elements/option_element.py
@@ -173,394 +173,393 @@ class option(BaseElement):
         Initialize 'option' (Option in a list box or combo box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `label` :
-            User-visible label
-        
-        `selected` :
-            Whether the option is selected by default
-        
-        `value` :
-            Value to be used for form submission
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            disabled:
+                Whether the form control is disabled
+            
+            label:
+                User-visible label
+            
+            selected:
+                Whether the option is selected by default
+            
+            value:
+                Value to be used for form submission
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "option", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/output_element.py
+++ b/src/html_compose/elements/output_element.py
@@ -180,392 +180,391 @@ class output(BaseElement):
         Initialize 'output' (Calculated output value) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `for_` :
-            Specifies controls from which the output was calculated
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            for_:
+                Specifies controls from which the output was calculated
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "output", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/p_element.py
+++ b/src/html_compose/elements/p_element.py
@@ -169,382 +169,381 @@ class p(BaseElement):
         Initialize 'p' (Paragraph) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "p", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/picture_element.py
+++ b/src/html_compose/elements/picture_element.py
@@ -169,382 +169,381 @@ class picture(BaseElement):
         Initialize 'picture' (Image) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "picture", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/pre_element.py
+++ b/src/html_compose/elements/pre_element.py
@@ -169,382 +169,381 @@ class pre(BaseElement):
         Initialize 'pre' (Block of preformatted text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "pre", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/progress_element.py
+++ b/src/html_compose/elements/progress_element.py
@@ -171,388 +171,387 @@ class progress(BaseElement):
         Initialize 'progress' (Progress bar) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `max` :
-            Upper bound of range
-        
-        `value` :
-            Current value of the element
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            max:
+                Upper bound of range
+            
+            value:
+                Current value of the element
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "progress", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/q_element.py
+++ b/src/html_compose/elements/q_element.py
@@ -170,386 +170,385 @@ class q(BaseElement):
         Initialize 'q' (Quotation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `cite` :
-            Link to the source of the quotation or more information about the edit  
-            Valid URL potentially surrounded by spaces
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            cite:
+                Link to the source of the quotation or more information about the edit.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "q", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/rp_element.py
+++ b/src/html_compose/elements/rp_element.py
@@ -169,382 +169,381 @@ class rp(BaseElement):
         Initialize 'rp' (Parenthesis for ruby annotation text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "rp", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/rt_element.py
+++ b/src/html_compose/elements/rt_element.py
@@ -169,382 +169,381 @@ class rt(BaseElement):
         Initialize 'rt' (Ruby annotation text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "rt", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/ruby_element.py
+++ b/src/html_compose/elements/ruby_element.py
@@ -169,382 +169,381 @@ class ruby(BaseElement):
         Initialize 'ruby' (Ruby annotation(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "ruby", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/s_element.py
+++ b/src/html_compose/elements/s_element.py
@@ -169,382 +169,381 @@ class s(BaseElement):
         Initialize 's' (Inaccurate text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "s", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/samp_element.py
+++ b/src/html_compose/elements/samp_element.py
@@ -169,382 +169,381 @@ class samp(BaseElement):
         Initialize 'samp' (Computer output) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "samp", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/script_element.py
+++ b/src/html_compose/elements/script_element.py
@@ -181,415 +181,414 @@ class script(BaseElement):
         Initialize 'script' (Embedded script) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `async_` :
-            Execute script when available, without blocking while fetching
-        
-        `blocking` :
-            Whether the element is potentially render-blocking
-        
-        `crossorigin` :
-            How the element handles crossorigin requests
-        
-        `defer` :
-            Defer script execution
-        
-        `fetchpriority` :
-            Sets the priority for fetches initiated by the element
-        
-        `integrity` :
-            Integrity metadata used in Subresource Integrity checks [SRI]
-        
-        `nomodule` :
-            Prevents execution in user agents that support module scripts
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `type` :
-            Type of script  
-            "module"; a valid MIME type string that is not a JavaScript MIME type essence match
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            async_:
+                Execute script when available, without blocking while fetching
+            
+            blocking:
+                Whether the element is potentially render-blocking
+            
+            crossorigin:
+                How the element handles crossorigin requests
+            
+            defer:
+                Defer script execution
+            
+            fetchpriority:
+                Sets the priority for fetches initiated by the element
+            
+            integrity:
+                Integrity metadata used in Subresource Integrity checks [SRI]
+            
+            nomodule:
+                Prevents execution in user agents that support module scripts
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            type:
+                Type of script.  
+                Value hint: "module"; a valid MIME type string that is not a JavaScript MIME type essence match
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "script", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/search_element.py
+++ b/src/html_compose/elements/search_element.py
@@ -169,382 +169,381 @@ class search(BaseElement):
         Initialize 'search' (Container for search controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "search", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/section_element.py
+++ b/src/html_compose/elements/section_element.py
@@ -169,382 +169,381 @@ class section(BaseElement):
         Initialize 'section' (Generic document or application section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "section", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/select_element.py
+++ b/src/html_compose/elements/select_element.py
@@ -186,406 +186,405 @@ class select(BaseElement):
         Initialize 'select' (List box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `autocomplete` :
-            Hint for form autofill feature  
-            Autofill field name and related tokens*
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `multiple` :
-            Whether to allow multiple values
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `required` :
-            Whether the control is required for form submission
-        
-        `size` :
-            Size of the control  
-            Valid non-negative integer greater than zero
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            autocomplete:
+                Hint for form autofill feature.  
+                Value hint: Autofill field name and related tokens*
+            
+            disabled:
+                Whether the form control is disabled
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            multiple:
+                Whether to allow multiple values
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            required:
+                Whether the control is required for form submission
+            
+            size:
+                Size of the control.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "select", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/slot_element.py
+++ b/src/html_compose/elements/slot_element.py
@@ -170,385 +170,384 @@ class slot(BaseElement):
         Initialize 'slot' (Shadow tree slot) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `name` :
-            Name of shadow tree slot
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            name:
+                Name of shadow tree slot
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "slot", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/small_element.py
+++ b/src/html_compose/elements/small_element.py
@@ -169,382 +169,381 @@ class small(BaseElement):
         Initialize 'small' (Side comment) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "small", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/source_element.py
+++ b/src/html_compose/elements/source_element.py
@@ -176,408 +176,407 @@ class source(BaseElement):
         Initialize 'source' (Image source for img or media source for video or audio) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `height` :
-            Vertical dimension
-        
-        `media` :
-            Applicable media  
-            Valid media query list
-        
-        `sizes` :
-            Image sizes for different page layouts  
-            Valid source size list
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `srcset` :
-            Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
-            Comma-separated list of image candidate strings
-        
-        `type` :
-            Type of embedded resource  
-            Valid MIME type string
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            height:
+                Vertical dimension
+            
+            media:
+                Applicable media.  
+                Value hint: Valid media query list
+            
+            sizes:
+                Image sizes for different page layouts.  
+                Value hint: Valid source size list
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            srcset:
+                Images to use in different situations, e.g., high-resolution displays, small monitors, etc..  
+                Value hint: Comma-separated list of image candidate strings
+            
+            type:
+                Type of embedded resource.  
+                Value hint: Valid MIME type string
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "source", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/span_element.py
+++ b/src/html_compose/elements/span_element.py
@@ -169,382 +169,381 @@ class span(BaseElement):
         Initialize 'span' (Generic phrasing container) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "span", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/strong_element.py
+++ b/src/html_compose/elements/strong_element.py
@@ -169,382 +169,381 @@ class strong(BaseElement):
         Initialize 'strong' (Importance) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "strong", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/style_element.py
+++ b/src/html_compose/elements/style_element.py
@@ -171,389 +171,388 @@ class style(BaseElement):  # type: ignore[misc]
         Initialize 'style' (Embedded styling information) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `blocking` :
-            Whether the element is potentially render-blocking
-        
-        `media` :
-            Applicable media  
-            Valid media query list
-        
-        `title` :
-            CSS style sheet set name
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            blocking:
+                Whether the element is potentially render-blocking
+            
+            media:
+                Applicable media.  
+                Value hint: Valid media query list
+            
+            title:
+                CSS style sheet set name
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "style", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/sub_element.py
+++ b/src/html_compose/elements/sub_element.py
@@ -169,382 +169,381 @@ class sub(BaseElement):
         Initialize 'sub' (Subscript) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "sub", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/summary_element.py
+++ b/src/html_compose/elements/summary_element.py
@@ -169,382 +169,381 @@ class summary(BaseElement):
         Initialize 'summary' (Caption for details) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "summary", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/sup_element.py
+++ b/src/html_compose/elements/sup_element.py
@@ -169,382 +169,381 @@ class sup(BaseElement):
         Initialize 'sup' (Superscript) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "sup", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/svg_element.py
+++ b/src/html_compose/elements/svg_element.py
@@ -169,382 +169,381 @@ class svg(BaseElement):
         Initialize 'svg' (SVG root) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "svg", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/table_element.py
+++ b/src/html_compose/elements/table_element.py
@@ -169,382 +169,381 @@ class table(BaseElement):
         Initialize 'table' (Table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "table", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/tbody_element.py
+++ b/src/html_compose/elements/tbody_element.py
@@ -169,382 +169,381 @@ class tbody(BaseElement):
         Initialize 'tbody' (Group of rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "tbody", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/td_element.py
+++ b/src/html_compose/elements/td_element.py
@@ -172,392 +172,391 @@ class td(BaseElement):
         Initialize 'td' (Table cell) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `colspan` :
-            Number of columns that the cell is to span  
-            Valid non-negative integer greater than zero
-        
-        `headers` :
-            The header cells for this cell
-        
-        `rowspan` :
-            Number of rows that the cell is to span
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            colspan:
+                Number of columns that the cell is to span.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            headers:
+                The header cells for this cell
+            
+            rowspan:
+                Number of rows that the cell is to span
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "td", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/template_element.py
+++ b/src/html_compose/elements/template_element.py
@@ -173,394 +173,393 @@ class template(BaseElement):
         Initialize 'template' (Template) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `shadowrootclonable` :
-            Sets clonable on a declarative shadow root
-        
-        `shadowrootdelegatesfocus` :
-            Sets delegates focus on a declarative shadow root
-        
-        `shadowrootmode` :
-            Enables streaming declarative shadow roots
-        
-        `shadowrootserializable` :
-            Sets serializable on a declarative shadow root
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            shadowrootclonable:
+                Sets clonable on a declarative shadow root
+            
+            shadowrootdelegatesfocus:
+                Sets delegates focus on a declarative shadow root
+            
+            shadowrootmode:
+                Enables streaming declarative shadow roots
+            
+            shadowrootserializable:
+                Sets serializable on a declarative shadow root
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "template", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/textarea_element.py
+++ b/src/html_compose/elements/textarea_element.py
@@ -192,425 +192,424 @@ class textarea(BaseElement):
         Initialize 'textarea' (Multiline text controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `autocomplete` :
-            Hint for form autofill feature  
-            Autofill field name and related tokens*
-        
-        `cols` :
-            Maximum number of characters per line  
-            Valid non-negative integer greater than zero
-        
-        `dirname` :
-            Name of form control to use for sending the element's directionality in form submission
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `maxlength` :
-            Maximum length of value
-        
-        `minlength` :
-            Minimum length of value
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `placeholder` :
-            User-visible label to be placed within the form control
-        
-        `readonly` :
-            Whether to allow the value to be edited by the user
-        
-        `required` :
-            Whether the control is required for form submission
-        
-        `rows` :
-            Number of lines to show  
-            Valid non-negative integer greater than zero
-        
-        `wrap` :
-            How the value of the form control is to be wrapped for form submission
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            autocomplete:
+                Hint for form autofill feature.  
+                Value hint: Autofill field name and related tokens*
+            
+            cols:
+                Maximum number of characters per line.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            dirname:
+                Name of form control to use for sending the element's directionality in form submission
+            
+            disabled:
+                Whether the form control is disabled
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            maxlength:
+                Maximum length of value
+            
+            minlength:
+                Minimum length of value
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            placeholder:
+                User-visible label to be placed within the form control
+            
+            readonly:
+                Whether to allow the value to be edited by the user
+            
+            required:
+                Whether the control is required for form submission
+            
+            rows:
+                Number of lines to show.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            wrap:
+                How the value of the form control is to be wrapped for form submission
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "textarea", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/tfoot_element.py
+++ b/src/html_compose/elements/tfoot_element.py
@@ -169,382 +169,381 @@ class tfoot(BaseElement):
         Initialize 'tfoot' (Group of footer rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "tfoot", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/th_element.py
+++ b/src/html_compose/elements/th_element.py
@@ -176,398 +176,397 @@ class th(BaseElement):
         Initialize 'th' (Table header cell) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `abbr` :
-            Alternative label to use for the header cell when referencing the cell in other contexts
-        
-        `colspan` :
-            Number of columns that the cell is to span  
-            Valid non-negative integer greater than zero
-        
-        `headers` :
-            The header cells for this cell
-        
-        `rowspan` :
-            Number of rows that the cell is to span
-        
-        `scope` :
-            Specifies which cells the header cell applies to
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            abbr:
+                Alternative label to use for the header cell when referencing the cell in other contexts
+            
+            colspan:
+                Number of columns that the cell is to span.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            headers:
+                The header cells for this cell
+            
+            rowspan:
+                Number of rows that the cell is to span
+            
+            scope:
+                Specifies which cells the header cell applies to
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "th", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/thead_element.py
+++ b/src/html_compose/elements/thead_element.py
@@ -169,382 +169,381 @@ class thead(BaseElement):
         Initialize 'thead' (Group of heading rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "thead", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/time_element.py
+++ b/src/html_compose/elements/time_element.py
@@ -170,386 +170,385 @@ class time(BaseElement):
         Initialize 'time' (Machine-readable equivalent of date- or time-related data) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `datetime` :
-            Machine-readable value  
-            Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            datetime:
+                Machine-readable value.  
+                Value hint: Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "time", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/title_element.py
+++ b/src/html_compose/elements/title_element.py
@@ -169,382 +169,381 @@ class title(BaseElement):
         Initialize 'title' (Document title) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "title", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/tr_element.py
+++ b/src/html_compose/elements/tr_element.py
@@ -169,382 +169,381 @@ class tr(BaseElement):
         Initialize 'tr' (Table row) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "tr", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/track_element.py
+++ b/src/html_compose/elements/track_element.py
@@ -178,399 +178,398 @@ class track(BaseElement):
         Initialize 'track' (Timed text track) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `default` :
-            Enable the track if no other text track is more suitable
-        
-        `kind` :
-            The type of text track
-        
-        `label` :
-            User-visible label
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `srclang` :
-            Language of the text track  
-            Valid BCP 47 language tag
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            default:
+                Enable the track if no other text track is more suitable
+            
+            kind:
+                The type of text track
+            
+            label:
+                User-visible label
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            srclang:
+                Language of the text track.  
+                Value hint: Valid BCP 47 language tag
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "track", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/elements/u_element.py
+++ b/src/html_compose/elements/u_element.py
@@ -169,382 +169,381 @@ class u(BaseElement):
         Initialize 'u' (Unarticulated annotation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "u", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/ul_element.py
+++ b/src/html_compose/elements/ul_element.py
@@ -169,382 +169,381 @@ class ul(BaseElement):
         Initialize 'ul' (List) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "ul", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/var_element.py
+++ b/src/html_compose/elements/var_element.py
@@ -169,382 +169,381 @@ class var(BaseElement):
         Initialize 'var' (Variable) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "var", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/video_element.py
+++ b/src/html_compose/elements/video_element.py
@@ -182,417 +182,416 @@ class video(BaseElement):
         Initialize 'video' (Video player) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `autoplay` :
-            Hint that the media resource can be started automatically when the page is loaded
-        
-        `controls` :
-            Show user agent controls
-        
-        `crossorigin` :
-            How the element handles crossorigin requests
-        
-        `height` :
-            Vertical dimension
-        
-        `loop` :
-            Whether to loop the media resource
-        
-        `muted` :
-            Whether to mute the media resource by default
-        
-        `playsinline` :
-            Encourage the user agent to display video content within the element's playback area
-        
-        `poster` :
-            Poster frame to show prior to video playback  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `preload` :
-            Hints how much buffering the media resource will likely need
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            autoplay:
+                Hint that the media resource can be started automatically when the page is loaded
+            
+            controls:
+                Show user agent controls
+            
+            crossorigin:
+                How the element handles crossorigin requests
+            
+            height:
+                Vertical dimension
+            
+            loop:
+                Whether to loop the media resource
+            
+            muted:
+                Whether to mute the media resource by default
+            
+            playsinline:
+                Encourage the user agent to display video content within the element's playback area
+            
+            poster:
+                Poster frame to show prior to video playback.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            preload:
+                Hints how much buffering the media resource will likely need
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "video", void_element=False, attrs=attrs, children=children

--- a/src/html_compose/elements/wbr_element.py
+++ b/src/html_compose/elements/wbr_element.py
@@ -169,382 +169,381 @@ class wbr(BaseElement):
         Initialize 'wbr' (Line breaking opportunity) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """  # fmt: skip
         super().__init__(
             "wbr", void_element=True, attrs=attrs, children=children

--- a/src/html_compose/live/watcher.py
+++ b/src/html_compose/live/watcher.py
@@ -149,6 +149,7 @@ class WatchCond:
 
         :param path_glob: Glob pattern(s) to watch for changes.
         :param action: Action to run when a change is detected. Shell command or function.
+                       When action is None, no action is run but reloads may still occur.
         :param ignore_glob: Glob patterns to ignore.
         :param delay: Delay in seconds before running the action after a change.
 

--- a/src/html_compose/notebook.py
+++ b/src/html_compose/notebook.py
@@ -1,13 +1,17 @@
+from html_compose.base_types import _HasHtml
+
 """
 Jupyter notebook helpers
 """
 
 
-def render(html_string: str):
+def render(html_string: str | _HasHtml):
     """
     Renders the given HTML string as an IPython HTML object.
     This is used by Jupyter notebooks to display HTML content.
     """
     from IPython.core.display import HTML
 
+    if isinstance(html_string, _HasHtml):
+        html_string = html_string.__html__()
     return HTML(html_string)

--- a/src/html_compose/resource/__init__.py
+++ b/src/html_compose/resource/__init__.py
@@ -1,0 +1,171 @@
+"""
+Resource import helper classes
+
+For javascript:
+* Manage preload
+* Manage import maps
+* Manage cache busting for local resources
+* Manage SRI hashes
+
+For css:
+* Manage preload
+* Manage cache busting for local resources
+* Manage SRI hashes
+
+For fonts:
+* Manage preconnect
+* Manage preload
+* Manage css @font-face generation or importing from providers i.e. Google Fonts
+
+"""
+
+import json
+from typing import Any, Iterable
+
+from .. import base_types, unsafe_text
+from .. import elements as el
+
+
+class settings:
+    """
+    Global settings for js_import/css_import behavior.
+
+    `base_dir` is base directory from which local static files are served
+    and is used to construct cache busting URLs.
+    """
+
+    # Base directory when resolving relative paths for local resources
+    base_dir = "."
+    # html-compose cache-buster timestamp
+    query_string = "hccbts"
+    # Maximum number of cached URIs for cache busting
+    cache_cap = 1000
+    stat_poll_interval: int | float = 1  # seconds
+
+
+class _State:
+    """
+    Internal state for local static resource imports
+    """
+
+    stat_cache: dict[str, int | float] = {}
+
+    misc_stat_cache: dict[str, int | float] = {}
+
+
+from .css_import import css_import  # noqa: E402
+from .font_import import font_import_manual, font_import_provider  # noqa: E402
+from .js_import import js_import  # noqa: E402
+
+
+def to_elements(
+    js: Iterable[str | js_import] | None = None,
+    css: Iterable[str | css_import] | None = None,
+    fonts: Iterable[font_import_manual | font_import_provider] | None = None,
+):
+    """
+    Generate elements for `head` element from resource imports
+
+    Depending on your use case consider caching the resolution of this function
+
+
+    :param js: Javascript imports. A string is treated as a simple script src
+    :param css: CSS imports. A string is treated as a simple link rel=stylesheet
+    :param fonts: Font imports
+    """
+    head_elements: list[base_types.Node] = []
+
+    preconnect_links = []
+    preload_links = []
+    links = []
+    if css:
+        for css_resource in css:
+            if isinstance(css_resource, css_import):
+                for link in css_resource.links():
+                    links.append(link)
+                for preload in css_resource.preloads():
+                    preload_links.append(preload)
+            else:
+                if not isinstance(css_resource, str):
+                    raise TypeError("css must be str or css_import")
+
+                links.append(el.link(rel="stylesheet", href=css_resource))
+
+    script_tags = []
+    if js:
+        #  <link rel="modulepreload" href="main.js" />
+        js_imports: dict[str, str] = {}
+        scopes: dict[str, dict[str, str]] = {}
+        for js_src in js:
+            if isinstance(js_src, js_import):
+                jsi: js_import = js_src
+                # Generate script tag
+                script_tags.append(jsi.script())
+                link = jsi.preload_link()
+                if link:
+                    preload_links.append(link)
+
+                entry = jsi.import_map_entry()
+                if entry:
+                    # Add to import map
+                    name, src = entry[0:2]
+                    js_imports[name] = src
+                    if len(entry) == 3:
+                        # Scopes feature, although I can't imagine anyone
+                        # using it.
+                        scope = str(entry[2])
+                        sdict = scopes.setdefault(scope, {})
+                        sdict[name] = src
+
+            else:
+                if not isinstance(js_src, str):
+                    raise TypeError("js must be str or js_import")
+                script_tags.append(el.script(src=js_src))
+
+        if js_imports:
+            import_map: dict[str, Any] = {"imports": js_imports}
+            if scopes:
+                import_map["scopes"] = scopes
+            # dump to json; prevent escapes
+            js_dump = json.dumps(import_map).replace("<", "\\u003c")
+            script_tags.insert(
+                0, el.script(type="importmap")[unsafe_text(js_dump)]
+            )
+    style_text: list[str] = []
+    if fonts:
+        for font in fonts:
+            # Each font may be a different kind but the interface means
+            # we capture anything they generate
+            links.extend(font.links())
+            preconnect_links.extend(font.preconnect_links())
+            preload_links.extend(font.preload_links())
+            style_data = font.style_data()
+            if style_data:
+                style_text.append(style_data)
+
+    if preconnect_links:
+        head_elements.extend(preconnect_links)
+
+    if preload_links:
+        head_elements.extend(preload_links)
+
+    if links:
+        head_elements.extend(links)
+
+    if style_text:
+        head_elements.append(el.style()[unsafe_text("\n".join(style_text))])
+
+    if script_tags:
+        head_elements.extend(script_tags)
+
+    return head_elements
+
+
+__all__ = [
+    "js_import",
+    "css_import",
+    "font_import_manual",
+    "font_import_provider",
+    "to_elements",
+    "settings",
+]

--- a/src/html_compose/resource/css_import.py
+++ b/src/html_compose/resource/css_import.py
@@ -1,0 +1,162 @@
+from typing import Literal
+
+from .. import elements as el
+from .util_funcs import _cachebust_resource_uri
+
+
+class css_import:
+    """
+    A css import helper class which employs:
+    - `link(rel="stylesheet")` to define the import
+    - `link(rel="preload")` to preload the import
+    - `hash` and `crossorigin` for SRI
+    - Local resource cache busting
+
+    An production usage might look like:
+    ```python
+    [
+    css_import('./static/admin.css',
+                cache_bust=True),
+
+    css_import(
+        "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css",
+        hash=(
+            "sha384-9ndCyUaIbzAi2FUVXJi0CjmCapS"
+            "mO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
+            ),
+        crossorigin="anonymous",
+        preload=True
+    )
+
+    ]
+    ...
+
+    ...
+
+    ## Generated "HTML":
+
+    ```python
+    import json
+    from html_compose import el
+
+    [
+        link(rel='preload',
+            href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css',
+            as_='style',
+            integrity='sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7'
+            'SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM',
+            crossorigin='anonymous'),
+
+        link(rel='stylesheet', href='./static/admin.css?ts=1760153426'),
+
+        link(rel='stylesheet',
+            href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css',
+            integrity='sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7'
+            'SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM',
+            crossorigin='anonymous')
+    ]
+    ```
+
+    See:
+        https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload
+        https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+        https://www.srihash.org/
+
+    """
+
+    def __init__(
+        self,
+        href: str,
+        preload: bool = False,
+        hash: str | None = None,
+        crossorigin: Literal["", "anonymous", "user-credentials"]
+        | str
+        | None = None,
+        cache_bust: bool = False,
+    ):
+        """
+        A css import wrapper to wrap some of the complexity of optimal
+        resource loading.
+
+
+        Parameters
+        ----------
+        `href`:
+            The literal href passed to the link tag
+
+        `preload`:
+            If true, adds a preload link for this resource
+
+        `hash`:
+            An optional SRI integrity hash for the import
+
+        `crossorigin`:
+            Optionally sets the crossorigin attribute on the link tag.
+            Valid values are "", "anonymous", "use-credentials"
+
+        `cache_bust`:
+            If true, appends a timestamp to the URL to prevent browser
+            caching. Webservers configured for static resources manage this
+            feature automatically, but for development this can be useful.
+
+            This feature only works for local resources, i.e. those that
+            exist in `resource.settings.base_dir`
+
+        """
+        self.href = href
+        self.preload = preload
+        self.hash = hash
+        self.crossorigin = crossorigin
+        self.cache_bust = cache_bust
+        self.has_link = preload
+        self._href = self.uri()
+
+        if hash and self.crossorigin is None:
+            raise ValueError(
+                "If hash is set, crossorigin must be set to ''/'anonymous'"
+            )
+
+    def uri(self):
+        """
+        Returns the source URI - with cache busting if enabled
+        which is implemented by getting the mtime of the local file
+
+        This operation performs up to two fs stats per call
+
+        1. The base static directory is checked once and cached per interpreter
+        2. The specific resource is checked if it is time to poll again
+           based on settings.stat_poll_interval
+        """
+        if not self.cache_bust:
+            return self.href
+
+        return _cachebust_resource_uri(self.href)
+
+    def preloads(self) -> list[el.link]:
+        """
+        Returns a link element for preloading this import if preload is set
+        """
+        attrs = {"href": self._href}
+        if self.hash:
+            attrs["integrity"] = self.hash
+        if self.crossorigin:
+            attrs["crossorigin"] = self.crossorigin
+        if self.preload:
+            return [el.link(attrs=attrs, rel="preload", as_="style")]
+
+        return []
+
+    def links(self):
+        """
+        Returns one or more link element for this import
+        """
+        links = []
+        attrs = {"href": self._href}
+        if self.hash:
+            attrs["integrity"] = self.hash
+        if self.crossorigin:
+            attrs["crossorigin"] = self.crossorigin
+
+        links.append(el.link(attrs=attrs, rel="stylesheet"))
+
+        return links

--- a/src/html_compose/resource/css_import.py
+++ b/src/html_compose/resource/css_import.py
@@ -29,9 +29,7 @@ class css_import:
     )
 
     ]
-    ...
-
-    ...
+    ```
 
     ## Generated "HTML":
 

--- a/src/html_compose/resource/font_import.py
+++ b/src/html_compose/resource/font_import.py
@@ -1,0 +1,387 @@
+from typing import Iterable, Literal
+
+from .. import elements as el
+from .util_funcs import _cachebust_resource_uri
+
+_AUTODETECT_CSS_FONT_TYPES = {
+    "otc": "collection",
+    "ttc": "collection",
+    "eot": "embedded-opentype",
+    "otf": "opentype",
+    "ttf": "truetype",
+    "svg": "svg",
+    "svgz": "svg",
+    "woff": "woff",
+    "woff2": "woff2",
+}
+
+_AUTODETECT_FONT_MIMETYPES = {
+    "otc": "font/collection",
+    "ttc": "font/collection",
+    "eot": "application/vnd.ms-fontobject",
+    "otf": "font/otf",
+    "ttf": "font/ttf",
+    "svg": "image/svg+xml",
+    "woff": "font/woff",
+    "woff2": "font/woff2",
+}
+
+
+class _font_import_base:
+    def preload_links(self) -> list[el.link]:
+        raise NotImplementedError()
+
+    def links(self) -> list[el.link]:
+        raise NotImplementedError()
+
+    def style_data(self) -> str:
+        raise NotImplementedError()
+
+    def preconnect_links(self) -> list[el.link]:
+        raise NotImplementedError()
+
+
+class font_import_manual(_font_import_base):
+    def __init__(
+        self,
+        hrefs: str | Iterable[str],
+        family: str,
+        weight: int
+        | tuple
+        | str
+        | Literal["bold", "light", "lighter", "bolder", "normal"]
+        | None = "normal",
+        style: Literal["normal", "italic", "oblique"] | str = "normal",
+        display: Literal["swap", "optional", "fallback", "auto", "block"]
+        | str = "swap",
+        preload: bool = True,
+        crossorigin: Literal["", "anonymous", "use-credentials"] | None = None,
+        unicode_range: str | None = None,
+        cache_bust: bool = False,
+    ) -> None:
+        """
+        Declare a web font via @font-face and (optionally) emit
+        a preload `<link>`.
+        This initializer targets the direct-file flow (you supply the exact .woff2 URL).
+
+        If multiple hrefs are provided, preload must choose only one and so
+        the first href is used for preload and the rest are only
+        in the @font-face.
+
+        Values are passed verbatim. NEVER use this with untrusted user input.
+
+        Parameters
+        ----------
+
+        `hrefs`:
+            1 or more URL to the font file (typically .woff2).
+            Pass a str for a single URL, or an iterable of str for multiple URLs.
+
+            The @font-face `src` will reference this URL verbatim.
+
+        `family`:
+            CSS `font-family` name to expose (e.g., "Noto Sans").
+            Do not include quotes; they are added automatically.
+
+        `weight`:
+            Single numeric weight (e.g., 400) for a static face, or a `(low, high)`
+            tuple (e.g., `(100, 900)`) for a variable font range.
+
+        `style`:
+            Font style for this face: `"normal"` or `"italic"`. Declare another
+            instance for the other style if needed.
+
+        `display`:
+            `font-display` strategy. `"swap"` is a safe default to avoid FOIT.
+
+        `preload`:
+            If `True`, also create a `<link rel="preload" as="font" ...>` for `href`.
+            Preload only warms the fetch; the @font-face rule still does the actual use.
+
+        `crossorigin`:
+            CORS mode for cross-origin fonts. When unset, it is
+            fetched as same-origin Use `""` or `anonymous` for most CDN/remote
+            cases, or `"use-credentials"` to pass cookies if strictly necessary.
+
+        `unicode_range`:
+            Optional CSS `unicode-range` (e.g., `"U+0000-00FF"`) to subset coverage.
+        """
+        if isinstance(hrefs, str):
+            hrefs = [hrefs]
+        self.hrefs = hrefs
+        self.weight = weight
+        self.style = style
+        self.display = display
+        self.preload = preload
+        self.crossorigin = crossorigin
+        self.cache_bust = cache_bust
+        self.has_link = preload
+        self.unicode_range = unicode_range
+        self._hrefs = self.uris()
+
+        # Escape most stuff that could break out of quotes
+        safe_family = (
+            family.replace("\\", "\\\\").replace("'", "\\'").replace('"', '\\"')
+        )
+        self.family = safe_family
+
+    def uris(self) -> list[str]:  # -> list[str] | list[Any]:
+        """
+        Returns the source URI - with cache busting if enabled
+        which is implemented by getting the mtime of the local file
+
+        This operation performs up to two fs stats per call
+
+        1. The base static directory is checked once and cached per interpreter
+        2. The specific resource is checked if it is time to poll again
+           based on settings.stat_poll_interval
+        """
+        hrefs = []
+        for h in self.hrefs:
+            if not self.cache_bust:
+                hrefs.append(h)
+                continue
+
+            hrefs.append(_cachebust_resource_uri(h))
+        return hrefs
+
+    @staticmethod
+    def get_font_format(href: str) -> str | None:
+        ext = href.split(".")[-1].lower()
+        return _AUTODETECT_CSS_FONT_TYPES.get(ext, None)
+
+    @staticmethod
+    def get_font_mime(href: str) -> str | None:
+        ext = href.split(".")[-1].lower()
+        return _AUTODETECT_FONT_MIMETYPES.get(ext, None)
+
+    def preload_links(self) -> list[el.link]:
+        """
+        Returns preload links if preload is set
+        """
+        if not self.preload:
+            return []
+
+        first_href = self._hrefs[0]
+        attrs = {"href": first_href}
+
+        if self.crossorigin:
+            attrs["crossorigin"] = self.crossorigin
+
+        mimetype = font_import_manual.get_font_mime(first_href)
+
+        if mimetype:
+            attrs["type"] = mimetype
+
+        return [el.link(attrs=attrs, rel="preload", as_="font")]
+
+    def links(self) -> list[el.link]:
+        return []
+
+    def style_data(self) -> str:
+        """
+        Returns one or more nodes for this import
+        """
+
+        font_refs = []
+
+        if len(self._hrefs) == 1:
+            # we don't have to hint format if there's only one
+            font_refs.append(f"url('{self._hrefs[0]}')")
+        else:
+            for h in self._hrefs:
+                entry = f"url('{h}')"
+                format = font_import_manual.get_font_format(h)
+                if format:
+                    entry += f" format('{format}')"
+
+                font_refs.append(entry)
+
+        if isinstance(self.weight, tuple):
+            font_weight = f"{self.weight[0]} {self.weight[1]}"
+        elif isinstance(self.weight, str):
+            font_weight = self.weight
+        elif isinstance(self.weight, int):
+            font_weight = str(self.weight)
+        else:
+            raise TypeError("font weight must be int, str, or tuple")
+
+        style_attrs = {
+            "font-family": f"'{self.family}'",
+            "src": ",\n\t\t".join(font_refs),
+            "font-style": self.style,
+            "font-display": self.display,
+            "font-weight": font_weight,
+            "unicode-range": self.unicode_range,
+        }
+        for k in list(style_attrs.keys()):
+            v = style_attrs[k]
+            if v is None:
+                del style_attrs[k]
+
+        return "\n".join(
+            [
+                "@font-face {",
+                "".join(
+                    [
+                        "\t",
+                        ";\n\t".join(
+                            [f"{k}: {v}" for k, v in style_attrs.items()]
+                        ),
+                        ";",  # Ensure last property ends with semicolon
+                    ]
+                ),
+                "}",
+            ]
+        )
+
+    def preconnect_links(self) -> list[el.link]:
+        return []
+
+
+class font_import_provider(_font_import_base):
+    def __init__(
+        self,
+        href: str,
+        preload: bool = False,
+        hash: str | None = None,
+        crossorigin: Literal["", "anonymous", "user-credentials"]
+        | str
+        | None = None,
+        cache_bust: bool = False,
+        preconnect: list[str] | None = None,
+        preconnect_crossorigin: Literal["", "anonymous", "user-credentials"]
+        | None = None,
+    ):
+        """
+        A font import helper class for css based imports which employs:
+        - `link(rel="stylesheet")` to define the import
+        - `link(rel="preload")` to preload the import
+        - `link(rel="preconnect")` to preconnect to font providers
+        - `hash` and `crossorigin` for SRI
+        - Local resource cache busting
+
+        NEVER use this with untrusted user input.
+
+        Parameters
+        ----------
+        `href`:
+            The literal href of the CSS resource which sets up the font
+
+        `preload`:
+            If true, adds a preload link for this resource
+
+        `hash`:
+            An optional SRI integrity hash for the import
+
+        `crossorigin`:
+            Optionally sets the crossorigin attribute on the link tag.
+            Valid values are "", "anonymous", "use-credentials"
+
+        `preconnect`:
+            A list of URLs to preconnect to. This is useful for font providers
+            such as Google Fonts.
+
+        `preconnect_crossorigin`:
+            Optionally sets the crossorigin attribute on the preconnect link tag.
+            If not set, it defaults to the value of `crossorigin`.
+
+        `cache_bust`:
+            If true, appends a timestamp to the URL to prevent browser
+            caching. Webservers configured for static resources manage this
+            feature automatically, but for development this can be useful.
+
+            This feature only works for local resources, i.e. those that
+            exist in `resource.settings.base_dir`
+
+        """
+        self.href = href
+        self.preload = preload
+        self.hash = hash
+        self.crossorigin = crossorigin
+        self.cache_bust = cache_bust
+        self.has_link = preload
+        self._href = self.uri()
+        self.preconnect = preconnect
+
+        if hash and self.crossorigin is None:
+            raise ValueError(
+                "If hash is set, crossorigin must be set to ''/'anonymous'"
+            )
+        self.preconnect_crossorigin = preconnect_crossorigin
+        if preconnect_crossorigin is None:
+            if self.crossorigin != "user-credentials":
+                self.preconnect_crossorigin = self.crossorigin
+            else:
+                raise ValueError(
+                    "Please set preconnect_crossorigin explicitly if "
+                    "crossorigin is 'user-credentials'"
+                )
+
+    def uri(self):
+        """
+        Returns the source URI - with cache busting if enabled
+        which is implemented by getting the mtime of the local file
+
+        This operation performs up to two fs stats per call
+
+        1. The base static directory is checked once and cached per interpreter
+        2. The specific resource is checked if it is time to poll again
+           based on settings.stat_poll_interval
+        """
+        if not self.cache_bust:
+            return self.href
+
+        return _cachebust_resource_uri(self.href)
+
+    def preload_links(
+        self,
+    ) -> list[el.link]:  # -> list[Any]:# -> list[Any]:# -> list[Any]:
+        """
+        Returns preload links if preload is set
+        """
+
+        links = []
+
+        if self.preload:
+            attrs = {"href": self._href}
+            if self.hash:
+                attrs["integrity"] = self.hash
+            if self.crossorigin:
+                attrs["crossorigin"] = self.crossorigin
+            links.append(el.link(attrs=attrs, rel="preload", as_="style"))
+
+        return links
+
+    def links(self) -> list[el.link]:
+        """
+        Returns link elements for this import
+        """
+        links = []
+
+        attrs = {"href": self._href}
+        if self.hash:
+            attrs["integrity"] = self.hash
+        if self.crossorigin:
+            attrs["crossorigin"] = self.crossorigin
+
+        links.append(el.link(attrs=attrs, rel="stylesheet"))
+
+        return links
+
+    def style_data(self) -> str:
+        # Fonts imported via CSS do not have style nodes
+        return ""
+
+    def preconnect_links(self) -> list[el.link]:
+        """
+        Returns generated preconnect link elements for this import
+        """
+        links = []
+        if self.preconnect:
+            for pc in self.preconnect:
+                pc_attrs = {"href": pc}
+                if self.preconnect_crossorigin:
+                    pc_attrs["crossorigin"] = self.preconnect_crossorigin
+                links.append(el.link(attrs=pc_attrs, rel="preconnect"))
+        return links

--- a/src/html_compose/resource/font_import.py
+++ b/src/html_compose/resource/font_import.py
@@ -309,9 +309,9 @@ class font_import_provider(_font_import_base):
                 "If hash is set, crossorigin must be set to ''/'anonymous'"
             )
         self.preconnect_crossorigin = preconnect_crossorigin
-        if preconnect_crossorigin is None:
+        if preconnect_crossorigin is None and self.crossorigin:
             if self.crossorigin != "user-credentials":
-                self.preconnect_crossorigin = self.crossorigin
+                self.preconnect_crossorigin = self.crossorigin  # type: ignore[assignment]
             else:
                 raise ValueError(
                     "Please set preconnect_crossorigin explicitly if "

--- a/src/html_compose/resource/js_import.py
+++ b/src/html_compose/resource/js_import.py
@@ -1,0 +1,274 @@
+from typing import Iterable, Literal
+
+from .. import elements as el
+from ..util_funcs import flatten_iterable, is_iterable_but_not_str
+from .util_funcs import _cachebust_resource_uri
+
+
+class js_import:
+    """
+    A javascript import helper class which employs one or more of:
+
+    - `script(` to define the import
+    - `importmap` which maps javascript module names to URLs
+    Setting the name parameter like so
+    ```python
+    js_import(
+        "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm",
+        name="alpinejs")
+    ```
+    creates an import map so javascript modules can be imported by name
+    - `link(rel="modulepreload")` to preload the import
+    - if cache_bust is true, appends a timestamp to the URL to
+
+    An production usage might look like:
+
+    ```python
+    [
+    js_import('./static/admin.js',
+                name='admin',
+                cache_bust=True),
+
+    js_import(
+        "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm",
+        name="alpinejs",
+        preload=True,
+        hash=(
+            "sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/"
+            "9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p"
+            ),
+        crossorigin="anonymous"
+        ),
+
+    ]
+    ```
+
+    ...
+
+    ## Usage in window:
+
+    ```python
+    script(type="module")[
+        '''
+        import Alpine from 'alpinejs'
+        window.Alpine = Alpine
+        Alpine.start()
+        '''
+    ]
+
+    ...
+
+    ## Generated "HTML":
+
+    ```python
+    import json
+    from html_compose import el, unsafe_text
+
+    [
+        el.script(type="importmap")[
+            unsafe_text('{"imports": {"admin": "./static/admin.js?ts=1760157623", "alpinejs": "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"}}')
+        ],
+
+        el.link(href="./static/admin.js?ts=1760157623", rel=["modulepreload"]),
+
+
+        el.link(
+            href="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm",
+            integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p",
+            crossorigin="anonymous",
+            rel=["modulepreload"],
+        ),
+
+        el.script(src="./static/admin.js?ts=1760157623", type="module"),
+
+        el.script(
+            src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm",
+            type="module",
+            integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p",
+            crossorigin="anonymous",
+        ),
+    ]
+    ```
+
+    See:
+    - https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap
+    - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
+    - https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/modulepreload
+    - https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload
+    - https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+    - https://www.srihash.org/
+
+    """
+
+    def __init__(
+        self,
+        source: str,
+        name: str | None = None,
+        preload: bool = False,
+        hash: str | None = None,
+        async_: bool = False,
+        defer: bool = False,
+        nomodule: bool = False,
+        scope_url: str | Iterable[str] | None = None,
+        crossorigin: Literal["", "anonymous", "user-credentials"]
+        | str
+        | None = None,
+        cache_bust: bool = False,
+    ):
+        """
+        A javascript import wrapper to manage optimal window import strategies.
+
+        If name is set, the import is added to an import map and imported
+        as a module.
+
+        Parameters
+        ----------
+        `source`:
+            The literal src passed to tags i.e. script and link preload.
+
+            If cache_bust is set, a timestamp is appended to the URL.
+        `name`:
+            The name of the import, e.g. "lodash" which can be used in
+            javascript type="module" imports.
+
+            Doing this automatically changes the script type to module
+
+        `preload`:
+            The modulepreload keyword, for the rel attribute of the `<link/>`
+            element, provides a declarative way to preemptively fetch a module
+            script, parse and compile it, and store it in the document's module
+            map for later execution.
+
+            If this is not a javascript module (i.e. name is not set),
+            the rel attribute is set to "preload" and the as_ attribute
+            is set to "script" instead.
+
+        `async_`:
+            The async attribute causes the script to be executed asynchronously as soon as it is available,
+            without blocking HTML parsing.
+
+        `defer`:
+            Defers script execution until document parsing is complete.
+            Has no effect on module scripts (they are deferred by default).
+
+        `nomodule`:
+            Added to script tag.
+
+            Indicates that the script should not be executed in browsers that
+            support ES modules — in effect, this can be used to serve fallback
+            scripts to older browsers that do not support javascript modules.
+
+        `hash`:
+            An optional SRI integrity hash for the import
+
+        `crossorigin`:
+            Optionally sets the crossorigin attribute on the script tag.
+            Valid values are "", "anonymous", "use-credentials"
+
+        `cache_bust`:
+            If true, appends a timestamp to the URL to work with browser
+            caching. Webservers configured for static resources manage this
+            feature automatically, but for development this can be useful.
+
+            This feature only works for local resources, i.e. those that
+            exist relative to `resource.settings.base_dir`
+
+        `scope_url`:
+            Optional route or list of paths where this import should be
+            included.
+
+            Scopes let you have different mappings for different parts of your
+            app.
+
+            Because they affect the import map but not what is loaded -
+            the script tag controls what loads - they are rarely used.
+
+        """
+
+        self.name = name
+        self.source = source
+        self.preload = preload
+        self.hash = hash
+        self.scope_url = scope_url
+        if scope_url and is_iterable_but_not_str(scope_url):
+            self.scope_url = flatten_iterable(scope_url)
+        self.crossorigin = crossorigin
+        self.cache_bust = cache_bust
+        self.has_link = preload
+        self.async_ = async_
+        self.defer = defer
+        self.nomodule = nomodule
+        self._src = self.uri()
+        if hash and self.crossorigin is None:
+            raise ValueError(
+                "If hash is set, crossorigin must be set to ''/'anonymous'"
+            )
+
+    def uri(self):
+        """
+        Returns the source URI - with cache busting if enabled
+        which is implemented by getting the mtime of the local file
+
+        This operation performs up to two fs stats per call
+
+        1. The base static directory is checked once and cached per interpreter
+        2. The specific resource is checked if it is time to poll again
+           based on settings.stat_poll_interval
+        """
+        if not self.cache_bust:
+            return self.source
+
+        return _cachebust_resource_uri(self.source)
+
+    def import_map_entry(
+        self,
+    ) -> tuple[str, str] | tuple[str, str, Iterable] | None:
+        """
+        Returns a tuple of (name, source, scope_url) for use in an import map
+        """
+        if self.name:
+            if self.scope_url is None:
+                return (self.name, self._src)
+            else:
+                return (self.name, self._src, self.scope_url)
+
+        return None
+
+    def preload_link(self) -> el.link | None:
+        """
+        Returns one or more link element for this import
+        """
+        if self.preload:
+            attrs = {"href": self._src}
+            if self.hash:
+                attrs["integrity"] = self.hash
+            if self.crossorigin:
+                attrs["crossorigin"] = self.crossorigin
+            if self.name:
+                return el.link(attrs=attrs, rel="modulepreload")
+            else:
+                return el.link(attrs=attrs, rel="preload", as_="script")
+
+        return None
+
+    def script(self) -> el.script:
+        """
+        Returns a script tag for this import
+        """
+        attrs: dict[str, str | bool] = {"src": self._src}
+
+        if self.name:
+            attrs["type"] = "module"
+        if self.hash:
+            attrs["integrity"] = self.hash
+        if self.crossorigin:
+            attrs["crossorigin"] = self.crossorigin
+        if self.async_:
+            attrs["async"] = True
+        if self.defer and not self.name:
+            # Only set defer for non-modules
+            attrs["defer"] = True
+        if self.nomodule:
+            attrs["nomodule"] = True
+
+        return el.script(attrs=attrs)

--- a/src/html_compose/resource/js_import.py
+++ b/src/html_compose/resource/js_import.py
@@ -55,8 +55,7 @@ class js_import:
         Alpine.start()
         '''
     ]
-
-    ...
+    ```
 
     ## Generated "HTML":
 

--- a/src/html_compose/resource/util_funcs.py
+++ b/src/html_compose/resource/util_funcs.py
@@ -1,0 +1,75 @@
+import urllib
+import urllib.parse
+from os import path, stat
+from time import time
+
+from . import _State, settings
+
+
+def _cachebust_resource_uri(source: str):
+    """
+    Returns the source URI - with cache busting if enabled
+    which is implemented by getting the mtime of the local file
+
+    This operation performs up to two fs stats per call
+
+    1. The base static directory is checked once and cached per interpreter
+    2. The specific resource is checked if it is time to poll again
+        based on settings.stat_poll_interval
+    """
+
+    misc_stat_cache = _State.misc_stat_cache
+    stat_cache = _State.stat_cache
+    cache_cap = settings.cache_cap
+    stat_poll_interval = settings.stat_poll_interval
+    base_dir = settings.base_dir
+    query_string = settings.query_string
+    base_dir = base_dir
+    if misc_stat_cache.get(base_dir) is None:
+        try:
+            misc_stat_cache[base_dir] = int(stat(base_dir).st_mtime)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                "js_import cache_bust enabled but "
+                f"js_import.settings.base_dir {base_dir} "
+                "does not exist"
+            ) from exc
+
+    resource_path = path.join(base_dir, source)
+    now = time()
+    ts = misc_stat_cache.get(path.join(base_dir, source), None)
+    update_ts = ts is None or (now - ts) > stat_poll_interval
+    if update_ts:
+        try:
+            ts = int(stat(resource_path).st_mtime)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                "js_import cache_bust enabled but "
+                f"resource {resource_path} "
+                "does not exist"
+            ) from exc
+
+        if len(stat_cache) >= cache_cap:
+            # Clear if it's too big
+            stat_cache.clear()
+        stat_cache[resource_path] = ts
+
+    assert ts is not None, "ts should be set by now"
+
+    spliturl = urllib.parse.urlsplit(source)
+    pairs = urllib.parse.parse_qsl(
+        spliturl.query,
+        keep_blank_values=True,
+        encoding="utf-8",
+        errors="surrogateescape",
+    )
+    # add our cache buster
+    pairs.append((query_string, str(int(ts))))
+    # re assemble the query string, try our best to preservees exactly
+    new_qs = urllib.parse.urlencode(
+        pairs,
+        quote_via=urllib.parse.quote,
+        encoding="utf-8",
+        errors="surrogateescape",
+    )
+    return spliturl._replace(query=new_qs).geturl()

--- a/src/html_compose/translate_html.py
+++ b/src/html_compose/translate_html.py
@@ -182,6 +182,12 @@ def translate(html: str, import_module: str | None = None) -> TranslateResult:
             tag_keys = inspect.signature(tag_cls.__init__).parameters.keys()
 
             for key, value in element.attrs.items():
+                # value bs4 gives us is sometimes
+                # like (key='rel', value=['preconnect'])
+                # If the attribute value is a list of one item, unwrap it
+                if isinstance(value, list) and len(value) == 1:
+                    value = value[0]
+
                 if key in ("attrs", "self", "children"):
                     # These are params of the constructor but the HTML given
                     # clashes with them

--- a/src/html_compose/translate_html.py
+++ b/src/html_compose/translate_html.py
@@ -1,7 +1,7 @@
 import inspect
 import re
 from functools import cache
-from typing import Any, cast
+from typing import Any
 
 from bs4 import BeautifulSoup, NavigableString, PageElement, Tag
 from bs4.element import Doctype

--- a/src/html_compose/translate_html.py
+++ b/src/html_compose/translate_html.py
@@ -3,7 +3,7 @@ import re
 from functools import cache
 from typing import Any, cast
 
-from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4 import BeautifulSoup, NavigableString, PageElement, Tag
 from bs4.element import Doctype
 
 from . import BaseElement, escape_text
@@ -161,7 +161,7 @@ def translate(html: str, import_module: str | None = None) -> TranslateResult:
 
     import_unsafe_text = False
 
-    def process_element(element) -> str | None:
+    def process_element(element: PageElement) -> str | None:
         if isinstance(element, Doctype):
             dt: Doctype = element
             tags["doctype"] = None
@@ -250,19 +250,15 @@ def translate(html: str, import_module: str | None = None) -> TranslateResult:
                 # We step backwards until we find a tag
                 prev_tag = next(
                     (
-                        cast(Tag, child_nodes[j])
-                        for j in range(i - 1, -1, -1)
-                        if isinstance(child_nodes[j], Tag)
+                        j
+                        for j in reversed(child_nodes[:i])
+                        if isinstance(j, Tag)
                     ),
                     None,
                 )
                 # Same deal, forwards until we find a tag
                 next_tag = next(
-                    (
-                        cast(Tag, child_nodes[j])
-                        for j in range(i + 1, len(child_nodes))
-                        if isinstance(child_nodes[j], Tag)
-                    ),
+                    (j for j in child_nodes[i + 1 :] if isinstance(j, Tag)),
                     None,
                 )
                 processed = read_string(

--- a/src/html_compose/util_funcs.py
+++ b/src/html_compose/util_funcs.py
@@ -19,7 +19,7 @@ def join_attrs(k, value_trusted):
     return f'{k}="{value_trusted}"'
 
 
-def is_iterable_but_not_str(input_iterable):
+def is_iterable_but_not_str(input_iterable: Any) -> bool:
     """
     Check if an iterable is not a string or bytes.
     Which prevents some bugs.

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -187,10 +187,7 @@ def test_equivalent():
 
 def test_document():
     doc = h.HTML5Document(
-        "Test",
-        lang="en",
-        head=None,
-        body=[h.button["Button"], h.br(), h.p["demo 2"]],
+        "Test", lang="en", body=[h.button["Button"], h.br(), h.p["demo 2"]]
     )
 
     expected = "\n".join(
@@ -203,7 +200,7 @@ def test_document():
             "</html>",
         ]
     )
-    assert doc == expected
+    assert str(doc) == expected
 
 
 def test_noconstructor():

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -196,7 +196,11 @@ def test_document():
     expected = "\n".join(
         [
             "<!DOCTYPE html>",
-            '<html lang="en"><head><meta content="width=device-width, initial-scale=1.0" name="viewport"/><title>Test</title></head><body><button>Button</button><br/><p>demo 2</p></body></html>',
+            '<html lang="en">',
+            '<head><meta content="width=device-width, initial-scale=1.0" name="viewport"/><title>Test</title></head>',
+            "",
+            "<body><button>Button</button><br/><p>demo 2</p></body>",
+            "</html>",
         ]
     )
     assert doc == expected

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -2,7 +2,7 @@ import pytest
 from bs4 import BeautifulSoup
 
 import html_compose as h
-from html_compose import a, div, img
+from html_compose import a, div, img, script
 
 
 def get_soup(input: str):
@@ -139,6 +139,14 @@ def test_generic_attr():
     assert el.render() == '<div data-foo="bar"></div>'
     el = div(attrs=[BaseAttribute("data-foo", "bar")])
     assert el.render() == '<div data-foo="bar"></div>'
+
+
+def test_defer_arg():
+    """
+    Confirm that boolean attributes work as expected
+    """
+    assert script(defer=True).render() == '<script defer="true"></script>'
+    assert script(defer=False).render() == "<script></script>"
 
 
 def test_kw_arg_attr():

--- a/tests/test_element.py
+++ b/tests/test_element.py
@@ -251,3 +251,8 @@ def test_custom_element():
     custom = CustomElement.create("custom")
     el = custom["Hello world"]
     assert el.render() == "<custom>Hello world</custom>"  # type: ignore
+
+
+def test_callable_br():
+    a = div()[h.p["hi"], h.br, h.p["there"]]
+    assert a.render() == "<div><p>hi</p><br/><p>there</p></div>"

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,7 +1,7 @@
 import pytest
 
 import html_compose.elements as el
-from html_compose.document import document_streamer
+from html_compose.document import HTML5Document
 from html_compose.resource import (
     css_import,
     font_import_manual,
@@ -124,16 +124,13 @@ def test_gen_docs():
         print(line)
     print("---")
     print(
-        "".join(
-            document_streamer(
-                title="demo",
-                lang="en",
-                js=js,
-                css=css,
-                fonts=fonts,
-                body_content=[el.h1()["Hello world"]],
-                stream_mode="full",
-            )
+        HTML5Document(
+            title="demo",
+            lang="en",
+            js=js,
+            css=css,
+            fonts=fonts,
+            body=[el.h1()["Hello world"]],
         )
     )
     assert False
@@ -297,14 +294,9 @@ def test_importer():
 def test_document_generator():
     css = get_css()
     js = get_js()
-    result = document_streamer(
-        title="demo",
-        lang="en",
-        js=js,
-        css=css,
-        body_content=[el.h1()["Hello world"]],
-        stream_mode="full",
-    )
+    result = HTML5Document(
+        title="demo", lang="en", js=js, css=css, body=[el.h1()["Hello world"]]
+    ).stream("full")
     expected = [
         '<!DOCTYPE html>\n<html lang="en">\n<head><meta content="width=device-width, initial-scale=1.0" name="viewport"/><title>demo</title><link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous" as="style" rel="preload"/><link href="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm" integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p" crossorigin="anonymous" rel="modulepreload"/><link href="./static/admin.css" rel="stylesheet"/><link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous" rel="stylesheet"/><script type="importmap">{"imports": {"admin": "./static/admin.js", "alpinejs": "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"}}</script><script src="./static/admin.js" type="module"></script><script src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm" type="module" integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p" crossorigin="anonymous"></script></head>\n\n',
         "<body>",

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1,0 +1,322 @@
+import pytest
+
+import html_compose.elements as el
+from html_compose.document import document_streamer
+from html_compose.resource import (
+    css_import,
+    font_import_manual,
+    font_import_provider,
+    js_import,
+    to_elements,
+)
+
+
+def get_css():
+    return [
+        css_import("./static/admin.css", cache_bust=False),
+        css_import(
+            "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css",
+            hash=(
+                "sha384-9ndCyUaIbzAi2FUVXJi0CjmCapS"
+                "mO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
+            ),
+            crossorigin="anonymous",
+            preload=True,
+        ),
+    ]
+
+
+def get_js():
+    return [
+        js_import("./static/admin.js", name="admin", cache_bust=False),
+        js_import(
+            "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm",
+            name="alpinejs",
+            preload=True,
+            hash=(
+                "sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/"
+                "9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p"
+            ),
+            crossorigin="anonymous",
+        ),
+    ]
+
+
+def get_font_manual():
+    return [
+        font_import_manual(
+            "./static/fonts/MyFont.woff2",
+            family="MyFont",
+            weight="normal",
+            style="normal",
+            display="swap",
+            cache_bust=False,
+        ),
+        font_import_manual(
+            "https://example.com/fonts/OtherFontBold.woff2",
+            family="OtherFont",
+            weight="bold",
+            display="swap",
+            crossorigin="anonymous",
+            preload=True,
+        ),
+        font_import_manual(
+            "https://example.com/fonts/OtherFontLight.woff2",
+            family="OtherFont",
+            weight=(1, 400),
+            style="normal",
+            display="swap",
+            crossorigin="anonymous",
+            preload=True,
+        ),
+    ]
+
+
+def get_font_remote():
+    """
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+    """
+
+    return [
+        font_import_provider(
+            href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap",
+            preconnect=[
+                "https://fonts.googleapis.com",
+                "https://fonts.gstatic.com",
+            ],
+            preconnect_crossorigin="anonymous",
+        )
+    ]
+
+
+def get_fonts():
+    return [
+        font_import_manual(
+            "./static/fonts/MyFont.woff2",
+            family="MyFont",
+            weight="normal",
+            style="normal",
+            display="swap",
+            cache_bust=False,
+        ),
+        font_import_provider(
+            href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap",
+            preconnect=[
+                "https://fonts.googleapis.com",
+                "https://fonts.gstatic.com",
+            ],
+            preconnect_crossorigin="anonymous",
+        ),
+    ]
+
+
+# This is only for the 06_resource_imports.md doc
+@pytest.mark.skip(reason="For doc generation only")
+def test_gen_docs():
+    css = get_css()
+    js = get_js()
+    fonts = get_fonts()
+    elements = to_elements(js, css, fonts)
+    doc = el.head()[elements].resolve()
+    for line in doc:
+        print(line)
+    print("---")
+    print(
+        "".join(
+            document_streamer(
+                title="demo",
+                lang="en",
+                js=js,
+                css=css,
+                fonts=fonts,
+                body_content=[el.h1()["Hello world"]],
+                stream_mode="full",
+            )
+        )
+    )
+    assert False
+
+
+def test_get_fonts():
+    fonts = get_fonts()
+    elements = to_elements([], [], fonts)
+
+    expected = [
+        "<head>",
+        '<link href="https://fonts.googleapis.com" crossorigin="anonymous" rel="preconnect"/>',
+        '<link href="https://fonts.gstatic.com" crossorigin="anonymous" rel="preconnect"/>',
+        '<link href="./static/fonts/MyFont.woff2" type="font/woff2" as="font" rel="preload"/>',
+        '<link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&amp;display=swap" rel="stylesheet"/>',
+        "<style>",
+        "@font-face {\n\tfont-family: 'MyFont';\n\tsrc: url('./static/fonts/MyFont.woff2');\n\tfont-style: normal;\n\tfont-display: swap;\n\tfont-weight: normal;\n}",
+        "</style>",
+        "</head>",
+    ]
+
+    result = [str(x) for x in el.head()[elements].resolve()]
+    # print(result)
+    for i, line in enumerate(result):
+        assert line == expected[i], f"Line {i + 1} does not match"
+
+
+def test_font_remote():
+    fonts = get_font_remote()
+    elements = to_elements([], [], fonts)
+
+    expected = [
+        "<head>",
+        '<link href="https://fonts.googleapis.com" crossorigin="anonymous" rel="preconnect"/>',
+        '<link href="https://fonts.gstatic.com" crossorigin="anonymous" rel="preconnect"/>',
+        '<link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&amp;display=swap" rel="stylesheet"/>',
+        "</head>",
+    ]
+
+    result = [str(x) for x in el.head()[elements].resolve()]
+    # print(result)
+    for i, line in enumerate(result):
+        assert line == expected[i], f"Line {i + 1} does not match"
+
+
+def test_js_import():
+    js = [
+        js_import(
+            "./static/admin.js", name="admin", preload=True, cache_bust=False
+        ),
+        js_import(
+            "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm",
+            name="alpinejs",
+            preload=True,
+            hash=(
+                "sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/"
+                "9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p"
+            ),
+            crossorigin="anonymous",
+        ),
+    ]
+    expected = [
+        "<head>",
+        '<link href="./static/admin.js" rel="modulepreload"/>',
+        '<link href="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm" integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p" crossorigin="anonymous" rel="modulepreload"/>',
+        '<script type="importmap">',
+        '{"imports": {"admin": "./static/admin.js", "alpinejs": "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"}}',
+        "</script>",
+        '<script src="./static/admin.js" type="module">',
+        "</script>",
+        '<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm" type="module" integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p" crossorigin="anonymous">',
+        "</script>",
+        "</head>",
+    ]
+    elements = to_elements(js, [])
+    result = [str(x) for x in el.head()[elements].resolve()]
+
+    for i, line in enumerate(result):
+        assert line == expected[i], f"Line {i + 1} does not match"
+
+
+def test_font_import_manual():
+    fonts = get_font_manual()
+    elements = to_elements([], [], fonts)
+
+    expected = [
+        "<head>",
+        '<link href="./static/fonts/MyFont.woff2" type="font/woff2" as="font" rel="preload"/>',
+        '<link href="https://example.com/fonts/OtherFontBold.woff2" crossorigin="anonymous" type="font/woff2" as="font" rel="preload"/>',
+        '<link href="https://example.com/fonts/OtherFontLight.woff2" crossorigin="anonymous" type="font/woff2" as="font" rel="preload"/>',
+        "<style>",
+        (
+            "@font-face {\n"
+            "\tfont-family: 'MyFont';\n"
+            "\tsrc: url('./static/fonts/MyFont.woff2');\n"
+            "\tfont-style: normal;\n"
+            "\tfont-display: swap;\n"
+            "\tfont-weight: normal;\n"
+            "}\n"
+            "@font-face {\n"
+            "\tfont-family: 'OtherFont';\n"
+            "\tsrc: url('https://example.com/fonts/OtherFontBold.woff2');\n"
+            "\tfont-style: normal;\n"
+            "\tfont-display: swap;\n"
+            "\tfont-weight: bold;\n"
+            "}\n"
+            "@font-face {\n"
+            "\tfont-family: 'OtherFont';\n"
+            "\tsrc: url('https://example.com/fonts/OtherFontLight.woff2');\n"
+            "\tfont-style: normal;\n"
+            "\tfont-display: swap;\n"
+            "\tfont-weight: 1 400;\n"
+            "}"
+        ),
+        "</style>",
+        "</head>",
+    ]
+
+    result = [str(x) for x in el.head()[elements].resolve()]
+    # print(result)
+    for i, line in enumerate(result):
+        assert line == expected[i], f"Line {i + 1} does not match"
+
+
+def test_importer():
+    css = get_css()
+    js = get_js()
+    elements = to_elements(js, css)
+    expected = [
+        "<head>",
+        '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous" as="style" rel="preload"/>',
+        '<link href="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm" integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p" crossorigin="anonymous" rel="modulepreload"/>',
+        '<link href="./static/admin.css" rel="stylesheet"/>',
+        '<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous" rel="stylesheet"/>',
+        '<script type="importmap">',
+        '{"imports": {"admin": "./static/admin.js", "alpinejs": "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"}}',
+        "</script>",
+        '<script src="./static/admin.js" type="module">',
+        "</script>",
+        '<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm" type="module" integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p" crossorigin="anonymous">',
+        "</script>",
+        "</head>",
+    ]
+    result = [str(x) for x in el.head()[elements].resolve()]
+    # print(result)
+    for i, line in enumerate(result):
+        assert line == expected[i], f"Line {i + 1} does not match"
+
+    with pytest.raises(ValueError):
+        js_import(
+            "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm",
+            name="alpinejs",
+            preload=True,
+            hash=(
+                "sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/"
+                "9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p"
+            ),
+        )  # noqa
+
+
+def test_document_generator():
+    css = get_css()
+    js = get_js()
+    result = document_streamer(
+        title="demo",
+        lang="en",
+        js=js,
+        css=css,
+        body_content=[el.h1()["Hello world"]],
+        stream_mode="full",
+    )
+    expected = [
+        '<!DOCTYPE html>\n<html lang="en">\n<head><meta content="width=device-width, initial-scale=1.0" name="viewport"/><title>demo</title><link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous" as="style" rel="preload"/><link href="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm" integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p" crossorigin="anonymous" rel="modulepreload"/><link href="./static/admin.css" rel="stylesheet"/><link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous" rel="stylesheet"/><script type="importmap">{"imports": {"admin": "./static/admin.js", "alpinejs": "https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm"}}</script><script src="./static/admin.js" type="module"></script><script src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.0/+esm" type="module" integrity="sha384-Yf57wlxlrA1+0X6Ye9NOBxQ1tpmiwI/9mFpv9tT/Rh2UAajwwAlTWHnvTGYhgv7p" crossorigin="anonymous"></script></head>\n\n',
+        "<body>",
+        "<h1>",
+        "Hello world",
+        "</h1>",
+        "</body>",
+        "\n",
+        "</html>",
+    ]
+
+    result = [str(x) for x in result]
+    # print(result)
+    for i, line in enumerate(result):
+        assert line == expected[i], f"Line {i + 1} does not match"

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -139,3 +139,17 @@ def test_round_trip():
     lines = "\n\n".join(tresult.elements) + ".render()"
     output = eval(lines)
     assert output == stripped
+
+
+def test_script_round_trip():
+    # Ensure that text nodes with <, >, & survive a round trip
+    html = '<script>if (a < b && c > d) { console.log("hello & welcome"); }</script>'
+    tresult = t.translate(html)
+    print(tresult.import_statement)
+    exec(tresult.import_statement)
+    if tresult.custom_elements:
+        exec("\n".join(tresult.custom_elements))
+    lines = "\n\n".join(tresult.elements) + ".render()"
+    print(lines)
+    output = eval(lines)
+    assert output == html

--- a/tools/generate_attributes.py
+++ b/tools/generate_attributes.py
@@ -26,9 +26,14 @@ def generate_class_template(
         "{element_name}" attribute: {attr_name}  
         {attr_desc}  
 
-        :param value: {value_desc}  
-        :return: An {attr_name} attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                {value_desc}
+        
+        Returns:
+            An {attr_name} attribute to be added to your element
+
+        """
         
         return BaseAttribute("{attr_name}", value{delimiter_stmt})
             '''

--- a/tools/generate_elements.py
+++ b/tools/generate_elements.py
@@ -389,7 +389,7 @@ if __name__ == "__main__":
         print(f"Copied generated elements to: {real_path}")
         init_data = [f'"""{elements_docstring()}\n"""']
         for name in el_names:
-            init_data.append(f"from .{name}_element import {name}")
+            init_data.append(f"from .{name}_element import {name} as {name}")
 
         imports = ", ".join(map(lambda x: f"'{x}'", el_names))
         init_data.append(

--- a/tools/generate_elements.py
+++ b/tools/generate_elements.py
@@ -104,7 +104,7 @@ class htmx:
     '''
 
     @staticmethod
-    def hx_get(value: str) -> BaseAttribute:
+    def get(value: str) -> BaseAttribute:
         '''
         htmx attribute: hx-get
             The hx-get attribute will cause an element to issue a
@@ -117,7 +117,7 @@ class htmx:
 
         return BaseAttribute("hx-get", value)
 
-btn = button([htmx.hx_get("/api/data")])["Click me!"]
+btn = button([htmx.get("/api/data")])["Click me!"]
 btn.render()  # '<button hx-get="/api/data">Click me!</button>'
 ```
 

--- a/tools/generate_elements.py
+++ b/tools/generate_elements.py
@@ -131,12 +131,12 @@ def generate_attrs(attr_class, attr_list) -> list[processed_attr]:  # -> list:
     for attr in attr_list:
         attrdef = ReadAttr(attr)
         dupe = attrdefs.get(attrdef.name, None)
-        docstring = [f"`{attrdef.safe_name}` :"]
+        docstring = [f"{attrdef.safe_name}:"]
 
         docstring.append(f"    {attrdef.description}")
         if not value_hint_to_python_type(attrdef.value_desc):
-            docstring[-1] += "  "  # markdown newline
-            docstring.append(f"    {attrdef.value_desc}")
+            docstring[-1] += ".  "  # markdown newline
+            docstring.append(f"    Value hint: {attrdef.value_desc}")
 
         def_dict = {"attr": attrdef, "docstring": docstring}
         if dupe:
@@ -244,7 +244,7 @@ def gen_elements():
             extra_attrs = ""
             attr_assignment = ""
             attr_docstrings = [
-                "`attrs`: ",
+                "attrs: ",
                 "    A list or dictionary of attributes for the element",
                 "",
             ]
@@ -332,9 +332,8 @@ def gen_elements():
                 f"        Initialize '{real_element}' ({desc}) element.  ",
                 f"        Documentation: {docs}",
                 "",
-                "        Parameters",
-                "        ----------",
-                "        " + "\n        ".join(attr_docstrings),
+                "        Args:",
+                "            " + "\n            ".join(attr_docstrings),
                 '        """ #fmt: skip',
                 "        super().__init__(",
                 f'            "{real_element}",',

--- a/tools/generate_elements.py
+++ b/tools/generate_elements.py
@@ -67,9 +67,6 @@ link = a(href="https://example.com", target="_blank")["Click here"]
 link.render()  # '<a href="https://example.com" target="_blank">Click here</a>'
 ```
 #### Attributes that aren't in the constructor signature
-**Note that events like .onclick are _not_ available in the constructor.**
-
-We do however provide the type hint via `<element>.hint`
 
 The first positional argument is `attrs=` which can be a list of attributes.
 We generate many of these for type hints under `<element>.hint or `<element>._`

--- a/tools/generated/a_attrs.py
+++ b/tools/generated/a_attrs.py
@@ -14,9 +14,14 @@ class AnchorAttrs:
         "a" attribute: download  
         Whether to download the resource instead of navigating to it, and its filename if so  
 
-        :param value: Text  
-        :return: An download attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An download attribute to be added to your element
+
+        """
         
         return BaseAttribute("download", value)
             
@@ -28,9 +33,14 @@ class AnchorAttrs:
         "a" attribute: href  
         Address of the hyperlink  
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An href attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+        
+        Returns:
+            An href attribute to be added to your element
+
+        """
         
         return BaseAttribute("href", value)
             
@@ -42,9 +52,14 @@ class AnchorAttrs:
         "a" attribute: hreflang  
         Language of the linked resource  
 
-        :param value: Valid BCP 47 language tag  
-        :return: An hreflang attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid BCP 47 language tag
+        
+        Returns:
+            An hreflang attribute to be added to your element
+
+        """
         
         return BaseAttribute("hreflang", value)
             
@@ -56,9 +71,14 @@ class AnchorAttrs:
         "a" attribute: ping  
         URLs to ping  
 
-        :param value: Set of space-separated tokens consisting of valid non-empty URLs  
-        :return: An ping attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Set of space-separated tokens consisting of valid non-empty URLs
+        
+        Returns:
+            An ping attribute to be added to your element
+
+        """
         
         return BaseAttribute("ping", value)
             
@@ -70,9 +90,14 @@ class AnchorAttrs:
         "a" attribute: referrerpolicy  
         Referrer policy for fetches initiated by the element  
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Referrer policy
+        
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
         
         return BaseAttribute("referrerpolicy", value)
             
@@ -84,9 +109,14 @@ class AnchorAttrs:
         "a" attribute: rel  
         Relationship between the location in the document containing the hyperlink and the destination resource  
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An rel attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+        
+        Returns:
+            An rel attribute to be added to your element
+
+        """
         
         return BaseAttribute("rel", value)
             
@@ -98,9 +128,14 @@ class AnchorAttrs:
         "a" attribute: target  
         Navigable for hyperlink navigation  
 
-        :param value: Valid navigable target name or keyword  
-        :return: An target attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+        
+        Returns:
+            An target attribute to be added to your element
+
+        """
         
         return BaseAttribute("target", value)
             
@@ -112,9 +147,14 @@ class AnchorAttrs:
         "a" attribute: type  
         Hint for the type of the referenced resource  
 
-        :param value: Valid MIME type string  
-        :return: An type attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid MIME type string
+        
+        Returns:
+            An type attribute to be added to your element
+
+        """
         
         return BaseAttribute("type", value)
             

--- a/tools/generated/abbr_attrs.py
+++ b/tools/generated/abbr_attrs.py
@@ -14,9 +14,14 @@ class AbbrAttrs:
         "abbr" attribute: title  
         Full term or expansion of abbreviation  
 
-        :param value: Text  
-        :return: An title attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An title attribute to be added to your element
+
+        """
         
         return BaseAttribute("title", value)
             

--- a/tools/generated/area_attrs.py
+++ b/tools/generated/area_attrs.py
@@ -14,9 +14,14 @@ class AreaAttrs:
         "area" attribute: alt  
         Replacement text for use when images are not available  
 
-        :param value: Text*  
-        :return: An alt attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An alt attribute to be added to your element
+
+        """
         
         return BaseAttribute("alt", value)
             
@@ -28,9 +33,14 @@ class AreaAttrs:
         "area" attribute: coords  
         Coordinates for the shape to be created in an image map  
 
-        :param value: Valid list of floating-point numbers*  
-        :return: An coords attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid list of floating-point numbers*
+        
+        Returns:
+            An coords attribute to be added to your element
+
+        """
         
         return BaseAttribute("coords", value)
             
@@ -42,9 +52,14 @@ class AreaAttrs:
         "area" attribute: download  
         Whether to download the resource instead of navigating to it, and its filename if so  
 
-        :param value: Text  
-        :return: An download attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An download attribute to be added to your element
+
+        """
         
         return BaseAttribute("download", value)
             
@@ -56,9 +71,14 @@ class AreaAttrs:
         "area" attribute: href  
         Address of the hyperlink  
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An href attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+        
+        Returns:
+            An href attribute to be added to your element
+
+        """
         
         return BaseAttribute("href", value)
             
@@ -70,9 +90,14 @@ class AreaAttrs:
         "area" attribute: ping  
         URLs to ping  
 
-        :param value: Set of space-separated tokens consisting of valid non-empty URLs  
-        :return: An ping attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Set of space-separated tokens consisting of valid non-empty URLs
+        
+        Returns:
+            An ping attribute to be added to your element
+
+        """
         
         return BaseAttribute("ping", value)
             
@@ -84,9 +109,14 @@ class AreaAttrs:
         "area" attribute: referrerpolicy  
         Referrer policy for fetches initiated by the element  
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Referrer policy
+        
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
         
         return BaseAttribute("referrerpolicy", value)
             
@@ -98,9 +128,14 @@ class AreaAttrs:
         "area" attribute: rel  
         Relationship between the location in the document containing the hyperlink and the destination resource  
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An rel attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+        
+        Returns:
+            An rel attribute to be added to your element
+
+        """
         
         return BaseAttribute("rel", value)
             
@@ -112,9 +147,14 @@ class AreaAttrs:
         "area" attribute: shape  
         The kind of shape to be created in an image map  
 
-        :param value: ['circle', 'default', 'poly', 'rect']  
-        :return: An shape attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['circle', 'default', 'poly', 'rect']
+        
+        Returns:
+            An shape attribute to be added to your element
+
+        """
         
         return BaseAttribute("shape", value)
             
@@ -126,9 +166,14 @@ class AreaAttrs:
         "area" attribute: target  
         Navigable for hyperlink navigation  
 
-        :param value: Valid navigable target name or keyword  
-        :return: An target attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+        
+        Returns:
+            An target attribute to be added to your element
+
+        """
         
         return BaseAttribute("target", value)
             

--- a/tools/generated/audio_attrs.py
+++ b/tools/generated/audio_attrs.py
@@ -14,9 +14,14 @@ class AudioAttrs:
         "audio" attribute: autoplay  
         Hint that the media resource can be started automatically when the page is loaded  
 
-        :param value: Boolean attribute  
-        :return: An autoplay attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An autoplay attribute to be added to your element
+
+        """
         
         return BaseAttribute("autoplay", value)
             
@@ -28,9 +33,14 @@ class AudioAttrs:
         "audio" attribute: controls  
         Show user agent controls  
 
-        :param value: Boolean attribute  
-        :return: An controls attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An controls attribute to be added to your element
+
+        """
         
         return BaseAttribute("controls", value)
             
@@ -42,9 +52,14 @@ class AudioAttrs:
         "audio" attribute: crossorigin  
         How the element handles crossorigin requests  
 
-        :param value: ['anonymous', 'use-credentials']  
-        :return: An crossorigin attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['anonymous', 'use-credentials']
+        
+        Returns:
+            An crossorigin attribute to be added to your element
+
+        """
         
         return BaseAttribute("crossorigin", value)
             
@@ -56,9 +71,14 @@ class AudioAttrs:
         "audio" attribute: loop  
         Whether to loop the media resource  
 
-        :param value: Boolean attribute  
-        :return: An loop attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An loop attribute to be added to your element
+
+        """
         
         return BaseAttribute("loop", value)
             
@@ -70,9 +90,14 @@ class AudioAttrs:
         "audio" attribute: muted  
         Whether to mute the media resource by default  
 
-        :param value: Boolean attribute  
-        :return: An muted attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An muted attribute to be added to your element
+
+        """
         
         return BaseAttribute("muted", value)
             
@@ -84,9 +109,14 @@ class AudioAttrs:
         "audio" attribute: preload  
         Hints how much buffering the media resource will likely need  
 
-        :param value: ['none', 'metadata', 'auto']  
-        :return: An preload attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['none', 'metadata', 'auto']
+        
+        Returns:
+            An preload attribute to be added to your element
+
+        """
         
         return BaseAttribute("preload", value)
             
@@ -98,9 +128,14 @@ class AudioAttrs:
         "audio" attribute: src  
         Address of the resource  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An src attribute to be added to your element
+
+        """
         
         return BaseAttribute("src", value)
             

--- a/tools/generated/base_attrs.py
+++ b/tools/generated/base_attrs.py
@@ -14,9 +14,14 @@ class BaseAttrs:
         "base" attribute: href  
         Document base URL  
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An href attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+        
+        Returns:
+            An href attribute to be added to your element
+
+        """
         
         return BaseAttribute("href", value)
             
@@ -28,9 +33,14 @@ class BaseAttrs:
         "base" attribute: target  
         Default navigable for hyperlink navigation and form submission  
 
-        :param value: Valid navigable target name or keyword  
-        :return: An target attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+        
+        Returns:
+            An target attribute to be added to your element
+
+        """
         
         return BaseAttribute("target", value)
             

--- a/tools/generated/bdo_attrs.py
+++ b/tools/generated/bdo_attrs.py
@@ -14,9 +14,14 @@ class BdoAttrs:
         "bdo" attribute: dir  
         The text directionality of the element  
 
-        :param value: ['ltr', 'rtl']  
-        :return: An dir attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['ltr', 'rtl']
+        
+        Returns:
+            An dir attribute to be added to your element
+
+        """
         
         return BaseAttribute("dir", value)
             

--- a/tools/generated/blockquote_attrs.py
+++ b/tools/generated/blockquote_attrs.py
@@ -14,9 +14,14 @@ class BlockquoteAttrs:
         "blockquote" attribute: cite  
         Link to the source of the quotation or more information about the edit  
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An cite attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+        
+        Returns:
+            An cite attribute to be added to your element
+
+        """
         
         return BaseAttribute("cite", value)
             

--- a/tools/generated/body_attrs.py
+++ b/tools/generated/body_attrs.py
@@ -14,9 +14,14 @@ class BodyAttrs:
         "body" attribute: onafterprint  
         afterprint event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onafterprint attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onafterprint attribute to be added to your element
+
+        """
         
         return BaseAttribute("onafterprint", value)
             
@@ -28,9 +33,14 @@ class BodyAttrs:
         "body" attribute: onbeforeprint  
         beforeprint event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onbeforeprint attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onbeforeprint attribute to be added to your element
+
+        """
         
         return BaseAttribute("onbeforeprint", value)
             
@@ -42,9 +52,14 @@ class BodyAttrs:
         "body" attribute: onbeforeunload  
         beforeunload event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onbeforeunload attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onbeforeunload attribute to be added to your element
+
+        """
         
         return BaseAttribute("onbeforeunload", value)
             
@@ -56,9 +71,14 @@ class BodyAttrs:
         "body" attribute: onhashchange  
         hashchange event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onhashchange attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onhashchange attribute to be added to your element
+
+        """
         
         return BaseAttribute("onhashchange", value)
             
@@ -70,9 +90,14 @@ class BodyAttrs:
         "body" attribute: onlanguagechange  
         languagechange event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onlanguagechange attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onlanguagechange attribute to be added to your element
+
+        """
         
         return BaseAttribute("onlanguagechange", value)
             
@@ -84,9 +109,14 @@ class BodyAttrs:
         "body" attribute: onmessage  
         message event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onmessage attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onmessage attribute to be added to your element
+
+        """
         
         return BaseAttribute("onmessage", value)
             
@@ -98,9 +128,14 @@ class BodyAttrs:
         "body" attribute: onmessageerror  
         messageerror event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onmessageerror attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onmessageerror attribute to be added to your element
+
+        """
         
         return BaseAttribute("onmessageerror", value)
             
@@ -112,9 +147,14 @@ class BodyAttrs:
         "body" attribute: onoffline  
         offline event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onoffline attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onoffline attribute to be added to your element
+
+        """
         
         return BaseAttribute("onoffline", value)
             
@@ -126,9 +166,14 @@ class BodyAttrs:
         "body" attribute: ononline  
         online event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An ononline attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ononline attribute to be added to your element
+
+        """
         
         return BaseAttribute("ononline", value)
             
@@ -140,9 +185,14 @@ class BodyAttrs:
         "body" attribute: onpagehide  
         pagehide event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onpagehide attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onpagehide attribute to be added to your element
+
+        """
         
         return BaseAttribute("onpagehide", value)
             
@@ -154,9 +204,14 @@ class BodyAttrs:
         "body" attribute: onpagereveal  
         pagereveal event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onpagereveal attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onpagereveal attribute to be added to your element
+
+        """
         
         return BaseAttribute("onpagereveal", value)
             
@@ -168,9 +223,14 @@ class BodyAttrs:
         "body" attribute: onpageshow  
         pageshow event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onpageshow attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onpageshow attribute to be added to your element
+
+        """
         
         return BaseAttribute("onpageshow", value)
             
@@ -182,9 +242,14 @@ class BodyAttrs:
         "body" attribute: onpageswap  
         pageswap event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onpageswap attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onpageswap attribute to be added to your element
+
+        """
         
         return BaseAttribute("onpageswap", value)
             
@@ -196,9 +261,14 @@ class BodyAttrs:
         "body" attribute: onpopstate  
         popstate event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onpopstate attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onpopstate attribute to be added to your element
+
+        """
         
         return BaseAttribute("onpopstate", value)
             
@@ -210,9 +280,14 @@ class BodyAttrs:
         "body" attribute: onrejectionhandled  
         rejectionhandled event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onrejectionhandled attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onrejectionhandled attribute to be added to your element
+
+        """
         
         return BaseAttribute("onrejectionhandled", value)
             
@@ -224,9 +299,14 @@ class BodyAttrs:
         "body" attribute: onstorage  
         storage event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onstorage attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onstorage attribute to be added to your element
+
+        """
         
         return BaseAttribute("onstorage", value)
             
@@ -238,9 +318,14 @@ class BodyAttrs:
         "body" attribute: onunhandledrejection  
         unhandledrejection event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onunhandledrejection attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onunhandledrejection attribute to be added to your element
+
+        """
         
         return BaseAttribute("onunhandledrejection", value)
             
@@ -252,9 +337,14 @@ class BodyAttrs:
         "body" attribute: onunload  
         unload event handler for Window object  
 
-        :param value: Event handler content attribute  
-        :return: An onunload attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onunload attribute to be added to your element
+
+        """
         
         return BaseAttribute("onunload", value)
             

--- a/tools/generated/button_attrs.py
+++ b/tools/generated/button_attrs.py
@@ -14,9 +14,14 @@ class ButtonAttrs:
         "button" attribute: disabled  
         Whether the form control is disabled  
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
         
         return BaseAttribute("disabled", value)
             
@@ -28,9 +33,14 @@ class ButtonAttrs:
         "button" attribute: form  
         Associates the element with a form element  
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An form attribute to be added to your element
+
+        """
         
         return BaseAttribute("form", value)
             
@@ -42,9 +52,14 @@ class ButtonAttrs:
         "button" attribute: formaction  
         URL to use for form submission  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An formaction attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An formaction attribute to be added to your element
+
+        """
         
         return BaseAttribute("formaction", value)
             
@@ -56,9 +71,14 @@ class ButtonAttrs:
         "button" attribute: formenctype  
         Entry list encoding type to use for form submission  
 
-        :param value: ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']  
-        :return: An formenctype attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']
+        
+        Returns:
+            An formenctype attribute to be added to your element
+
+        """
         
         return BaseAttribute("formenctype", value)
             
@@ -70,9 +90,14 @@ class ButtonAttrs:
         "button" attribute: formmethod  
         Variant to use for form submission  
 
-        :param value: ['GET', 'POST', 'dialog']  
-        :return: An formmethod attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['GET', 'POST', 'dialog']
+        
+        Returns:
+            An formmethod attribute to be added to your element
+
+        """
         
         return BaseAttribute("formmethod", value)
             
@@ -84,9 +109,14 @@ class ButtonAttrs:
         "button" attribute: formnovalidate  
         Bypass form control validation for form submission  
 
-        :param value: Boolean attribute  
-        :return: An formnovalidate attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An formnovalidate attribute to be added to your element
+
+        """
         
         return BaseAttribute("formnovalidate", value)
             
@@ -98,9 +128,14 @@ class ButtonAttrs:
         "button" attribute: formtarget  
         Navigable for form submission  
 
-        :param value: Valid navigable target name or keyword  
-        :return: An formtarget attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+        
+        Returns:
+            An formtarget attribute to be added to your element
+
+        """
         
         return BaseAttribute("formtarget", value)
             
@@ -112,9 +147,14 @@ class ButtonAttrs:
         "button" attribute: name  
         Name of the element to use for form submission and in the form.elements API  
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             
@@ -126,9 +166,14 @@ class ButtonAttrs:
         "button" attribute: popovertarget  
         Targets a popover element to toggle, show, or hide  
 
-        :param value: ID*  
-        :return: An popovertarget attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An popovertarget attribute to be added to your element
+
+        """
         
         return BaseAttribute("popovertarget", value)
             
@@ -140,9 +185,14 @@ class ButtonAttrs:
         "button" attribute: popovertargetaction  
         Indicates whether a targeted popover element is to be toggled, shown, or hidden  
 
-        :param value: ['toggle', 'show', 'hide']  
-        :return: An popovertargetaction attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['toggle', 'show', 'hide']
+        
+        Returns:
+            An popovertargetaction attribute to be added to your element
+
+        """
         
         return BaseAttribute("popovertargetaction", value)
             
@@ -154,9 +204,14 @@ class ButtonAttrs:
         "button" attribute: type  
         Type of button  
 
-        :param value: ['submit', 'reset', 'button']  
-        :return: An type attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['submit', 'reset', 'button']
+        
+        Returns:
+            An type attribute to be added to your element
+
+        """
         
         return BaseAttribute("type", value)
             
@@ -168,9 +223,14 @@ class ButtonAttrs:
         "button" attribute: value  
         Value to be used for form submission  
 
-        :param value: Text  
-        :return: An value attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An value attribute to be added to your element
+
+        """
         
         return BaseAttribute("value", value)
             

--- a/tools/generated/canvas_attrs.py
+++ b/tools/generated/canvas_attrs.py
@@ -14,9 +14,14 @@ class CanvasAttrs:
         "canvas" attribute: height  
         Vertical dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An height attribute to be added to your element
+
+        """
         
         return BaseAttribute("height", value)
             
@@ -28,9 +33,14 @@ class CanvasAttrs:
         "canvas" attribute: width  
         Horizontal dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An width attribute to be added to your element
+
+        """
         
         return BaseAttribute("width", value)
             

--- a/tools/generated/col_attrs.py
+++ b/tools/generated/col_attrs.py
@@ -14,9 +14,14 @@ class ColAttrs:
         "col" attribute: span  
         Number of columns spanned by the element  
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An span attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+        
+        Returns:
+            An span attribute to be added to your element
+
+        """
         
         return BaseAttribute("span", value)
             

--- a/tools/generated/colgroup_attrs.py
+++ b/tools/generated/colgroup_attrs.py
@@ -14,9 +14,14 @@ class ColgroupAttrs:
         "colgroup" attribute: span  
         Number of columns spanned by the element  
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An span attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+        
+        Returns:
+            An span attribute to be added to your element
+
+        """
         
         return BaseAttribute("span", value)
             

--- a/tools/generated/data_attrs.py
+++ b/tools/generated/data_attrs.py
@@ -14,9 +14,14 @@ class DataAttrs:
         "data" attribute: value  
         Machine-readable value  
 
-        :param value: Text*  
-        :return: An value attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An value attribute to be added to your element
+
+        """
         
         return BaseAttribute("value", value)
             

--- a/tools/generated/del_attrs.py
+++ b/tools/generated/del_attrs.py
@@ -14,9 +14,14 @@ class DelAttrs:
         "del" attribute: cite  
         Link to the source of the quotation or more information about the edit  
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An cite attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+        
+        Returns:
+            An cite attribute to be added to your element
+
+        """
         
         return BaseAttribute("cite", value)
             
@@ -28,9 +33,14 @@ class DelAttrs:
         "del" attribute: datetime  
         Date and (optionally) time of the change  
 
-        :param value: Valid date string with optional time  
-        :return: An datetime attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid date string with optional time
+        
+        Returns:
+            An datetime attribute to be added to your element
+
+        """
         
         return BaseAttribute("datetime", value)
             

--- a/tools/generated/details_attrs.py
+++ b/tools/generated/details_attrs.py
@@ -14,9 +14,14 @@ class DetailsAttrs:
         "details" attribute: name  
         Name of group of mutually-exclusive details elements  
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             
@@ -28,9 +33,14 @@ class DetailsAttrs:
         "details" attribute: open  
         Whether the details are visible  
 
-        :param value: Boolean attribute  
-        :return: An open attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An open attribute to be added to your element
+
+        """
         
         return BaseAttribute("open", value)
             

--- a/tools/generated/dfn_attrs.py
+++ b/tools/generated/dfn_attrs.py
@@ -14,9 +14,14 @@ class DfnAttrs:
         "dfn" attribute: title  
         Full term or expansion of abbreviation  
 
-        :param value: Text  
-        :return: An title attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An title attribute to be added to your element
+
+        """
         
         return BaseAttribute("title", value)
             

--- a/tools/generated/dialog_attrs.py
+++ b/tools/generated/dialog_attrs.py
@@ -14,9 +14,14 @@ class DialogAttrs:
         "dialog" attribute: open  
         Whether the dialog box is showing  
 
-        :param value: Boolean attribute  
-        :return: An open attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An open attribute to be added to your element
+
+        """
         
         return BaseAttribute("open", value)
             

--- a/tools/generated/elements/a_element.py
+++ b/tools/generated/elements/a_element.py
@@ -145,411 +145,410 @@ class a(BaseElement):
         Initialize 'a' (Hyperlink) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `download` :
-            Whether to download the resource instead of navigating to it, and its filename if so
-        
-        `href` :
-            Address of the hyperlink  
-            Valid URL potentially surrounded by spaces
-        
-        `hreflang` :
-            Language of the linked resource  
-            Valid BCP 47 language tag
-        
-        `ping` :
-            URLs to ping
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `rel` :
-            Relationship between the location in the document containing the hyperlink and the destination resource
-        
-        `target` :
-            Navigable for hyperlink navigation  
-            Valid navigable target name or keyword
-        
-        `type` :
-            Hint for the type of the referenced resource  
-            Valid MIME type string
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            download:
+                Whether to download the resource instead of navigating to it, and its filename if so
+            
+            href:
+                Address of the hyperlink.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            hreflang:
+                Language of the linked resource.  
+                Value hint: Valid BCP 47 language tag
+            
+            ping:
+                URLs to ping
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            rel:
+                Relationship between the location in the document containing the hyperlink and the destination resource
+            
+            target:
+                Navigable for hyperlink navigation.  
+                Value hint: Valid navigable target name or keyword
+            
+            type:
+                Hint for the type of the referenced resource.  
+                Value hint: Valid MIME type string
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "a",

--- a/tools/generated/elements/abbr_element.py
+++ b/tools/generated/elements/abbr_element.py
@@ -137,382 +137,381 @@ class abbr(BaseElement):
         Initialize 'abbr' (Abbreviation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "abbr",

--- a/tools/generated/elements/address_element.py
+++ b/tools/generated/elements/address_element.py
@@ -137,382 +137,381 @@ class address(BaseElement):
         Initialize 'address' (Contact information for a page or article element) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "address",

--- a/tools/generated/elements/area_element.py
+++ b/tools/generated/elements/area_element.py
@@ -146,413 +146,412 @@ class area(BaseElement):
         Initialize 'area' (Hyperlink or dead area on an image map) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `alt` :
-            Replacement text for use when images are not available
-        
-        `coords` :
-            Coordinates for the shape to be created in an image map  
-            Valid list of floating-point numbers*
-        
-        `download` :
-            Whether to download the resource instead of navigating to it, and its filename if so
-        
-        `href` :
-            Address of the hyperlink  
-            Valid URL potentially surrounded by spaces
-        
-        `ping` :
-            URLs to ping
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `rel` :
-            Relationship between the location in the document containing the hyperlink and the destination resource
-        
-        `shape` :
-            The kind of shape to be created in an image map
-        
-        `target` :
-            Navigable for hyperlink navigation  
-            Valid navigable target name or keyword
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            alt:
+                Replacement text for use when images are not available
+            
+            coords:
+                Coordinates for the shape to be created in an image map.  
+                Value hint: Valid list of floating-point numbers*
+            
+            download:
+                Whether to download the resource instead of navigating to it, and its filename if so
+            
+            href:
+                Address of the hyperlink.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            ping:
+                URLs to ping
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            rel:
+                Relationship between the location in the document containing the hyperlink and the destination resource
+            
+            shape:
+                The kind of shape to be created in an image map
+            
+            target:
+                Navigable for hyperlink navigation.  
+                Value hint: Valid navigable target name or keyword
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "area",

--- a/tools/generated/elements/article_element.py
+++ b/tools/generated/elements/article_element.py
@@ -137,382 +137,381 @@ class article(BaseElement):
         Initialize 'article' (Self-contained syndicatable or reusable composition) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "article",

--- a/tools/generated/elements/aside_element.py
+++ b/tools/generated/elements/aside_element.py
@@ -137,382 +137,381 @@ class aside(BaseElement):
         Initialize 'aside' (Sidebar for tangentially related content) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "aside",

--- a/tools/generated/elements/audio_element.py
+++ b/tools/generated/elements/audio_element.py
@@ -144,404 +144,403 @@ class audio(BaseElement):
         Initialize 'audio' (Audio player) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `autoplay` :
-            Hint that the media resource can be started automatically when the page is loaded
-        
-        `controls` :
-            Show user agent controls
-        
-        `crossorigin` :
-            How the element handles crossorigin requests
-        
-        `loop` :
-            Whether to loop the media resource
-        
-        `muted` :
-            Whether to mute the media resource by default
-        
-        `preload` :
-            Hints how much buffering the media resource will likely need
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            autoplay:
+                Hint that the media resource can be started automatically when the page is loaded
+            
+            controls:
+                Show user agent controls
+            
+            crossorigin:
+                How the element handles crossorigin requests
+            
+            loop:
+                Whether to loop the media resource
+            
+            muted:
+                Whether to mute the media resource by default
+            
+            preload:
+                Hints how much buffering the media resource will likely need
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "audio",

--- a/tools/generated/elements/b_element.py
+++ b/tools/generated/elements/b_element.py
@@ -137,382 +137,381 @@ class b(BaseElement):
         Initialize 'b' (Keywords) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "b",

--- a/tools/generated/elements/base_element.py
+++ b/tools/generated/elements/base_element.py
@@ -139,390 +139,389 @@ class base(BaseElement):
         Initialize 'base' (Base URL and default target navigable for hyperlinks and forms) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `href` :
-            Document base URL  
-            Valid URL potentially surrounded by spaces
-        
-        `target` :
-            Default navigable for hyperlink navigation and form submission  
-            Valid navigable target name or keyword
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            href:
+                Document base URL.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            target:
+                Default navigable for hyperlink navigation and form submission.  
+                Value hint: Valid navigable target name or keyword
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "base",

--- a/tools/generated/elements/bdi_element.py
+++ b/tools/generated/elements/bdi_element.py
@@ -137,382 +137,381 @@ class bdi(BaseElement):
         Initialize 'bdi' (Text directionality isolation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "bdi",

--- a/tools/generated/elements/bdo_element.py
+++ b/tools/generated/elements/bdo_element.py
@@ -137,382 +137,381 @@ class bdo(BaseElement):
         Initialize 'bdo' (Text directionality formatting) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "bdo",

--- a/tools/generated/elements/blockquote_element.py
+++ b/tools/generated/elements/blockquote_element.py
@@ -138,386 +138,385 @@ class blockquote(BaseElement):
         Initialize 'blockquote' (A section quoted from another source) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `cite` :
-            Link to the source of the quotation or more information about the edit  
-            Valid URL potentially surrounded by spaces
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            cite:
+                Link to the source of the quotation or more information about the edit.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "blockquote",

--- a/tools/generated/elements/body_element.py
+++ b/tools/generated/elements/body_element.py
@@ -155,454 +155,453 @@ class body(BaseElement):
         Initialize 'body' (Document body) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `onafterprint` :
-            afterprint event handler for Window object  
-            Event handler content attribute
-        
-        `onbeforeprint` :
-            beforeprint event handler for Window object  
-            Event handler content attribute
-        
-        `onbeforeunload` :
-            beforeunload event handler for Window object  
-            Event handler content attribute
-        
-        `onhashchange` :
-            hashchange event handler for Window object  
-            Event handler content attribute
-        
-        `onlanguagechange` :
-            languagechange event handler for Window object  
-            Event handler content attribute
-        
-        `onmessage` :
-            message event handler for Window object  
-            Event handler content attribute
-        
-        `onmessageerror` :
-            messageerror event handler for Window object  
-            Event handler content attribute
-        
-        `onoffline` :
-            offline event handler for Window object  
-            Event handler content attribute
-        
-        `ononline` :
-            online event handler for Window object  
-            Event handler content attribute
-        
-        `onpagehide` :
-            pagehide event handler for Window object  
-            Event handler content attribute
-        
-        `onpagereveal` :
-            pagereveal event handler for Window object  
-            Event handler content attribute
-        
-        `onpageshow` :
-            pageshow event handler for Window object  
-            Event handler content attribute
-        
-        `onpageswap` :
-            pageswap event handler for Window object  
-            Event handler content attribute
-        
-        `onpopstate` :
-            popstate event handler for Window object  
-            Event handler content attribute
-        
-        `onrejectionhandled` :
-            rejectionhandled event handler for Window object  
-            Event handler content attribute
-        
-        `onstorage` :
-            storage event handler for Window object  
-            Event handler content attribute
-        
-        `onunhandledrejection` :
-            unhandledrejection event handler for Window object  
-            Event handler content attribute
-        
-        `onunload` :
-            unload event handler for Window object  
-            Event handler content attribute
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            onafterprint:
+                afterprint event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onbeforeprint:
+                beforeprint event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onbeforeunload:
+                beforeunload event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onhashchange:
+                hashchange event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onlanguagechange:
+                languagechange event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onmessage:
+                message event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onmessageerror:
+                messageerror event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onoffline:
+                offline event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            ononline:
+                online event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onpagehide:
+                pagehide event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onpagereveal:
+                pagereveal event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onpageshow:
+                pageshow event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onpageswap:
+                pageswap event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onpopstate:
+                popstate event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onrejectionhandled:
+                rejectionhandled event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onstorage:
+                storage event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onunhandledrejection:
+                unhandledrejection event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            onunload:
+                unload event handler for Window object.  
+                Value hint: Event handler content attribute
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "body",

--- a/tools/generated/elements/br_element.py
+++ b/tools/generated/elements/br_element.py
@@ -137,382 +137,381 @@ class br(BaseElement):
         Initialize 'br' (Line break, e.g. in poem or postal address) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "br",

--- a/tools/generated/elements/button_element.py
+++ b/tools/generated/elements/button_element.py
@@ -149,422 +149,421 @@ class button(BaseElement):
         Initialize 'button' (Button control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `formaction` :
-            URL to use for form submission  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `formenctype` :
-            Entry list encoding type to use for form submission
-        
-        `formmethod` :
-            Variant to use for form submission
-        
-        `formnovalidate` :
-            Bypass form control validation for form submission
-        
-        `formtarget` :
-            Navigable for form submission  
-            Valid navigable target name or keyword
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `popovertarget` :
-            Targets a popover element to toggle, show, or hide  
-            ID*
-        
-        `popovertargetaction` :
-            Indicates whether a targeted popover element is to be toggled, shown, or hidden
-        
-        `type` :
-            Type of button
-        
-        `value` :
-            Value to be used for form submission
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            disabled:
+                Whether the form control is disabled
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            formaction:
+                URL to use for form submission.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            formenctype:
+                Entry list encoding type to use for form submission
+            
+            formmethod:
+                Variant to use for form submission
+            
+            formnovalidate:
+                Bypass form control validation for form submission
+            
+            formtarget:
+                Navigable for form submission.  
+                Value hint: Valid navigable target name or keyword
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            popovertarget:
+                Targets a popover element to toggle, show, or hide.  
+                Value hint: ID*
+            
+            popovertargetaction:
+                Indicates whether a targeted popover element is to be toggled, shown, or hidden
+            
+            type:
+                Type of button
+            
+            value:
+                Value to be used for form submission
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "button",

--- a/tools/generated/elements/canvas_element.py
+++ b/tools/generated/elements/canvas_element.py
@@ -139,388 +139,387 @@ class canvas(BaseElement):
         Initialize 'canvas' (Scriptable bitmap canvas) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `height` :
-            Vertical dimension
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            height:
+                Vertical dimension
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "canvas",

--- a/tools/generated/elements/caption_element.py
+++ b/tools/generated/elements/caption_element.py
@@ -137,382 +137,381 @@ class caption(BaseElement):
         Initialize 'caption' (Table caption) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "caption",

--- a/tools/generated/elements/cite_element.py
+++ b/tools/generated/elements/cite_element.py
@@ -137,382 +137,381 @@ class cite(BaseElement):
         Initialize 'cite' (Title of a work) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "cite",

--- a/tools/generated/elements/code_element.py
+++ b/tools/generated/elements/code_element.py
@@ -137,382 +137,381 @@ class code(BaseElement):
         Initialize 'code' (Computer code) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "code",

--- a/tools/generated/elements/col_element.py
+++ b/tools/generated/elements/col_element.py
@@ -138,386 +138,385 @@ class col(BaseElement):
         Initialize 'col' (Table column) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `span` :
-            Number of columns spanned by the element  
-            Valid non-negative integer greater than zero
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            span:
+                Number of columns spanned by the element.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "col",

--- a/tools/generated/elements/colgroup_element.py
+++ b/tools/generated/elements/colgroup_element.py
@@ -138,386 +138,385 @@ class colgroup(BaseElement):
         Initialize 'colgroup' (Group of columns in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `span` :
-            Number of columns spanned by the element  
-            Valid non-negative integer greater than zero
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            span:
+                Number of columns spanned by the element.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "colgroup",

--- a/tools/generated/elements/data_element.py
+++ b/tools/generated/elements/data_element.py
@@ -138,385 +138,384 @@ class data(BaseElement):
         Initialize 'data' (Machine-readable equivalent) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `value` :
-            Machine-readable value
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            value:
+                Machine-readable value
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "data",

--- a/tools/generated/elements/datalist_element.py
+++ b/tools/generated/elements/datalist_element.py
@@ -137,382 +137,381 @@ class datalist(BaseElement):
         Initialize 'datalist' (Container for options for combo box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "datalist",

--- a/tools/generated/elements/dd_element.py
+++ b/tools/generated/elements/dd_element.py
@@ -137,382 +137,381 @@ class dd(BaseElement):
         Initialize 'dd' (Content for corresponding dt element(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "dd",

--- a/tools/generated/elements/del__element.py
+++ b/tools/generated/elements/del__element.py
@@ -139,390 +139,389 @@ class del_(BaseElement):
         Initialize 'del' (A removal from the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `cite` :
-            Link to the source of the quotation or more information about the edit  
-            Valid URL potentially surrounded by spaces
-        
-        `datetime` :
-            Date and (optionally) time of the change  
-            Valid date string with optional time
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            cite:
+                Link to the source of the quotation or more information about the edit.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            datetime:
+                Date and (optionally) time of the change.  
+                Value hint: Valid date string with optional time
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "del",

--- a/tools/generated/elements/details_element.py
+++ b/tools/generated/elements/details_element.py
@@ -139,388 +139,387 @@ class details(BaseElement):
         Initialize 'details' (Disclosure control for hiding details) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `name` :
-            Name of group of mutually-exclusive details elements
-        
-        `open` :
-            Whether the details are visible
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            name:
+                Name of group of mutually-exclusive details elements
+            
+            open:
+                Whether the details are visible
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "details",

--- a/tools/generated/elements/dfn_element.py
+++ b/tools/generated/elements/dfn_element.py
@@ -137,382 +137,381 @@ class dfn(BaseElement):
         Initialize 'dfn' (Defining instance) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "dfn",

--- a/tools/generated/elements/dialog_element.py
+++ b/tools/generated/elements/dialog_element.py
@@ -138,385 +138,384 @@ class dialog(BaseElement):
         Initialize 'dialog' (Dialog box or window) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `open` :
-            Whether the dialog box is showing
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            open:
+                Whether the dialog box is showing
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "dialog",

--- a/tools/generated/elements/div_element.py
+++ b/tools/generated/elements/div_element.py
@@ -137,382 +137,381 @@ class div(BaseElement):
         Initialize 'div' (Generic flow container, or container for name-value groups in dl elements) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "div",

--- a/tools/generated/elements/dl_element.py
+++ b/tools/generated/elements/dl_element.py
@@ -137,382 +137,381 @@ class dl(BaseElement):
         Initialize 'dl' (Association list consisting of zero or more name-value groups) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "dl",

--- a/tools/generated/elements/dt_element.py
+++ b/tools/generated/elements/dt_element.py
@@ -137,382 +137,381 @@ class dt(BaseElement):
         Initialize 'dt' (Legend for corresponding dd element(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "dt",

--- a/tools/generated/elements/em_element.py
+++ b/tools/generated/elements/em_element.py
@@ -137,382 +137,381 @@ class em(BaseElement):
         Initialize 'em' (Stress emphasis) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "em",

--- a/tools/generated/elements/embed_element.py
+++ b/tools/generated/elements/embed_element.py
@@ -141,396 +141,395 @@ class embed(BaseElement):
         Initialize 'embed' (Plugin) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `height` :
-            Vertical dimension
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `type` :
-            Type of embedded resource  
-            Valid MIME type string
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            height:
+                Vertical dimension
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            type:
+                Type of embedded resource.  
+                Value hint: Valid MIME type string
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "embed",

--- a/tools/generated/elements/fieldset_element.py
+++ b/tools/generated/elements/fieldset_element.py
@@ -140,392 +140,391 @@ class fieldset(BaseElement):
         Initialize 'fieldset' (Group of form controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `disabled` :
-            Whether the descendant form controls, except any inside legend, are disabled
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            disabled:
+                Whether the descendant form controls, except any inside legend, are disabled
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "fieldset",

--- a/tools/generated/elements/figcaption_element.py
+++ b/tools/generated/elements/figcaption_element.py
@@ -137,382 +137,381 @@ class figcaption(BaseElement):
         Initialize 'figcaption' (Caption for figure) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "figcaption",

--- a/tools/generated/elements/figure_element.py
+++ b/tools/generated/elements/figure_element.py
@@ -137,382 +137,381 @@ class figure(BaseElement):
         Initialize 'figure' (Figure with optional caption) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "figure",

--- a/tools/generated/elements/footer_element.py
+++ b/tools/generated/elements/footer_element.py
@@ -137,382 +137,381 @@ class footer(BaseElement):
         Initialize 'footer' (Footer for a page or section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "footer",

--- a/tools/generated/elements/form_element.py
+++ b/tools/generated/elements/form_element.py
@@ -145,409 +145,408 @@ class form(BaseElement):
         Initialize 'form' (User-submittable form) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accept_charset` :
-            Character encodings to use for form submission  
-            ASCII case-insensitive match for "UTF-8"
-        
-        `action` :
-            URL to use for form submission  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `autocomplete` :
-            Default setting for autofill feature for controls in the form
-        
-        `enctype` :
-            Entry list encoding type to use for form submission
-        
-        `method` :
-            Variant to use for form submission
-        
-        `name` :
-            Name of form to use in the document.forms API
-        
-        `novalidate` :
-            Bypass form control validation for form submission
-        
-        `target` :
-            Navigable for form submission  
-            Valid navigable target name or keyword
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accept_charset:
+                Character encodings to use for form submission.  
+                Value hint: ASCII case-insensitive match for "UTF-8"
+            
+            action:
+                URL to use for form submission.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            autocomplete:
+                Default setting for autofill feature for controls in the form
+            
+            enctype:
+                Entry list encoding type to use for form submission
+            
+            method:
+                Variant to use for form submission
+            
+            name:
+                Name of form to use in the document.forms API
+            
+            novalidate:
+                Bypass form control validation for form submission
+            
+            target:
+                Navigable for form submission.  
+                Value hint: Valid navigable target name or keyword
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "form",

--- a/tools/generated/elements/h1_element.py
+++ b/tools/generated/elements/h1_element.py
@@ -137,382 +137,381 @@ class h1(BaseElement):
         Initialize 'h1' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "h1",

--- a/tools/generated/elements/h2_element.py
+++ b/tools/generated/elements/h2_element.py
@@ -137,382 +137,381 @@ class h2(BaseElement):
         Initialize 'h2' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "h2",

--- a/tools/generated/elements/h3_element.py
+++ b/tools/generated/elements/h3_element.py
@@ -137,382 +137,381 @@ class h3(BaseElement):
         Initialize 'h3' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "h3",

--- a/tools/generated/elements/h4_element.py
+++ b/tools/generated/elements/h4_element.py
@@ -137,382 +137,381 @@ class h4(BaseElement):
         Initialize 'h4' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "h4",

--- a/tools/generated/elements/h5_element.py
+++ b/tools/generated/elements/h5_element.py
@@ -137,382 +137,381 @@ class h5(BaseElement):
         Initialize 'h5' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "h5",

--- a/tools/generated/elements/h6_element.py
+++ b/tools/generated/elements/h6_element.py
@@ -137,382 +137,381 @@ class h6(BaseElement):
         Initialize 'h6' (Heading) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "h6",

--- a/tools/generated/elements/head_element.py
+++ b/tools/generated/elements/head_element.py
@@ -137,382 +137,381 @@ class head(BaseElement):
         Initialize 'head' (Container for document metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "head",

--- a/tools/generated/elements/header_element.py
+++ b/tools/generated/elements/header_element.py
@@ -137,382 +137,381 @@ class header(BaseElement):
         Initialize 'header' (Introductory or navigational aids for a page or section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "header",

--- a/tools/generated/elements/hgroup_element.py
+++ b/tools/generated/elements/hgroup_element.py
@@ -137,382 +137,381 @@ class hgroup(BaseElement):
         Initialize 'hgroup' (Heading container) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "hgroup",

--- a/tools/generated/elements/hr_element.py
+++ b/tools/generated/elements/hr_element.py
@@ -137,382 +137,381 @@ class hr(BaseElement):
         Initialize 'hr' (Thematic break) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "hr",

--- a/tools/generated/elements/html_element.py
+++ b/tools/generated/elements/html_element.py
@@ -137,382 +137,381 @@ class html(BaseElement):
         Initialize 'html' (Root element) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "html",

--- a/tools/generated/elements/i_element.py
+++ b/tools/generated/elements/i_element.py
@@ -137,382 +137,381 @@ class i(BaseElement):
         Initialize 'i' (Alternate voice) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "i",

--- a/tools/generated/elements/iframe_element.py
+++ b/tools/generated/elements/iframe_element.py
@@ -147,417 +147,416 @@ class iframe(BaseElement):
         Initialize 'iframe' (Child navigable) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `allow` :
-            Permissions policy to be applied to the iframe's contents  
-            Serialized permissions policy
-        
-        `allowfullscreen` :
-            Whether to allow the iframe's contents to use requestFullscreen()
-        
-        `height` :
-            Vertical dimension
-        
-        `loading` :
-            Used when determining loading deferral
-        
-        `name` :
-            Name of content navigable  
-            Valid navigable target name or keyword
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `sandbox` :
-            Security rules for nested content
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `srcdoc` :
-            A document to render in the iframe  
-            The source of an iframe srcdoc document*
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            allow:
+                Permissions policy to be applied to the iframe's contents.  
+                Value hint: Serialized permissions policy
+            
+            allowfullscreen:
+                Whether to allow the iframe's contents to use requestFullscreen()
+            
+            height:
+                Vertical dimension
+            
+            loading:
+                Used when determining loading deferral
+            
+            name:
+                Name of content navigable.  
+                Value hint: Valid navigable target name or keyword
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            sandbox:
+                Security rules for nested content
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            srcdoc:
+                A document to render in the iframe.  
+                Value hint: The source of an iframe srcdoc document*
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "iframe",

--- a/tools/generated/elements/img_element.py
+++ b/tools/generated/elements/img_element.py
@@ -150,426 +150,425 @@ class img(BaseElement):
         Initialize 'img' (Image) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `alt` :
-            Replacement text for use when images are not available
-        
-        `crossorigin` :
-            How the element handles crossorigin requests
-        
-        `decoding` :
-            Decoding hint to use when processing this image for presentation
-        
-        `fetchpriority` :
-            Sets the priority for fetches initiated by the element
-        
-        `height` :
-            Vertical dimension
-        
-        `ismap` :
-            Whether the image is a server-side image map
-        
-        `loading` :
-            Used when determining loading deferral
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `sizes` :
-            Image sizes for different page layouts  
-            Valid source size list
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `srcset` :
-            Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
-            Comma-separated list of image candidate strings
-        
-        `usemap` :
-            Name of image map to use  
-            Valid hash-name reference*
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            alt:
+                Replacement text for use when images are not available
+            
+            crossorigin:
+                How the element handles crossorigin requests
+            
+            decoding:
+                Decoding hint to use when processing this image for presentation
+            
+            fetchpriority:
+                Sets the priority for fetches initiated by the element
+            
+            height:
+                Vertical dimension
+            
+            ismap:
+                Whether the image is a server-side image map
+            
+            loading:
+                Used when determining loading deferral
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            sizes:
+                Image sizes for different page layouts.  
+                Value hint: Valid source size list
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            srcset:
+                Images to use in different situations, e.g., high-resolution displays, small monitors, etc..  
+                Value hint: Comma-separated list of image candidate strings
+            
+            usemap:
+                Name of image map to use.  
+                Value hint: Valid hash-name reference*
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "img",

--- a/tools/generated/elements/input_element.py
+++ b/tools/generated/elements/input_element.py
@@ -171,498 +171,497 @@ class input(BaseElement): # type: ignore[misc]
         Initialize 'input' (Form control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accept` :
-            Hint for expected file type in file upload controls  
-            Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*
-        
-        `alpha` :
-            Allow the color's alpha component to be set
-        
-        `alt` :
-            Replacement text for use when images are not available
-        
-        `autocomplete` :
-            Hint for form autofill feature  
-            Autofill field name and related tokens*
-        
-        `checked` :
-            Whether the control is checked
-        
-        `colorspace` :
-            The color space of the serialized color
-        
-        `dirname` :
-            Name of form control to use for sending the element's directionality in form submission
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `formaction` :
-            URL to use for form submission  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `formenctype` :
-            Entry list encoding type to use for form submission
-        
-        `formmethod` :
-            Variant to use for form submission
-        
-        `formnovalidate` :
-            Bypass form control validation for form submission
-        
-        `formtarget` :
-            Navigable for form submission  
-            Valid navigable target name or keyword
-        
-        `height` :
-            Vertical dimension
-        
-        `list` :
-            List of autocomplete options  
-            ID*
-        
-        `max` :
-            Maximum value  
-            Varies*
-        
-        `maxlength` :
-            Maximum length of value
-        
-        `min` :
-            Minimum value  
-            Varies*
-        
-        `minlength` :
-            Minimum length of value
-        
-        `multiple` :
-            Whether to allow multiple values
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `pattern` :
-            Pattern to be matched by the form control's value  
-            Regular expression matching the JavaScript Pattern production
-        
-        `placeholder` :
-            User-visible label to be placed within the form control
-        
-        `popovertarget` :
-            Targets a popover element to toggle, show, or hide  
-            ID*
-        
-        `popovertargetaction` :
-            Indicates whether a targeted popover element is to be toggled, shown, or hidden
-        
-        `readonly` :
-            Whether to allow the value to be edited by the user
-        
-        `required` :
-            Whether the control is required for form submission
-        
-        `size` :
-            Size of the control  
-            Valid non-negative integer greater than zero
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `step` :
-            Granularity to be matched by the form control's value
-        
-        `title` :
-            Description of pattern (when used with pattern attribute)
-        
-        `type` :
-            Type of form control  
-            input type keyword
-        
-        `value` :
-            Value of the form control  
-            Varies*
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accept:
+                Hint for expected file type in file upload controls.  
+                Value hint: Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*
+            
+            alpha:
+                Allow the color's alpha component to be set
+            
+            alt:
+                Replacement text for use when images are not available
+            
+            autocomplete:
+                Hint for form autofill feature.  
+                Value hint: Autofill field name and related tokens*
+            
+            checked:
+                Whether the control is checked
+            
+            colorspace:
+                The color space of the serialized color
+            
+            dirname:
+                Name of form control to use for sending the element's directionality in form submission
+            
+            disabled:
+                Whether the form control is disabled
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            formaction:
+                URL to use for form submission.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            formenctype:
+                Entry list encoding type to use for form submission
+            
+            formmethod:
+                Variant to use for form submission
+            
+            formnovalidate:
+                Bypass form control validation for form submission
+            
+            formtarget:
+                Navigable for form submission.  
+                Value hint: Valid navigable target name or keyword
+            
+            height:
+                Vertical dimension
+            
+            list:
+                List of autocomplete options.  
+                Value hint: ID*
+            
+            max:
+                Maximum value.  
+                Value hint: Varies*
+            
+            maxlength:
+                Maximum length of value
+            
+            min:
+                Minimum value.  
+                Value hint: Varies*
+            
+            minlength:
+                Minimum length of value
+            
+            multiple:
+                Whether to allow multiple values
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            pattern:
+                Pattern to be matched by the form control's value.  
+                Value hint: Regular expression matching the JavaScript Pattern production
+            
+            placeholder:
+                User-visible label to be placed within the form control
+            
+            popovertarget:
+                Targets a popover element to toggle, show, or hide.  
+                Value hint: ID*
+            
+            popovertargetaction:
+                Indicates whether a targeted popover element is to be toggled, shown, or hidden
+            
+            readonly:
+                Whether to allow the value to be edited by the user
+            
+            required:
+                Whether the control is required for form submission
+            
+            size:
+                Size of the control.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            step:
+                Granularity to be matched by the form control's value
+            
+            title:
+                Description of pattern (when used with pattern attribute)
+            
+            type:
+                Type of form control.  
+                Value hint: input type keyword
+            
+            value:
+                Value of the form control.  
+                Value hint: Varies*
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "input",

--- a/tools/generated/elements/ins_element.py
+++ b/tools/generated/elements/ins_element.py
@@ -139,390 +139,389 @@ class ins(BaseElement):
         Initialize 'ins' (An addition to the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `cite` :
-            Link to the source of the quotation or more information about the edit  
-            Valid URL potentially surrounded by spaces
-        
-        `datetime` :
-            Date and (optionally) time of the change  
-            Valid date string with optional time
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            cite:
+                Link to the source of the quotation or more information about the edit.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            datetime:
+                Date and (optionally) time of the change.  
+                Value hint: Valid date string with optional time
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "ins",

--- a/tools/generated/elements/kbd_element.py
+++ b/tools/generated/elements/kbd_element.py
@@ -137,382 +137,381 @@ class kbd(BaseElement):
         Initialize 'kbd' (User input) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "kbd",

--- a/tools/generated/elements/label_element.py
+++ b/tools/generated/elements/label_element.py
@@ -138,386 +138,385 @@ class label(BaseElement):
         Initialize 'label' (Caption for a form control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `for_` :
-            Associate the label with form control  
-            ID*
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            for_:
+                Associate the label with form control.  
+                Value hint: ID*
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "label",

--- a/tools/generated/elements/legend_element.py
+++ b/tools/generated/elements/legend_element.py
@@ -137,382 +137,381 @@ class legend(BaseElement):
         Initialize 'legend' (Caption for fieldset) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "legend",

--- a/tools/generated/elements/li_element.py
+++ b/tools/generated/elements/li_element.py
@@ -138,385 +138,384 @@ class li(BaseElement):
         Initialize 'li' (List item) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `value` :
-            Ordinal value of the list item
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            value:
+                Ordinal value of the list item
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "li",

--- a/tools/generated/elements/link_element.py
+++ b/tools/generated/elements/link_element.py
@@ -153,441 +153,440 @@ class link(BaseElement): # type: ignore[misc]
         Initialize 'link' (Link metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `as_` :
-            Potential destination for a preload request (for rel="preload" and rel="modulepreload")  
-            Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
-        
-        `blocking` :
-            Whether the element is potentially render-blocking
-        
-        `color` :
-            Color to use when customizing a site's icon (for rel="mask-icon")  
-            CSS <color>
-        
-        `crossorigin` :
-            How the element handles crossorigin requests
-        
-        `disabled` :
-            Whether the link is disabled
-        
-        `fetchpriority` :
-            Sets the priority for fetches initiated by the element
-        
-        `href` :
-            Address of the hyperlink  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `hreflang` :
-            Language of the linked resource  
-            Valid BCP 47 language tag
-        
-        `imagesizes` :
-            Image sizes for different page layouts (for rel="preload")  
-            Valid source size list
-        
-        `imagesrcset` :
-            Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")  
-            Comma-separated list of image candidate strings
-        
-        `integrity` :
-            Integrity metadata used in Subresource Integrity checks [SRI]
-        
-        `media` :
-            Applicable media  
-            Valid media query list
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `rel` :
-            Relationship between the document containing the hyperlink and the destination resource
-        
-        `sizes` :
-            Sizes of the icons (for rel="icon")
-        
-        `title` :
-            CSS style sheet set name
-        `title` :
-            Title of the link
-        
-        `type` :
-            Hint for the type of the referenced resource  
-            Valid MIME type string
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            as_:
+                Potential destination for a preload request (for rel="preload" and rel="modulepreload").  
+                Value hint: Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
+            
+            blocking:
+                Whether the element is potentially render-blocking
+            
+            color:
+                Color to use when customizing a site's icon (for rel="mask-icon").  
+                Value hint: CSS <color>
+            
+            crossorigin:
+                How the element handles crossorigin requests
+            
+            disabled:
+                Whether the link is disabled
+            
+            fetchpriority:
+                Sets the priority for fetches initiated by the element
+            
+            href:
+                Address of the hyperlink.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            hreflang:
+                Language of the linked resource.  
+                Value hint: Valid BCP 47 language tag
+            
+            imagesizes:
+                Image sizes for different page layouts (for rel="preload").  
+                Value hint: Valid source size list
+            
+            imagesrcset:
+                Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload").  
+                Value hint: Comma-separated list of image candidate strings
+            
+            integrity:
+                Integrity metadata used in Subresource Integrity checks [SRI]
+            
+            media:
+                Applicable media.  
+                Value hint: Valid media query list
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            rel:
+                Relationship between the document containing the hyperlink and the destination resource
+            
+            sizes:
+                Sizes of the icons (for rel="icon")
+            
+            title:
+                CSS style sheet set name
+            title:
+                Title of the link
+            
+            type:
+                Hint for the type of the referenced resource.  
+                Value hint: Valid MIME type string
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "link",

--- a/tools/generated/elements/main_element.py
+++ b/tools/generated/elements/main_element.py
@@ -137,382 +137,381 @@ class main(BaseElement):
         Initialize 'main' (Container for the dominant contents of the document) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "main",

--- a/tools/generated/elements/map_element.py
+++ b/tools/generated/elements/map_element.py
@@ -138,385 +138,384 @@ class map(BaseElement):
         Initialize 'map' (Image map) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `name` :
-            Name of image map to reference from the usemap attribute
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            name:
+                Name of image map to reference from the usemap attribute
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "map",

--- a/tools/generated/elements/mark_element.py
+++ b/tools/generated/elements/mark_element.py
@@ -137,382 +137,381 @@ class mark(BaseElement):
         Initialize 'mark' (Highlight) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "mark",

--- a/tools/generated/elements/menu_element.py
+++ b/tools/generated/elements/menu_element.py
@@ -137,382 +137,381 @@ class menu(BaseElement):
         Initialize 'menu' (Menu of commands) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "menu",

--- a/tools/generated/elements/meta_element.py
+++ b/tools/generated/elements/meta_element.py
@@ -142,398 +142,397 @@ class meta(BaseElement):
         Initialize 'meta' (Text metadata) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `charset` :
-            Character encoding declaration
-        
-        `content` :
-            Value of the element
-        
-        `http_equiv` :
-            Pragma directive
-        
-        `media` :
-            Applicable media  
-            Valid media query list
-        
-        `name` :
-            Metadata name
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            charset:
+                Character encoding declaration
+            
+            content:
+                Value of the element
+            
+            http_equiv:
+                Pragma directive
+            
+            media:
+                Applicable media.  
+                Value hint: Valid media query list
+            
+            name:
+                Metadata name
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "meta",

--- a/tools/generated/elements/meter_element.py
+++ b/tools/generated/elements/meter_element.py
@@ -143,400 +143,399 @@ class meter(BaseElement):
         Initialize 'meter' (Gauge) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `high` :
-            Low limit of high range
-        
-        `low` :
-            High limit of low range
-        
-        `max` :
-            Upper bound of range
-        
-        `min` :
-            Lower bound of range
-        
-        `optimum` :
-            Optimum value in gauge
-        
-        `value` :
-            Current value of the element
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            high:
+                Low limit of high range
+            
+            low:
+                High limit of low range
+            
+            max:
+                Upper bound of range
+            
+            min:
+                Lower bound of range
+            
+            optimum:
+                Optimum value in gauge
+            
+            value:
+                Current value of the element
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "meter",

--- a/tools/generated/elements/nav_element.py
+++ b/tools/generated/elements/nav_element.py
@@ -137,382 +137,381 @@ class nav(BaseElement):
         Initialize 'nav' (Section with navigational links) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "nav",

--- a/tools/generated/elements/noscript_element.py
+++ b/tools/generated/elements/noscript_element.py
@@ -137,382 +137,381 @@ class noscript(BaseElement):
         Initialize 'noscript' (Fallback content for script) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "noscript",

--- a/tools/generated/elements/object_element.py
+++ b/tools/generated/elements/object_element.py
@@ -143,404 +143,403 @@ class object(BaseElement):
         Initialize 'object' (Image, child navigable, or plugin) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `data` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `height` :
-            Vertical dimension
-        
-        `name` :
-            Name of content navigable  
-            Valid navigable target name or keyword
-        
-        `type` :
-            Type of embedded resource  
-            Valid MIME type string
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            data:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            height:
+                Vertical dimension
+            
+            name:
+                Name of content navigable.  
+                Value hint: Valid navigable target name or keyword
+            
+            type:
+                Type of embedded resource.  
+                Value hint: Valid MIME type string
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "object",

--- a/tools/generated/elements/ol_element.py
+++ b/tools/generated/elements/ol_element.py
@@ -140,391 +140,390 @@ class ol(BaseElement):
         Initialize 'ol' (Ordered list) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `reversed` :
-            Number the list backwards
-        
-        `start` :
-            Starting value of the list
-        
-        `type` :
-            Kind of list marker
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            reversed:
+                Number the list backwards
+            
+            start:
+                Starting value of the list
+            
+            type:
+                Kind of list marker
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "ol",

--- a/tools/generated/elements/optgroup_element.py
+++ b/tools/generated/elements/optgroup_element.py
@@ -139,388 +139,387 @@ class optgroup(BaseElement):
         Initialize 'optgroup' (Group of options in a list box) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `label` :
-            User-visible label
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            disabled:
+                Whether the form control is disabled
+            
+            label:
+                User-visible label
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "optgroup",

--- a/tools/generated/elements/option_element.py
+++ b/tools/generated/elements/option_element.py
@@ -141,394 +141,393 @@ class option(BaseElement):
         Initialize 'option' (Option in a list box or combo box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `label` :
-            User-visible label
-        
-        `selected` :
-            Whether the option is selected by default
-        
-        `value` :
-            Value to be used for form submission
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            disabled:
+                Whether the form control is disabled
+            
+            label:
+                User-visible label
+            
+            selected:
+                Whether the option is selected by default
+            
+            value:
+                Value to be used for form submission
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "option",

--- a/tools/generated/elements/output_element.py
+++ b/tools/generated/elements/output_element.py
@@ -140,392 +140,391 @@ class output(BaseElement):
         Initialize 'output' (Calculated output value) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `for_` :
-            Specifies controls from which the output was calculated
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            for_:
+                Specifies controls from which the output was calculated
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "output",

--- a/tools/generated/elements/p_element.py
+++ b/tools/generated/elements/p_element.py
@@ -137,382 +137,381 @@ class p(BaseElement):
         Initialize 'p' (Paragraph) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "p",

--- a/tools/generated/elements/picture_element.py
+++ b/tools/generated/elements/picture_element.py
@@ -137,382 +137,381 @@ class picture(BaseElement):
         Initialize 'picture' (Image) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "picture",

--- a/tools/generated/elements/pre_element.py
+++ b/tools/generated/elements/pre_element.py
@@ -137,382 +137,381 @@ class pre(BaseElement):
         Initialize 'pre' (Block of preformatted text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "pre",

--- a/tools/generated/elements/progress_element.py
+++ b/tools/generated/elements/progress_element.py
@@ -139,388 +139,387 @@ class progress(BaseElement):
         Initialize 'progress' (Progress bar) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `max` :
-            Upper bound of range
-        
-        `value` :
-            Current value of the element
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            max:
+                Upper bound of range
+            
+            value:
+                Current value of the element
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "progress",

--- a/tools/generated/elements/q_element.py
+++ b/tools/generated/elements/q_element.py
@@ -138,386 +138,385 @@ class q(BaseElement):
         Initialize 'q' (Quotation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `cite` :
-            Link to the source of the quotation or more information about the edit  
-            Valid URL potentially surrounded by spaces
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            cite:
+                Link to the source of the quotation or more information about the edit.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "q",

--- a/tools/generated/elements/rp_element.py
+++ b/tools/generated/elements/rp_element.py
@@ -137,382 +137,381 @@ class rp(BaseElement):
         Initialize 'rp' (Parenthesis for ruby annotation text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "rp",

--- a/tools/generated/elements/rt_element.py
+++ b/tools/generated/elements/rt_element.py
@@ -137,382 +137,381 @@ class rt(BaseElement):
         Initialize 'rt' (Ruby annotation text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "rt",

--- a/tools/generated/elements/ruby_element.py
+++ b/tools/generated/elements/ruby_element.py
@@ -137,382 +137,381 @@ class ruby(BaseElement):
         Initialize 'ruby' (Ruby annotation(s)) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "ruby",

--- a/tools/generated/elements/s_element.py
+++ b/tools/generated/elements/s_element.py
@@ -137,382 +137,381 @@ class s(BaseElement):
         Initialize 's' (Inaccurate text) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "s",

--- a/tools/generated/elements/samp_element.py
+++ b/tools/generated/elements/samp_element.py
@@ -137,382 +137,381 @@ class samp(BaseElement):
         Initialize 'samp' (Computer output) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "samp",

--- a/tools/generated/elements/script_element.py
+++ b/tools/generated/elements/script_element.py
@@ -147,415 +147,414 @@ class script(BaseElement):
         Initialize 'script' (Embedded script) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `async_` :
-            Execute script when available, without blocking while fetching
-        
-        `blocking` :
-            Whether the element is potentially render-blocking
-        
-        `crossorigin` :
-            How the element handles crossorigin requests
-        
-        `defer` :
-            Defer script execution
-        
-        `fetchpriority` :
-            Sets the priority for fetches initiated by the element
-        
-        `integrity` :
-            Integrity metadata used in Subresource Integrity checks [SRI]
-        
-        `nomodule` :
-            Prevents execution in user agents that support module scripts
-        
-        `referrerpolicy` :
-            Referrer policy for fetches initiated by the element  
-            Referrer policy
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `type` :
-            Type of script  
-            "module"; a valid MIME type string that is not a JavaScript MIME type essence match
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            async_:
+                Execute script when available, without blocking while fetching
+            
+            blocking:
+                Whether the element is potentially render-blocking
+            
+            crossorigin:
+                How the element handles crossorigin requests
+            
+            defer:
+                Defer script execution
+            
+            fetchpriority:
+                Sets the priority for fetches initiated by the element
+            
+            integrity:
+                Integrity metadata used in Subresource Integrity checks [SRI]
+            
+            nomodule:
+                Prevents execution in user agents that support module scripts
+            
+            referrerpolicy:
+                Referrer policy for fetches initiated by the element.  
+                Value hint: Referrer policy
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            type:
+                Type of script.  
+                Value hint: "module"; a valid MIME type string that is not a JavaScript MIME type essence match
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "script",

--- a/tools/generated/elements/search_element.py
+++ b/tools/generated/elements/search_element.py
@@ -137,382 +137,381 @@ class search(BaseElement):
         Initialize 'search' (Container for search controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "search",

--- a/tools/generated/elements/section_element.py
+++ b/tools/generated/elements/section_element.py
@@ -137,382 +137,381 @@ class section(BaseElement):
         Initialize 'section' (Generic document or application section) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "section",

--- a/tools/generated/elements/select_element.py
+++ b/tools/generated/elements/select_element.py
@@ -144,406 +144,405 @@ class select(BaseElement):
         Initialize 'select' (List box control) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `autocomplete` :
-            Hint for form autofill feature  
-            Autofill field name and related tokens*
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `multiple` :
-            Whether to allow multiple values
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `required` :
-            Whether the control is required for form submission
-        
-        `size` :
-            Size of the control  
-            Valid non-negative integer greater than zero
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            autocomplete:
+                Hint for form autofill feature.  
+                Value hint: Autofill field name and related tokens*
+            
+            disabled:
+                Whether the form control is disabled
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            multiple:
+                Whether to allow multiple values
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            required:
+                Whether the control is required for form submission
+            
+            size:
+                Size of the control.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "select",

--- a/tools/generated/elements/slot_element.py
+++ b/tools/generated/elements/slot_element.py
@@ -138,385 +138,384 @@ class slot(BaseElement):
         Initialize 'slot' (Shadow tree slot) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `name` :
-            Name of shadow tree slot
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            name:
+                Name of shadow tree slot
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "slot",

--- a/tools/generated/elements/small_element.py
+++ b/tools/generated/elements/small_element.py
@@ -137,382 +137,381 @@ class small(BaseElement):
         Initialize 'small' (Side comment) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "small",

--- a/tools/generated/elements/source_element.py
+++ b/tools/generated/elements/source_element.py
@@ -144,408 +144,407 @@ class source(BaseElement):
         Initialize 'source' (Image source for img or media source for video or audio) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `height` :
-            Vertical dimension
-        
-        `media` :
-            Applicable media  
-            Valid media query list
-        
-        `sizes` :
-            Image sizes for different page layouts  
-            Valid source size list
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `srcset` :
-            Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
-            Comma-separated list of image candidate strings
-        
-        `type` :
-            Type of embedded resource  
-            Valid MIME type string
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            height:
+                Vertical dimension
+            
+            media:
+                Applicable media.  
+                Value hint: Valid media query list
+            
+            sizes:
+                Image sizes for different page layouts.  
+                Value hint: Valid source size list
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            srcset:
+                Images to use in different situations, e.g., high-resolution displays, small monitors, etc..  
+                Value hint: Comma-separated list of image candidate strings
+            
+            type:
+                Type of embedded resource.  
+                Value hint: Valid MIME type string
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "source",

--- a/tools/generated/elements/span_element.py
+++ b/tools/generated/elements/span_element.py
@@ -137,382 +137,381 @@ class span(BaseElement):
         Initialize 'span' (Generic phrasing container) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "span",

--- a/tools/generated/elements/strong_element.py
+++ b/tools/generated/elements/strong_element.py
@@ -137,382 +137,381 @@ class strong(BaseElement):
         Initialize 'strong' (Importance) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "strong",

--- a/tools/generated/elements/style_element.py
+++ b/tools/generated/elements/style_element.py
@@ -139,389 +139,388 @@ class style(BaseElement): # type: ignore[misc]
         Initialize 'style' (Embedded styling information) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `blocking` :
-            Whether the element is potentially render-blocking
-        
-        `media` :
-            Applicable media  
-            Valid media query list
-        
-        `title` :
-            CSS style sheet set name
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            blocking:
+                Whether the element is potentially render-blocking
+            
+            media:
+                Applicable media.  
+                Value hint: Valid media query list
+            
+            title:
+                CSS style sheet set name
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "style",

--- a/tools/generated/elements/sub_element.py
+++ b/tools/generated/elements/sub_element.py
@@ -137,382 +137,381 @@ class sub(BaseElement):
         Initialize 'sub' (Subscript) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "sub",

--- a/tools/generated/elements/summary_element.py
+++ b/tools/generated/elements/summary_element.py
@@ -137,382 +137,381 @@ class summary(BaseElement):
         Initialize 'summary' (Caption for details) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "summary",

--- a/tools/generated/elements/sup_element.py
+++ b/tools/generated/elements/sup_element.py
@@ -137,382 +137,381 @@ class sup(BaseElement):
         Initialize 'sup' (Superscript) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "sup",

--- a/tools/generated/elements/svg_element.py
+++ b/tools/generated/elements/svg_element.py
@@ -137,382 +137,381 @@ class svg(BaseElement):
         Initialize 'svg' (SVG root) element.  
         Documentation: None
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "svg",

--- a/tools/generated/elements/table_element.py
+++ b/tools/generated/elements/table_element.py
@@ -137,382 +137,381 @@ class table(BaseElement):
         Initialize 'table' (Table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "table",

--- a/tools/generated/elements/tbody_element.py
+++ b/tools/generated/elements/tbody_element.py
@@ -137,382 +137,381 @@ class tbody(BaseElement):
         Initialize 'tbody' (Group of rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "tbody",

--- a/tools/generated/elements/td_element.py
+++ b/tools/generated/elements/td_element.py
@@ -140,392 +140,391 @@ class td(BaseElement):
         Initialize 'td' (Table cell) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `colspan` :
-            Number of columns that the cell is to span  
-            Valid non-negative integer greater than zero
-        
-        `headers` :
-            The header cells for this cell
-        
-        `rowspan` :
-            Number of rows that the cell is to span
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            colspan:
+                Number of columns that the cell is to span.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            headers:
+                The header cells for this cell
+            
+            rowspan:
+                Number of rows that the cell is to span
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "td",

--- a/tools/generated/elements/template_element.py
+++ b/tools/generated/elements/template_element.py
@@ -141,394 +141,393 @@ class template(BaseElement):
         Initialize 'template' (Template) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `shadowrootclonable` :
-            Sets clonable on a declarative shadow root
-        
-        `shadowrootdelegatesfocus` :
-            Sets delegates focus on a declarative shadow root
-        
-        `shadowrootmode` :
-            Enables streaming declarative shadow roots
-        
-        `shadowrootserializable` :
-            Sets serializable on a declarative shadow root
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            shadowrootclonable:
+                Sets clonable on a declarative shadow root
+            
+            shadowrootdelegatesfocus:
+                Sets delegates focus on a declarative shadow root
+            
+            shadowrootmode:
+                Enables streaming declarative shadow roots
+            
+            shadowrootserializable:
+                Sets serializable on a declarative shadow root
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "template",

--- a/tools/generated/elements/textarea_element.py
+++ b/tools/generated/elements/textarea_element.py
@@ -150,425 +150,424 @@ class textarea(BaseElement):
         Initialize 'textarea' (Multiline text controls) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `autocomplete` :
-            Hint for form autofill feature  
-            Autofill field name and related tokens*
-        
-        `cols` :
-            Maximum number of characters per line  
-            Valid non-negative integer greater than zero
-        
-        `dirname` :
-            Name of form control to use for sending the element's directionality in form submission
-        
-        `disabled` :
-            Whether the form control is disabled
-        
-        `form` :
-            Associates the element with a form element  
-            ID*
-        
-        `maxlength` :
-            Maximum length of value
-        
-        `minlength` :
-            Minimum length of value
-        
-        `name` :
-            Name of the element to use for form submission and in the form.elements API
-        
-        `placeholder` :
-            User-visible label to be placed within the form control
-        
-        `readonly` :
-            Whether to allow the value to be edited by the user
-        
-        `required` :
-            Whether the control is required for form submission
-        
-        `rows` :
-            Number of lines to show  
-            Valid non-negative integer greater than zero
-        
-        `wrap` :
-            How the value of the form control is to be wrapped for form submission
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            autocomplete:
+                Hint for form autofill feature.  
+                Value hint: Autofill field name and related tokens*
+            
+            cols:
+                Maximum number of characters per line.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            dirname:
+                Name of form control to use for sending the element's directionality in form submission
+            
+            disabled:
+                Whether the form control is disabled
+            
+            form:
+                Associates the element with a form element.  
+                Value hint: ID*
+            
+            maxlength:
+                Maximum length of value
+            
+            minlength:
+                Minimum length of value
+            
+            name:
+                Name of the element to use for form submission and in the form.elements API
+            
+            placeholder:
+                User-visible label to be placed within the form control
+            
+            readonly:
+                Whether to allow the value to be edited by the user
+            
+            required:
+                Whether the control is required for form submission
+            
+            rows:
+                Number of lines to show.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            wrap:
+                How the value of the form control is to be wrapped for form submission
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "textarea",

--- a/tools/generated/elements/tfoot_element.py
+++ b/tools/generated/elements/tfoot_element.py
@@ -137,382 +137,381 @@ class tfoot(BaseElement):
         Initialize 'tfoot' (Group of footer rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "tfoot",

--- a/tools/generated/elements/th_element.py
+++ b/tools/generated/elements/th_element.py
@@ -142,398 +142,397 @@ class th(BaseElement):
         Initialize 'th' (Table header cell) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `abbr` :
-            Alternative label to use for the header cell when referencing the cell in other contexts
-        
-        `colspan` :
-            Number of columns that the cell is to span  
-            Valid non-negative integer greater than zero
-        
-        `headers` :
-            The header cells for this cell
-        
-        `rowspan` :
-            Number of rows that the cell is to span
-        
-        `scope` :
-            Specifies which cells the header cell applies to
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            abbr:
+                Alternative label to use for the header cell when referencing the cell in other contexts
+            
+            colspan:
+                Number of columns that the cell is to span.  
+                Value hint: Valid non-negative integer greater than zero
+            
+            headers:
+                The header cells for this cell
+            
+            rowspan:
+                Number of rows that the cell is to span
+            
+            scope:
+                Specifies which cells the header cell applies to
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "th",

--- a/tools/generated/elements/thead_element.py
+++ b/tools/generated/elements/thead_element.py
@@ -137,382 +137,381 @@ class thead(BaseElement):
         Initialize 'thead' (Group of heading rows in a table) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "thead",

--- a/tools/generated/elements/time_element.py
+++ b/tools/generated/elements/time_element.py
@@ -138,386 +138,385 @@ class time(BaseElement):
         Initialize 'time' (Machine-readable equivalent of date- or time-related data) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `datetime` :
-            Machine-readable value  
-            Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            datetime:
+                Machine-readable value.  
+                Value hint: Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "time",

--- a/tools/generated/elements/title_element.py
+++ b/tools/generated/elements/title_element.py
@@ -137,382 +137,381 @@ class title(BaseElement):
         Initialize 'title' (Document title) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "title",

--- a/tools/generated/elements/tr_element.py
+++ b/tools/generated/elements/tr_element.py
@@ -137,382 +137,381 @@ class tr(BaseElement):
         Initialize 'tr' (Table row) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "tr",

--- a/tools/generated/elements/track_element.py
+++ b/tools/generated/elements/track_element.py
@@ -142,399 +142,398 @@ class track(BaseElement):
         Initialize 'track' (Timed text track) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `default` :
-            Enable the track if no other text track is more suitable
-        
-        `kind` :
-            The type of text track
-        
-        `label` :
-            User-visible label
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `srclang` :
-            Language of the text track  
-            Valid BCP 47 language tag
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            default:
+                Enable the track if no other text track is more suitable
+            
+            kind:
+                The type of text track
+            
+            label:
+                User-visible label
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            srclang:
+                Language of the text track.  
+                Value hint: Valid BCP 47 language tag
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "track",

--- a/tools/generated/elements/u_element.py
+++ b/tools/generated/elements/u_element.py
@@ -137,382 +137,381 @@ class u(BaseElement):
         Initialize 'u' (Unarticulated annotation) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "u",

--- a/tools/generated/elements/ul_element.py
+++ b/tools/generated/elements/ul_element.py
@@ -137,382 +137,381 @@ class ul(BaseElement):
         Initialize 'ul' (List) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "ul",

--- a/tools/generated/elements/var_element.py
+++ b/tools/generated/elements/var_element.py
@@ -137,382 +137,381 @@ class var(BaseElement):
         Initialize 'var' (Variable) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "var",

--- a/tools/generated/elements/video_element.py
+++ b/tools/generated/elements/video_element.py
@@ -148,417 +148,416 @@ class video(BaseElement):
         Initialize 'video' (Video player) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `autoplay` :
-            Hint that the media resource can be started automatically when the page is loaded
-        
-        `controls` :
-            Show user agent controls
-        
-        `crossorigin` :
-            How the element handles crossorigin requests
-        
-        `height` :
-            Vertical dimension
-        
-        `loop` :
-            Whether to loop the media resource
-        
-        `muted` :
-            Whether to mute the media resource by default
-        
-        `playsinline` :
-            Encourage the user agent to display video content within the element's playback area
-        
-        `poster` :
-            Poster frame to show prior to video playback  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `preload` :
-            Hints how much buffering the media resource will likely need
-        
-        `src` :
-            Address of the resource  
-            Valid non-empty URL potentially surrounded by spaces
-        
-        `width` :
-            Horizontal dimension
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            autoplay:
+                Hint that the media resource can be started automatically when the page is loaded
+            
+            controls:
+                Show user agent controls
+            
+            crossorigin:
+                How the element handles crossorigin requests
+            
+            height:
+                Vertical dimension
+            
+            loop:
+                Whether to loop the media resource
+            
+            muted:
+                Whether to mute the media resource by default
+            
+            playsinline:
+                Encourage the user agent to display video content within the element's playback area
+            
+            poster:
+                Poster frame to show prior to video playback.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            preload:
+                Hints how much buffering the media resource will likely need
+            
+            src:
+                Address of the resource.  
+                Value hint: Valid non-empty URL potentially surrounded by spaces
+            
+            width:
+                Horizontal dimension
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "video",

--- a/tools/generated/elements/wbr_element.py
+++ b/tools/generated/elements/wbr_element.py
@@ -137,382 +137,381 @@ class wbr(BaseElement):
         Initialize 'wbr' (Line breaking opportunity) element.  
         Documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
 
-        Parameters
-        ----------
-        `attrs`: 
-            A list or dictionary of attributes for the element
-        
-        `id` :
-            The element's ID
-        
-        `class_` :
-            Classes to which the element belongs
-        
-        `accesskey` :
-            Keyboard shortcut to activate or focus element
-        
-        `autocapitalize` :
-            Recommended autocapitalization behavior (for supported input methods)
-        
-        `autocorrect` :
-            Recommended autocorrection behavior (for supported input methods)
-        
-        `autofocus` :
-            Automatically focus the element when the page is loaded
-        
-        `contenteditable` :
-            Whether the element is editable
-        
-        `dir` :
-            The text directionality of the element
-        
-        `draggable` :
-            Whether the element is draggable
-        
-        `enterkeyhint` :
-            Hint for selecting an enter key action
-        
-        `hidden` :
-            Whether the element is relevant
-        
-        `inert` :
-            Whether the element is inert.
-        
-        `inputmode` :
-            Hint for selecting an input modality
-        
-        `is_` :
-            Creates a customized built-in element  
-            Valid custom element name of a defined customized built-in element
-        
-        `itemid` :
-            Global identifier for a microdata item  
-            Valid URL potentially surrounded by spaces
-        
-        `itemprop` :
-            Property names of a microdata item
-        
-        `itemref` :
-            Referenced elements
-        
-        `itemscope` :
-            Introduces a microdata item
-        
-        `itemtype` :
-            Item types of a microdata item
-        
-        `lang` :
-            Language of the element  
-            Valid BCP 47 language tag or the empty string
-        
-        `nonce` :
-            Cryptographic nonce used in Content Security Policy checks [CSP]
-        
-        `onauxclick` :
-            auxclick event handler  
-            Event handler content attribute
-        
-        `onbeforeinput` :
-            beforeinput event handler  
-            Event handler content attribute
-        
-        `onbeforematch` :
-            beforematch event handler  
-            Event handler content attribute
-        
-        `onbeforetoggle` :
-            beforetoggle event handler  
-            Event handler content attribute
-        
-        `onblur` :
-            blur event handler  
-            Event handler content attribute
-        
-        `oncancel` :
-            cancel event handler  
-            Event handler content attribute
-        
-        `oncanplay` :
-            canplay event handler  
-            Event handler content attribute
-        
-        `oncanplaythrough` :
-            canplaythrough event handler  
-            Event handler content attribute
-        
-        `onchange` :
-            change event handler  
-            Event handler content attribute
-        
-        `onclick` :
-            click event handler  
-            Event handler content attribute
-        
-        `onclose` :
-            close event handler  
-            Event handler content attribute
-        
-        `oncontextlost` :
-            contextlost event handler  
-            Event handler content attribute
-        
-        `oncontextmenu` :
-            contextmenu event handler  
-            Event handler content attribute
-        
-        `oncontextrestored` :
-            contextrestored event handler  
-            Event handler content attribute
-        
-        `oncopy` :
-            copy event handler  
-            Event handler content attribute
-        
-        `oncuechange` :
-            cuechange event handler  
-            Event handler content attribute
-        
-        `oncut` :
-            cut event handler  
-            Event handler content attribute
-        
-        `ondblclick` :
-            dblclick event handler  
-            Event handler content attribute
-        
-        `ondrag` :
-            drag event handler  
-            Event handler content attribute
-        
-        `ondragend` :
-            dragend event handler  
-            Event handler content attribute
-        
-        `ondragenter` :
-            dragenter event handler  
-            Event handler content attribute
-        
-        `ondragleave` :
-            dragleave event handler  
-            Event handler content attribute
-        
-        `ondragover` :
-            dragover event handler  
-            Event handler content attribute
-        
-        `ondragstart` :
-            dragstart event handler  
-            Event handler content attribute
-        
-        `ondrop` :
-            drop event handler  
-            Event handler content attribute
-        
-        `ondurationchange` :
-            durationchange event handler  
-            Event handler content attribute
-        
-        `onemptied` :
-            emptied event handler  
-            Event handler content attribute
-        
-        `onended` :
-            ended event handler  
-            Event handler content attribute
-        
-        `onerror` :
-            error event handler  
-            Event handler content attribute
-        
-        `onfocus` :
-            focus event handler  
-            Event handler content attribute
-        
-        `onformdata` :
-            formdata event handler  
-            Event handler content attribute
-        
-        `oninput` :
-            input event handler  
-            Event handler content attribute
-        
-        `oninvalid` :
-            invalid event handler  
-            Event handler content attribute
-        
-        `onkeydown` :
-            keydown event handler  
-            Event handler content attribute
-        
-        `onkeypress` :
-            keypress event handler  
-            Event handler content attribute
-        
-        `onkeyup` :
-            keyup event handler  
-            Event handler content attribute
-        
-        `onload` :
-            load event handler  
-            Event handler content attribute
-        
-        `onloadeddata` :
-            loadeddata event handler  
-            Event handler content attribute
-        
-        `onloadedmetadata` :
-            loadedmetadata event handler  
-            Event handler content attribute
-        
-        `onloadstart` :
-            loadstart event handler  
-            Event handler content attribute
-        
-        `onmousedown` :
-            mousedown event handler  
-            Event handler content attribute
-        
-        `onmouseenter` :
-            mouseenter event handler  
-            Event handler content attribute
-        
-        `onmouseleave` :
-            mouseleave event handler  
-            Event handler content attribute
-        
-        `onmousemove` :
-            mousemove event handler  
-            Event handler content attribute
-        
-        `onmouseout` :
-            mouseout event handler  
-            Event handler content attribute
-        
-        `onmouseover` :
-            mouseover event handler  
-            Event handler content attribute
-        
-        `onmouseup` :
-            mouseup event handler  
-            Event handler content attribute
-        
-        `onpaste` :
-            paste event handler  
-            Event handler content attribute
-        
-        `onpause` :
-            pause event handler  
-            Event handler content attribute
-        
-        `onplay` :
-            play event handler  
-            Event handler content attribute
-        
-        `onplaying` :
-            playing event handler  
-            Event handler content attribute
-        
-        `onprogress` :
-            progress event handler  
-            Event handler content attribute
-        
-        `onratechange` :
-            ratechange event handler  
-            Event handler content attribute
-        
-        `onreset` :
-            reset event handler  
-            Event handler content attribute
-        
-        `onresize` :
-            resize event handler  
-            Event handler content attribute
-        
-        `onscroll` :
-            scroll event handler  
-            Event handler content attribute
-        
-        `onscrollend` :
-            scrollend event handler  
-            Event handler content attribute
-        
-        `onsecuritypolicyviolation` :
-            securitypolicyviolation event handler  
-            Event handler content attribute
-        
-        `onseeked` :
-            seeked event handler  
-            Event handler content attribute
-        
-        `onseeking` :
-            seeking event handler  
-            Event handler content attribute
-        
-        `onselect` :
-            select event handler  
-            Event handler content attribute
-        
-        `onslotchange` :
-            slotchange event handler  
-            Event handler content attribute
-        
-        `onstalled` :
-            stalled event handler  
-            Event handler content attribute
-        
-        `onsubmit` :
-            submit event handler  
-            Event handler content attribute
-        
-        `onsuspend` :
-            suspend event handler  
-            Event handler content attribute
-        
-        `ontimeupdate` :
-            timeupdate event handler  
-            Event handler content attribute
-        
-        `ontoggle` :
-            toggle event handler  
-            Event handler content attribute
-        
-        `onvolumechange` :
-            volumechange event handler  
-            Event handler content attribute
-        
-        `onwaiting` :
-            waiting event handler  
-            Event handler content attribute
-        
-        `onwheel` :
-            wheel event handler  
-            Event handler content attribute
-        
-        `popover` :
-            Makes the element a popover element
-        
-        `slot` :
-            The element's desired slot
-        
-        `spellcheck` :
-            Whether the element is to have its spelling and grammar checked
-        
-        `style` :
-            Presentational and formatting instructions  
-            CSS declarations*
-        
-        `tabindex` :
-            Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
-        
-        `title` :
-            Advisory information for the element
-        
-        `translate` :
-            Whether the element is to be translated when the page is localized
-        
-        `writingsuggestions` :
-            Whether the element can offer writing suggestions or not.
-        
+        Args:
+            attrs: 
+                A list or dictionary of attributes for the element
+            
+            id:
+                The element's ID
+            
+            class_:
+                Classes to which the element belongs
+            
+            accesskey:
+                Keyboard shortcut to activate or focus element
+            
+            autocapitalize:
+                Recommended autocapitalization behavior (for supported input methods)
+            
+            autocorrect:
+                Recommended autocorrection behavior (for supported input methods)
+            
+            autofocus:
+                Automatically focus the element when the page is loaded
+            
+            contenteditable:
+                Whether the element is editable
+            
+            dir:
+                The text directionality of the element
+            
+            draggable:
+                Whether the element is draggable
+            
+            enterkeyhint:
+                Hint for selecting an enter key action
+            
+            hidden:
+                Whether the element is relevant
+            
+            inert:
+                Whether the element is inert.
+            
+            inputmode:
+                Hint for selecting an input modality
+            
+            is_:
+                Creates a customized built-in element.  
+                Value hint: Valid custom element name of a defined customized built-in element
+            
+            itemid:
+                Global identifier for a microdata item.  
+                Value hint: Valid URL potentially surrounded by spaces
+            
+            itemprop:
+                Property names of a microdata item
+            
+            itemref:
+                Referenced elements
+            
+            itemscope:
+                Introduces a microdata item
+            
+            itemtype:
+                Item types of a microdata item
+            
+            lang:
+                Language of the element.  
+                Value hint: Valid BCP 47 language tag or the empty string
+            
+            nonce:
+                Cryptographic nonce used in Content Security Policy checks [CSP]
+            
+            onauxclick:
+                auxclick event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforeinput:
+                beforeinput event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforematch:
+                beforematch event handler.  
+                Value hint: Event handler content attribute
+            
+            onbeforetoggle:
+                beforetoggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onblur:
+                blur event handler.  
+                Value hint: Event handler content attribute
+            
+            oncancel:
+                cancel event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplay:
+                canplay event handler.  
+                Value hint: Event handler content attribute
+            
+            oncanplaythrough:
+                canplaythrough event handler.  
+                Value hint: Event handler content attribute
+            
+            onchange:
+                change event handler.  
+                Value hint: Event handler content attribute
+            
+            onclick:
+                click event handler.  
+                Value hint: Event handler content attribute
+            
+            onclose:
+                close event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextlost:
+                contextlost event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextmenu:
+                contextmenu event handler.  
+                Value hint: Event handler content attribute
+            
+            oncontextrestored:
+                contextrestored event handler.  
+                Value hint: Event handler content attribute
+            
+            oncopy:
+                copy event handler.  
+                Value hint: Event handler content attribute
+            
+            oncuechange:
+                cuechange event handler.  
+                Value hint: Event handler content attribute
+            
+            oncut:
+                cut event handler.  
+                Value hint: Event handler content attribute
+            
+            ondblclick:
+                dblclick event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrag:
+                drag event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragend:
+                dragend event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragenter:
+                dragenter event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragleave:
+                dragleave event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragover:
+                dragover event handler.  
+                Value hint: Event handler content attribute
+            
+            ondragstart:
+                dragstart event handler.  
+                Value hint: Event handler content attribute
+            
+            ondrop:
+                drop event handler.  
+                Value hint: Event handler content attribute
+            
+            ondurationchange:
+                durationchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onemptied:
+                emptied event handler.  
+                Value hint: Event handler content attribute
+            
+            onended:
+                ended event handler.  
+                Value hint: Event handler content attribute
+            
+            onerror:
+                error event handler.  
+                Value hint: Event handler content attribute
+            
+            onfocus:
+                focus event handler.  
+                Value hint: Event handler content attribute
+            
+            onformdata:
+                formdata event handler.  
+                Value hint: Event handler content attribute
+            
+            oninput:
+                input event handler.  
+                Value hint: Event handler content attribute
+            
+            oninvalid:
+                invalid event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeydown:
+                keydown event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeypress:
+                keypress event handler.  
+                Value hint: Event handler content attribute
+            
+            onkeyup:
+                keyup event handler.  
+                Value hint: Event handler content attribute
+            
+            onload:
+                load event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadeddata:
+                loadeddata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadedmetadata:
+                loadedmetadata event handler.  
+                Value hint: Event handler content attribute
+            
+            onloadstart:
+                loadstart event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousedown:
+                mousedown event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseenter:
+                mouseenter event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseleave:
+                mouseleave event handler.  
+                Value hint: Event handler content attribute
+            
+            onmousemove:
+                mousemove event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseout:
+                mouseout event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseover:
+                mouseover event handler.  
+                Value hint: Event handler content attribute
+            
+            onmouseup:
+                mouseup event handler.  
+                Value hint: Event handler content attribute
+            
+            onpaste:
+                paste event handler.  
+                Value hint: Event handler content attribute
+            
+            onpause:
+                pause event handler.  
+                Value hint: Event handler content attribute
+            
+            onplay:
+                play event handler.  
+                Value hint: Event handler content attribute
+            
+            onplaying:
+                playing event handler.  
+                Value hint: Event handler content attribute
+            
+            onprogress:
+                progress event handler.  
+                Value hint: Event handler content attribute
+            
+            onratechange:
+                ratechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onreset:
+                reset event handler.  
+                Value hint: Event handler content attribute
+            
+            onresize:
+                resize event handler.  
+                Value hint: Event handler content attribute
+            
+            onscroll:
+                scroll event handler.  
+                Value hint: Event handler content attribute
+            
+            onscrollend:
+                scrollend event handler.  
+                Value hint: Event handler content attribute
+            
+            onsecuritypolicyviolation:
+                securitypolicyviolation event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeked:
+                seeked event handler.  
+                Value hint: Event handler content attribute
+            
+            onseeking:
+                seeking event handler.  
+                Value hint: Event handler content attribute
+            
+            onselect:
+                select event handler.  
+                Value hint: Event handler content attribute
+            
+            onslotchange:
+                slotchange event handler.  
+                Value hint: Event handler content attribute
+            
+            onstalled:
+                stalled event handler.  
+                Value hint: Event handler content attribute
+            
+            onsubmit:
+                submit event handler.  
+                Value hint: Event handler content attribute
+            
+            onsuspend:
+                suspend event handler.  
+                Value hint: Event handler content attribute
+            
+            ontimeupdate:
+                timeupdate event handler.  
+                Value hint: Event handler content attribute
+            
+            ontoggle:
+                toggle event handler.  
+                Value hint: Event handler content attribute
+            
+            onvolumechange:
+                volumechange event handler.  
+                Value hint: Event handler content attribute
+            
+            onwaiting:
+                waiting event handler.  
+                Value hint: Event handler content attribute
+            
+            onwheel:
+                wheel event handler.  
+                Value hint: Event handler content attribute
+            
+            popover:
+                Makes the element a popover element
+            
+            slot:
+                The element's desired slot
+            
+            spellcheck:
+                Whether the element is to have its spelling and grammar checked
+            
+            style:
+                Presentational and formatting instructions.  
+                Value hint: CSS declarations*
+            
+            tabindex:
+                Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation
+            
+            title:
+                Advisory information for the element
+            
+            translate:
+                Whether the element is to be translated when the page is localized
+            
+            writingsuggestions:
+                Whether the element can offer writing suggestions or not.
+            
         """ #fmt: skip
         super().__init__(
             "wbr",

--- a/tools/generated/embed_attrs.py
+++ b/tools/generated/embed_attrs.py
@@ -14,9 +14,14 @@ class EmbedAttrs:
         "embed" attribute: height  
         Vertical dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An height attribute to be added to your element
+
+        """
         
         return BaseAttribute("height", value)
             
@@ -28,9 +33,14 @@ class EmbedAttrs:
         "embed" attribute: src  
         Address of the resource  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An src attribute to be added to your element
+
+        """
         
         return BaseAttribute("src", value)
             
@@ -42,9 +52,14 @@ class EmbedAttrs:
         "embed" attribute: type  
         Type of embedded resource  
 
-        :param value: Valid MIME type string  
-        :return: An type attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid MIME type string
+        
+        Returns:
+            An type attribute to be added to your element
+
+        """
         
         return BaseAttribute("type", value)
             
@@ -56,9 +71,14 @@ class EmbedAttrs:
         "embed" attribute: width  
         Horizontal dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An width attribute to be added to your element
+
+        """
         
         return BaseAttribute("width", value)
             

--- a/tools/generated/fieldset_attrs.py
+++ b/tools/generated/fieldset_attrs.py
@@ -14,9 +14,14 @@ class FieldsetAttrs:
         "fieldset" attribute: disabled  
         Whether the descendant form controls, except any inside legend, are disabled  
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
         
         return BaseAttribute("disabled", value)
             
@@ -28,9 +33,14 @@ class FieldsetAttrs:
         "fieldset" attribute: form  
         Associates the element with a form element  
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An form attribute to be added to your element
+
+        """
         
         return BaseAttribute("form", value)
             
@@ -42,9 +52,14 @@ class FieldsetAttrs:
         "fieldset" attribute: name  
         Name of the element to use for form submission and in the form.elements API  
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             

--- a/tools/generated/form_attrs.py
+++ b/tools/generated/form_attrs.py
@@ -14,9 +14,14 @@ class FormAttrs:
         "form" attribute: accept-charset  
         Character encodings to use for form submission  
 
-        :param value: ASCII case-insensitive match for "UTF-8"  
-        :return: An accept-charset attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ASCII case-insensitive match for "UTF-8"
+        
+        Returns:
+            An accept-charset attribute to be added to your element
+
+        """
         
         return BaseAttribute("accept-charset", value)
             
@@ -28,9 +33,14 @@ class FormAttrs:
         "form" attribute: action  
         URL to use for form submission  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An action attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An action attribute to be added to your element
+
+        """
         
         return BaseAttribute("action", value)
             
@@ -42,9 +52,14 @@ class FormAttrs:
         "form" attribute: autocomplete  
         Default setting for autofill feature for controls in the form  
 
-        :param value: ['on', 'off']  
-        :return: An autocomplete attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['on', 'off']
+        
+        Returns:
+            An autocomplete attribute to be added to your element
+
+        """
         
         return BaseAttribute("autocomplete", value)
             
@@ -56,9 +71,14 @@ class FormAttrs:
         "form" attribute: enctype  
         Entry list encoding type to use for form submission  
 
-        :param value: ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']  
-        :return: An enctype attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']
+        
+        Returns:
+            An enctype attribute to be added to your element
+
+        """
         
         return BaseAttribute("enctype", value)
             
@@ -70,9 +90,14 @@ class FormAttrs:
         "form" attribute: method  
         Variant to use for form submission  
 
-        :param value: ['GET', 'POST', 'dialog']  
-        :return: An method attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['GET', 'POST', 'dialog']
+        
+        Returns:
+            An method attribute to be added to your element
+
+        """
         
         return BaseAttribute("method", value)
             
@@ -84,9 +109,14 @@ class FormAttrs:
         "form" attribute: name  
         Name of form to use in the document.forms API  
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             
@@ -98,9 +128,14 @@ class FormAttrs:
         "form" attribute: novalidate  
         Bypass form control validation for form submission  
 
-        :param value: Boolean attribute  
-        :return: An novalidate attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An novalidate attribute to be added to your element
+
+        """
         
         return BaseAttribute("novalidate", value)
             
@@ -112,9 +147,14 @@ class FormAttrs:
         "form" attribute: target  
         Navigable for form submission  
 
-        :param value: Valid navigable target name or keyword  
-        :return: An target attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+        
+        Returns:
+            An target attribute to be added to your element
+
+        """
         
         return BaseAttribute("target", value)
             

--- a/tools/generated/global_attrs.py
+++ b/tools/generated/global_attrs.py
@@ -14,9 +14,14 @@ class GlobalAttrs:
         "global" attribute: accesskey  
         Keyboard shortcut to activate or focus element  
 
-        :param value: Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length  
-        :return: An accesskey attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Ordered set of unique space-separated tokens, none of which are identical to another, each consisting of one code point in length
+        
+        Returns:
+            An accesskey attribute to be added to your element
+
+        """
         
         return BaseAttribute("accesskey", value)
             
@@ -28,9 +33,14 @@ class GlobalAttrs:
         "global" attribute: autocapitalize  
         Recommended autocapitalization behavior (for supported input methods)  
 
-        :param value: ['on', 'off', 'none', 'sentences', 'words', 'characters']  
-        :return: An autocapitalize attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['on', 'off', 'none', 'sentences', 'words', 'characters']
+        
+        Returns:
+            An autocapitalize attribute to be added to your element
+
+        """
         
         return BaseAttribute("autocapitalize", value)
             
@@ -42,9 +52,14 @@ class GlobalAttrs:
         "global" attribute: autocorrect  
         Recommended autocorrection behavior (for supported input methods)  
 
-        :param value: ['on', 'off']  
-        :return: An autocorrect attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['on', 'off']
+        
+        Returns:
+            An autocorrect attribute to be added to your element
+
+        """
         
         return BaseAttribute("autocorrect", value)
             
@@ -56,9 +71,14 @@ class GlobalAttrs:
         "global" attribute: autofocus  
         Automatically focus the element when the page is loaded  
 
-        :param value: Boolean attribute  
-        :return: An autofocus attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An autofocus attribute to be added to your element
+
+        """
         
         return BaseAttribute("autofocus", value)
             
@@ -70,9 +90,14 @@ class GlobalAttrs:
         "global" attribute: class  
         Classes to which the element belongs  
 
-        :param value: Set of space-separated tokens  
-        :return: An class attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Set of space-separated tokens
+        
+        Returns:
+            An class attribute to be added to your element
+
+        """
         
         return BaseAttribute("class", value)
             
@@ -84,9 +109,14 @@ class GlobalAttrs:
         "global" attribute: contenteditable  
         Whether the element is editable  
 
-        :param value: ['true', 'plaintext-only', 'false']  
-        :return: An contenteditable attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['true', 'plaintext-only', 'false']
+        
+        Returns:
+            An contenteditable attribute to be added to your element
+
+        """
         
         return BaseAttribute("contenteditable", value)
             
@@ -98,9 +128,14 @@ class GlobalAttrs:
         "global" attribute: dir  
         The text directionality of the element  
 
-        :param value: ['ltr', 'rtl', 'auto']  
-        :return: An dir attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['ltr', 'rtl', 'auto']
+        
+        Returns:
+            An dir attribute to be added to your element
+
+        """
         
         return BaseAttribute("dir", value)
             
@@ -112,9 +147,14 @@ class GlobalAttrs:
         "global" attribute: draggable  
         Whether the element is draggable  
 
-        :param value: ['true', 'false']  
-        :return: An draggable attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['true', 'false']
+        
+        Returns:
+            An draggable attribute to be added to your element
+
+        """
         
         return BaseAttribute("draggable", value)
             
@@ -126,9 +166,14 @@ class GlobalAttrs:
         "global" attribute: enterkeyhint  
         Hint for selecting an enter key action  
 
-        :param value: ['enter', 'done', 'go', 'next', 'previous', 'search', 'send']  
-        :return: An enterkeyhint attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['enter', 'done', 'go', 'next', 'previous', 'search', 'send']
+        
+        Returns:
+            An enterkeyhint attribute to be added to your element
+
+        """
         
         return BaseAttribute("enterkeyhint", value)
             
@@ -140,9 +185,14 @@ class GlobalAttrs:
         "global" attribute: hidden  
         Whether the element is relevant  
 
-        :param value: ['until-found', 'hidden', '']  
-        :return: An hidden attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['until-found', 'hidden', '']
+        
+        Returns:
+            An hidden attribute to be added to your element
+
+        """
         
         return BaseAttribute("hidden", value)
             
@@ -154,9 +204,14 @@ class GlobalAttrs:
         "global" attribute: id  
         The element's ID  
 
-        :param value: Text*  
-        :return: An id attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An id attribute to be added to your element
+
+        """
         
         return BaseAttribute("id", value)
             
@@ -168,9 +223,14 @@ class GlobalAttrs:
         "global" attribute: inert  
         Whether the element is inert.  
 
-        :param value: Boolean attribute  
-        :return: An inert attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An inert attribute to be added to your element
+
+        """
         
         return BaseAttribute("inert", value)
             
@@ -182,9 +242,14 @@ class GlobalAttrs:
         "global" attribute: inputmode  
         Hint for selecting an input modality  
 
-        :param value: ['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']  
-        :return: An inputmode attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['none', 'text', 'tel', 'email', 'url', 'numeric', 'decimal', 'search']
+        
+        Returns:
+            An inputmode attribute to be added to your element
+
+        """
         
         return BaseAttribute("inputmode", value)
             
@@ -196,9 +261,14 @@ class GlobalAttrs:
         "global" attribute: is  
         Creates a customized built-in element  
 
-        :param value: Valid custom element name of a defined customized built-in element  
-        :return: An is attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid custom element name of a defined customized built-in element
+        
+        Returns:
+            An is attribute to be added to your element
+
+        """
         
         return BaseAttribute("is", value)
             
@@ -210,9 +280,14 @@ class GlobalAttrs:
         "global" attribute: itemid  
         Global identifier for a microdata item  
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An itemid attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+        
+        Returns:
+            An itemid attribute to be added to your element
+
+        """
         
         return BaseAttribute("itemid", value)
             
@@ -224,9 +299,14 @@ class GlobalAttrs:
         "global" attribute: itemprop  
         Property names of a microdata item  
 
-        :param value: Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*  
-        :return: An itemprop attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of valid absolute URLs, defined property names, or text*
+        
+        Returns:
+            An itemprop attribute to be added to your element
+
+        """
         
         return BaseAttribute("itemprop", value)
             
@@ -238,9 +318,14 @@ class GlobalAttrs:
         "global" attribute: itemref  
         Referenced elements  
 
-        :param value: Unordered set of unique space-separated tokens consisting of IDs*  
-        :return: An itemref attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of IDs*
+        
+        Returns:
+            An itemref attribute to be added to your element
+
+        """
         
         return BaseAttribute("itemref", value)
             
@@ -252,9 +337,14 @@ class GlobalAttrs:
         "global" attribute: itemscope  
         Introduces a microdata item  
 
-        :param value: Boolean attribute  
-        :return: An itemscope attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An itemscope attribute to be added to your element
+
+        """
         
         return BaseAttribute("itemscope", value)
             
@@ -266,9 +356,14 @@ class GlobalAttrs:
         "global" attribute: itemtype  
         Item types of a microdata item  
 
-        :param value: Unordered set of unique space-separated tokens consisting of valid absolute URLs*  
-        :return: An itemtype attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of valid absolute URLs*
+        
+        Returns:
+            An itemtype attribute to be added to your element
+
+        """
         
         return BaseAttribute("itemtype", value)
             
@@ -280,9 +375,14 @@ class GlobalAttrs:
         "global" attribute: lang  
         Language of the element  
 
-        :param value: Valid BCP 47 language tag or the empty string  
-        :return: An lang attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid BCP 47 language tag or the empty string
+        
+        Returns:
+            An lang attribute to be added to your element
+
+        """
         
         return BaseAttribute("lang", value)
             
@@ -294,9 +394,14 @@ class GlobalAttrs:
         "global" attribute: nonce  
         Cryptographic nonce used in Content Security Policy checks [CSP]  
 
-        :param value: Text  
-        :return: An nonce attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An nonce attribute to be added to your element
+
+        """
         
         return BaseAttribute("nonce", value)
             
@@ -308,9 +413,14 @@ class GlobalAttrs:
         "global" attribute: popover  
         Makes the element a popover element  
 
-        :param value: ['auto', 'manual']  
-        :return: An popover attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['auto', 'manual']
+        
+        Returns:
+            An popover attribute to be added to your element
+
+        """
         
         return BaseAttribute("popover", value)
             
@@ -322,9 +432,14 @@ class GlobalAttrs:
         "global" attribute: slot  
         The element's desired slot  
 
-        :param value: Text  
-        :return: An slot attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An slot attribute to be added to your element
+
+        """
         
         return BaseAttribute("slot", value)
             
@@ -336,9 +451,14 @@ class GlobalAttrs:
         "global" attribute: spellcheck  
         Whether the element is to have its spelling and grammar checked  
 
-        :param value: ['true', 'false', '']  
-        :return: An spellcheck attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['true', 'false', '']
+        
+        Returns:
+            An spellcheck attribute to be added to your element
+
+        """
         
         return BaseAttribute("spellcheck", value)
             
@@ -350,9 +470,14 @@ class GlobalAttrs:
         "global" attribute: style  
         Presentational and formatting instructions  
 
-        :param value: CSS declarations*  
-        :return: An style attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                CSS declarations*
+        
+        Returns:
+            An style attribute to be added to your element
+
+        """
         
         return BaseAttribute("style", value, delimiter='; ')
             
@@ -364,9 +489,14 @@ class GlobalAttrs:
         "global" attribute: tabindex  
         Whether the element is focusable and sequentially focusable, and the relative order of the element for the purposes of sequential focus navigation  
 
-        :param value: Valid integer  
-        :return: An tabindex attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid integer
+        
+        Returns:
+            An tabindex attribute to be added to your element
+
+        """
         
         return BaseAttribute("tabindex", value)
             
@@ -378,9 +508,14 @@ class GlobalAttrs:
         "global" attribute: title  
         Advisory information for the element  
 
-        :param value: Text  
-        :return: An title attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An title attribute to be added to your element
+
+        """
         
         return BaseAttribute("title", value)
             
@@ -392,9 +527,14 @@ class GlobalAttrs:
         "global" attribute: translate  
         Whether the element is to be translated when the page is localized  
 
-        :param value: ['yes', 'no']  
-        :return: An translate attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['yes', 'no']
+        
+        Returns:
+            An translate attribute to be added to your element
+
+        """
         
         return BaseAttribute("translate", value)
             
@@ -406,9 +546,14 @@ class GlobalAttrs:
         "global" attribute: writingsuggestions  
         Whether the element can offer writing suggestions or not.  
 
-        :param value: ['true', 'false', '']  
-        :return: An writingsuggestions attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['true', 'false', '']
+        
+        Returns:
+            An writingsuggestions attribute to be added to your element
+
+        """
         
         return BaseAttribute("writingsuggestions", value)
             
@@ -420,9 +565,14 @@ class GlobalAttrs:
         "global" attribute: onauxclick  
         auxclick event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onauxclick attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onauxclick attribute to be added to your element
+
+        """
         
         return BaseAttribute("onauxclick", value)
             
@@ -434,9 +584,14 @@ class GlobalAttrs:
         "global" attribute: onbeforeinput  
         beforeinput event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onbeforeinput attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onbeforeinput attribute to be added to your element
+
+        """
         
         return BaseAttribute("onbeforeinput", value)
             
@@ -448,9 +603,14 @@ class GlobalAttrs:
         "global" attribute: onbeforematch  
         beforematch event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onbeforematch attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onbeforematch attribute to be added to your element
+
+        """
         
         return BaseAttribute("onbeforematch", value)
             
@@ -462,9 +622,14 @@ class GlobalAttrs:
         "global" attribute: onbeforetoggle  
         beforetoggle event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onbeforetoggle attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onbeforetoggle attribute to be added to your element
+
+        """
         
         return BaseAttribute("onbeforetoggle", value)
             
@@ -476,9 +641,14 @@ class GlobalAttrs:
         "global" attribute: onblur  
         blur event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onblur attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onblur attribute to be added to your element
+
+        """
         
         return BaseAttribute("onblur", value)
             
@@ -490,9 +660,14 @@ class GlobalAttrs:
         "global" attribute: oncancel  
         cancel event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oncancel attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oncancel attribute to be added to your element
+
+        """
         
         return BaseAttribute("oncancel", value)
             
@@ -504,9 +679,14 @@ class GlobalAttrs:
         "global" attribute: oncanplay  
         canplay event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oncanplay attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oncanplay attribute to be added to your element
+
+        """
         
         return BaseAttribute("oncanplay", value)
             
@@ -518,9 +698,14 @@ class GlobalAttrs:
         "global" attribute: oncanplaythrough  
         canplaythrough event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oncanplaythrough attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oncanplaythrough attribute to be added to your element
+
+        """
         
         return BaseAttribute("oncanplaythrough", value)
             
@@ -532,9 +717,14 @@ class GlobalAttrs:
         "global" attribute: onchange  
         change event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onchange attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onchange attribute to be added to your element
+
+        """
         
         return BaseAttribute("onchange", value)
             
@@ -546,9 +736,14 @@ class GlobalAttrs:
         "global" attribute: onclick  
         click event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onclick attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onclick attribute to be added to your element
+
+        """
         
         return BaseAttribute("onclick", value)
             
@@ -560,9 +755,14 @@ class GlobalAttrs:
         "global" attribute: onclose  
         close event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onclose attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onclose attribute to be added to your element
+
+        """
         
         return BaseAttribute("onclose", value)
             
@@ -574,9 +774,14 @@ class GlobalAttrs:
         "global" attribute: oncontextlost  
         contextlost event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oncontextlost attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oncontextlost attribute to be added to your element
+
+        """
         
         return BaseAttribute("oncontextlost", value)
             
@@ -588,9 +793,14 @@ class GlobalAttrs:
         "global" attribute: oncontextmenu  
         contextmenu event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oncontextmenu attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oncontextmenu attribute to be added to your element
+
+        """
         
         return BaseAttribute("oncontextmenu", value)
             
@@ -602,9 +812,14 @@ class GlobalAttrs:
         "global" attribute: oncontextrestored  
         contextrestored event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oncontextrestored attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oncontextrestored attribute to be added to your element
+
+        """
         
         return BaseAttribute("oncontextrestored", value)
             
@@ -616,9 +831,14 @@ class GlobalAttrs:
         "global" attribute: oncopy  
         copy event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oncopy attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oncopy attribute to be added to your element
+
+        """
         
         return BaseAttribute("oncopy", value)
             
@@ -630,9 +850,14 @@ class GlobalAttrs:
         "global" attribute: oncuechange  
         cuechange event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oncuechange attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oncuechange attribute to be added to your element
+
+        """
         
         return BaseAttribute("oncuechange", value)
             
@@ -644,9 +869,14 @@ class GlobalAttrs:
         "global" attribute: oncut  
         cut event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oncut attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oncut attribute to be added to your element
+
+        """
         
         return BaseAttribute("oncut", value)
             
@@ -658,9 +888,14 @@ class GlobalAttrs:
         "global" attribute: ondblclick  
         dblclick event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ondblclick attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ondblclick attribute to be added to your element
+
+        """
         
         return BaseAttribute("ondblclick", value)
             
@@ -672,9 +907,14 @@ class GlobalAttrs:
         "global" attribute: ondrag  
         drag event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ondrag attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ondrag attribute to be added to your element
+
+        """
         
         return BaseAttribute("ondrag", value)
             
@@ -686,9 +926,14 @@ class GlobalAttrs:
         "global" attribute: ondragend  
         dragend event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ondragend attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ondragend attribute to be added to your element
+
+        """
         
         return BaseAttribute("ondragend", value)
             
@@ -700,9 +945,14 @@ class GlobalAttrs:
         "global" attribute: ondragenter  
         dragenter event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ondragenter attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ondragenter attribute to be added to your element
+
+        """
         
         return BaseAttribute("ondragenter", value)
             
@@ -714,9 +964,14 @@ class GlobalAttrs:
         "global" attribute: ondragleave  
         dragleave event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ondragleave attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ondragleave attribute to be added to your element
+
+        """
         
         return BaseAttribute("ondragleave", value)
             
@@ -728,9 +983,14 @@ class GlobalAttrs:
         "global" attribute: ondragover  
         dragover event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ondragover attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ondragover attribute to be added to your element
+
+        """
         
         return BaseAttribute("ondragover", value)
             
@@ -742,9 +1002,14 @@ class GlobalAttrs:
         "global" attribute: ondragstart  
         dragstart event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ondragstart attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ondragstart attribute to be added to your element
+
+        """
         
         return BaseAttribute("ondragstart", value)
             
@@ -756,9 +1021,14 @@ class GlobalAttrs:
         "global" attribute: ondrop  
         drop event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ondrop attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ondrop attribute to be added to your element
+
+        """
         
         return BaseAttribute("ondrop", value)
             
@@ -770,9 +1040,14 @@ class GlobalAttrs:
         "global" attribute: ondurationchange  
         durationchange event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ondurationchange attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ondurationchange attribute to be added to your element
+
+        """
         
         return BaseAttribute("ondurationchange", value)
             
@@ -784,9 +1059,14 @@ class GlobalAttrs:
         "global" attribute: onemptied  
         emptied event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onemptied attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onemptied attribute to be added to your element
+
+        """
         
         return BaseAttribute("onemptied", value)
             
@@ -798,9 +1078,14 @@ class GlobalAttrs:
         "global" attribute: onended  
         ended event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onended attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onended attribute to be added to your element
+
+        """
         
         return BaseAttribute("onended", value)
             
@@ -812,9 +1097,14 @@ class GlobalAttrs:
         "global" attribute: onerror  
         error event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onerror attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onerror attribute to be added to your element
+
+        """
         
         return BaseAttribute("onerror", value)
             
@@ -826,9 +1116,14 @@ class GlobalAttrs:
         "global" attribute: onfocus  
         focus event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onfocus attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onfocus attribute to be added to your element
+
+        """
         
         return BaseAttribute("onfocus", value)
             
@@ -840,9 +1135,14 @@ class GlobalAttrs:
         "global" attribute: onformdata  
         formdata event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onformdata attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onformdata attribute to be added to your element
+
+        """
         
         return BaseAttribute("onformdata", value)
             
@@ -854,9 +1154,14 @@ class GlobalAttrs:
         "global" attribute: oninput  
         input event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oninput attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oninput attribute to be added to your element
+
+        """
         
         return BaseAttribute("oninput", value)
             
@@ -868,9 +1173,14 @@ class GlobalAttrs:
         "global" attribute: oninvalid  
         invalid event handler  
 
-        :param value: Event handler content attribute  
-        :return: An oninvalid attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An oninvalid attribute to be added to your element
+
+        """
         
         return BaseAttribute("oninvalid", value)
             
@@ -882,9 +1192,14 @@ class GlobalAttrs:
         "global" attribute: onkeydown  
         keydown event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onkeydown attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onkeydown attribute to be added to your element
+
+        """
         
         return BaseAttribute("onkeydown", value)
             
@@ -896,9 +1211,14 @@ class GlobalAttrs:
         "global" attribute: onkeypress  
         keypress event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onkeypress attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onkeypress attribute to be added to your element
+
+        """
         
         return BaseAttribute("onkeypress", value)
             
@@ -910,9 +1230,14 @@ class GlobalAttrs:
         "global" attribute: onkeyup  
         keyup event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onkeyup attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onkeyup attribute to be added to your element
+
+        """
         
         return BaseAttribute("onkeyup", value)
             
@@ -924,9 +1249,14 @@ class GlobalAttrs:
         "global" attribute: onload  
         load event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onload attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onload attribute to be added to your element
+
+        """
         
         return BaseAttribute("onload", value)
             
@@ -938,9 +1268,14 @@ class GlobalAttrs:
         "global" attribute: onloadeddata  
         loadeddata event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onloadeddata attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onloadeddata attribute to be added to your element
+
+        """
         
         return BaseAttribute("onloadeddata", value)
             
@@ -952,9 +1287,14 @@ class GlobalAttrs:
         "global" attribute: onloadedmetadata  
         loadedmetadata event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onloadedmetadata attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onloadedmetadata attribute to be added to your element
+
+        """
         
         return BaseAttribute("onloadedmetadata", value)
             
@@ -966,9 +1306,14 @@ class GlobalAttrs:
         "global" attribute: onloadstart  
         loadstart event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onloadstart attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onloadstart attribute to be added to your element
+
+        """
         
         return BaseAttribute("onloadstart", value)
             
@@ -980,9 +1325,14 @@ class GlobalAttrs:
         "global" attribute: onmousedown  
         mousedown event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onmousedown attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onmousedown attribute to be added to your element
+
+        """
         
         return BaseAttribute("onmousedown", value)
             
@@ -994,9 +1344,14 @@ class GlobalAttrs:
         "global" attribute: onmouseenter  
         mouseenter event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onmouseenter attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onmouseenter attribute to be added to your element
+
+        """
         
         return BaseAttribute("onmouseenter", value)
             
@@ -1008,9 +1363,14 @@ class GlobalAttrs:
         "global" attribute: onmouseleave  
         mouseleave event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onmouseleave attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onmouseleave attribute to be added to your element
+
+        """
         
         return BaseAttribute("onmouseleave", value)
             
@@ -1022,9 +1382,14 @@ class GlobalAttrs:
         "global" attribute: onmousemove  
         mousemove event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onmousemove attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onmousemove attribute to be added to your element
+
+        """
         
         return BaseAttribute("onmousemove", value)
             
@@ -1036,9 +1401,14 @@ class GlobalAttrs:
         "global" attribute: onmouseout  
         mouseout event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onmouseout attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onmouseout attribute to be added to your element
+
+        """
         
         return BaseAttribute("onmouseout", value)
             
@@ -1050,9 +1420,14 @@ class GlobalAttrs:
         "global" attribute: onmouseover  
         mouseover event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onmouseover attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onmouseover attribute to be added to your element
+
+        """
         
         return BaseAttribute("onmouseover", value)
             
@@ -1064,9 +1439,14 @@ class GlobalAttrs:
         "global" attribute: onmouseup  
         mouseup event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onmouseup attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onmouseup attribute to be added to your element
+
+        """
         
         return BaseAttribute("onmouseup", value)
             
@@ -1078,9 +1458,14 @@ class GlobalAttrs:
         "global" attribute: onpaste  
         paste event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onpaste attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onpaste attribute to be added to your element
+
+        """
         
         return BaseAttribute("onpaste", value)
             
@@ -1092,9 +1477,14 @@ class GlobalAttrs:
         "global" attribute: onpause  
         pause event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onpause attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onpause attribute to be added to your element
+
+        """
         
         return BaseAttribute("onpause", value)
             
@@ -1106,9 +1496,14 @@ class GlobalAttrs:
         "global" attribute: onplay  
         play event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onplay attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onplay attribute to be added to your element
+
+        """
         
         return BaseAttribute("onplay", value)
             
@@ -1120,9 +1515,14 @@ class GlobalAttrs:
         "global" attribute: onplaying  
         playing event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onplaying attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onplaying attribute to be added to your element
+
+        """
         
         return BaseAttribute("onplaying", value)
             
@@ -1134,9 +1534,14 @@ class GlobalAttrs:
         "global" attribute: onprogress  
         progress event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onprogress attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onprogress attribute to be added to your element
+
+        """
         
         return BaseAttribute("onprogress", value)
             
@@ -1148,9 +1553,14 @@ class GlobalAttrs:
         "global" attribute: onratechange  
         ratechange event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onratechange attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onratechange attribute to be added to your element
+
+        """
         
         return BaseAttribute("onratechange", value)
             
@@ -1162,9 +1572,14 @@ class GlobalAttrs:
         "global" attribute: onreset  
         reset event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onreset attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onreset attribute to be added to your element
+
+        """
         
         return BaseAttribute("onreset", value)
             
@@ -1176,9 +1591,14 @@ class GlobalAttrs:
         "global" attribute: onresize  
         resize event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onresize attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onresize attribute to be added to your element
+
+        """
         
         return BaseAttribute("onresize", value)
             
@@ -1190,9 +1610,14 @@ class GlobalAttrs:
         "global" attribute: onscroll  
         scroll event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onscroll attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onscroll attribute to be added to your element
+
+        """
         
         return BaseAttribute("onscroll", value)
             
@@ -1204,9 +1629,14 @@ class GlobalAttrs:
         "global" attribute: onscrollend  
         scrollend event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onscrollend attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onscrollend attribute to be added to your element
+
+        """
         
         return BaseAttribute("onscrollend", value)
             
@@ -1218,9 +1648,14 @@ class GlobalAttrs:
         "global" attribute: onsecuritypolicyviolation  
         securitypolicyviolation event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onsecuritypolicyviolation attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onsecuritypolicyviolation attribute to be added to your element
+
+        """
         
         return BaseAttribute("onsecuritypolicyviolation", value)
             
@@ -1232,9 +1667,14 @@ class GlobalAttrs:
         "global" attribute: onseeked  
         seeked event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onseeked attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onseeked attribute to be added to your element
+
+        """
         
         return BaseAttribute("onseeked", value)
             
@@ -1246,9 +1686,14 @@ class GlobalAttrs:
         "global" attribute: onseeking  
         seeking event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onseeking attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onseeking attribute to be added to your element
+
+        """
         
         return BaseAttribute("onseeking", value)
             
@@ -1260,9 +1705,14 @@ class GlobalAttrs:
         "global" attribute: onselect  
         select event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onselect attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onselect attribute to be added to your element
+
+        """
         
         return BaseAttribute("onselect", value)
             
@@ -1274,9 +1724,14 @@ class GlobalAttrs:
         "global" attribute: onslotchange  
         slotchange event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onslotchange attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onslotchange attribute to be added to your element
+
+        """
         
         return BaseAttribute("onslotchange", value)
             
@@ -1288,9 +1743,14 @@ class GlobalAttrs:
         "global" attribute: onstalled  
         stalled event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onstalled attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onstalled attribute to be added to your element
+
+        """
         
         return BaseAttribute("onstalled", value)
             
@@ -1302,9 +1762,14 @@ class GlobalAttrs:
         "global" attribute: onsubmit  
         submit event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onsubmit attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onsubmit attribute to be added to your element
+
+        """
         
         return BaseAttribute("onsubmit", value)
             
@@ -1316,9 +1781,14 @@ class GlobalAttrs:
         "global" attribute: onsuspend  
         suspend event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onsuspend attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onsuspend attribute to be added to your element
+
+        """
         
         return BaseAttribute("onsuspend", value)
             
@@ -1330,9 +1800,14 @@ class GlobalAttrs:
         "global" attribute: ontimeupdate  
         timeupdate event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ontimeupdate attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ontimeupdate attribute to be added to your element
+
+        """
         
         return BaseAttribute("ontimeupdate", value)
             
@@ -1344,9 +1819,14 @@ class GlobalAttrs:
         "global" attribute: ontoggle  
         toggle event handler  
 
-        :param value: Event handler content attribute  
-        :return: An ontoggle attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An ontoggle attribute to be added to your element
+
+        """
         
         return BaseAttribute("ontoggle", value)
             
@@ -1358,9 +1838,14 @@ class GlobalAttrs:
         "global" attribute: onvolumechange  
         volumechange event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onvolumechange attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onvolumechange attribute to be added to your element
+
+        """
         
         return BaseAttribute("onvolumechange", value)
             
@@ -1372,9 +1857,14 @@ class GlobalAttrs:
         "global" attribute: onwaiting  
         waiting event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onwaiting attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onwaiting attribute to be added to your element
+
+        """
         
         return BaseAttribute("onwaiting", value)
             
@@ -1386,9 +1876,14 @@ class GlobalAttrs:
         "global" attribute: onwheel  
         wheel event handler  
 
-        :param value: Event handler content attribute  
-        :return: An onwheel attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Event handler content attribute
+        
+        Returns:
+            An onwheel attribute to be added to your element
+
+        """
         
         return BaseAttribute("onwheel", value)
             

--- a/tools/generated/iframe_attrs.py
+++ b/tools/generated/iframe_attrs.py
@@ -14,9 +14,14 @@ class IframeAttrs:
         "iframe" attribute: allow  
         Permissions policy to be applied to the iframe's contents  
 
-        :param value: Serialized permissions policy  
-        :return: An allow attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Serialized permissions policy
+        
+        Returns:
+            An allow attribute to be added to your element
+
+        """
         
         return BaseAttribute("allow", value)
             
@@ -28,9 +33,14 @@ class IframeAttrs:
         "iframe" attribute: allowfullscreen  
         Whether to allow the iframe's contents to use requestFullscreen()  
 
-        :param value: Boolean attribute  
-        :return: An allowfullscreen attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An allowfullscreen attribute to be added to your element
+
+        """
         
         return BaseAttribute("allowfullscreen", value)
             
@@ -42,9 +52,14 @@ class IframeAttrs:
         "iframe" attribute: height  
         Vertical dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An height attribute to be added to your element
+
+        """
         
         return BaseAttribute("height", value)
             
@@ -56,9 +71,14 @@ class IframeAttrs:
         "iframe" attribute: loading  
         Used when determining loading deferral  
 
-        :param value: ['lazy', 'eager']  
-        :return: An loading attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['lazy', 'eager']
+        
+        Returns:
+            An loading attribute to be added to your element
+
+        """
         
         return BaseAttribute("loading", value)
             
@@ -70,9 +90,14 @@ class IframeAttrs:
         "iframe" attribute: name  
         Name of content navigable  
 
-        :param value: Valid navigable target name or keyword  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             
@@ -84,9 +109,14 @@ class IframeAttrs:
         "iframe" attribute: referrerpolicy  
         Referrer policy for fetches initiated by the element  
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Referrer policy
+        
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
         
         return BaseAttribute("referrerpolicy", value)
             
@@ -98,9 +128,14 @@ class IframeAttrs:
         "iframe" attribute: sandbox  
         Security rules for nested content  
 
-        :param value: Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of "allow-downloads" "allow-forms" "allow-modals" "allow-orientation-lock" "allow-pointer-lock" "allow-popups" "allow-popups-to-escape-sandbox" "allow-presentation" "allow-same-origin" "allow-scripts" "allow-top-navigation" "allow-top-navigation-by-user-activation" "allow-top-navigation-to-custom-protocols"  
-        :return: An sandbox attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of "allow-downloads" "allow-forms" "allow-modals" "allow-orientation-lock" "allow-pointer-lock" "allow-popups" "allow-popups-to-escape-sandbox" "allow-presentation" "allow-same-origin" "allow-scripts" "allow-top-navigation" "allow-top-navigation-by-user-activation" "allow-top-navigation-to-custom-protocols"
+        
+        Returns:
+            An sandbox attribute to be added to your element
+
+        """
         
         return BaseAttribute("sandbox", value)
             
@@ -112,9 +147,14 @@ class IframeAttrs:
         "iframe" attribute: src  
         Address of the resource  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An src attribute to be added to your element
+
+        """
         
         return BaseAttribute("src", value)
             
@@ -126,9 +166,14 @@ class IframeAttrs:
         "iframe" attribute: srcdoc  
         A document to render in the iframe  
 
-        :param value: The source of an iframe srcdoc document*  
-        :return: An srcdoc attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                The source of an iframe srcdoc document*
+        
+        Returns:
+            An srcdoc attribute to be added to your element
+
+        """
         
         return BaseAttribute("srcdoc", value)
             
@@ -140,9 +185,14 @@ class IframeAttrs:
         "iframe" attribute: width  
         Horizontal dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An width attribute to be added to your element
+
+        """
         
         return BaseAttribute("width", value)
             

--- a/tools/generated/img_attrs.py
+++ b/tools/generated/img_attrs.py
@@ -14,9 +14,14 @@ class ImgAttrs:
         "img" attribute: alt  
         Replacement text for use when images are not available  
 
-        :param value: Text*  
-        :return: An alt attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An alt attribute to be added to your element
+
+        """
         
         return BaseAttribute("alt", value)
             
@@ -28,9 +33,14 @@ class ImgAttrs:
         "img" attribute: crossorigin  
         How the element handles crossorigin requests  
 
-        :param value: ['anonymous', 'use-credentials']  
-        :return: An crossorigin attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['anonymous', 'use-credentials']
+        
+        Returns:
+            An crossorigin attribute to be added to your element
+
+        """
         
         return BaseAttribute("crossorigin", value)
             
@@ -42,9 +52,14 @@ class ImgAttrs:
         "img" attribute: decoding  
         Decoding hint to use when processing this image for presentation  
 
-        :param value: ['sync', 'async', 'auto']  
-        :return: An decoding attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['sync', 'async', 'auto']
+        
+        Returns:
+            An decoding attribute to be added to your element
+
+        """
         
         return BaseAttribute("decoding", value)
             
@@ -56,9 +71,14 @@ class ImgAttrs:
         "img" attribute: fetchpriority  
         Sets the priority for fetches initiated by the element  
 
-        :param value: ['auto', 'high', 'low']  
-        :return: An fetchpriority attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['auto', 'high', 'low']
+        
+        Returns:
+            An fetchpriority attribute to be added to your element
+
+        """
         
         return BaseAttribute("fetchpriority", value)
             
@@ -70,9 +90,14 @@ class ImgAttrs:
         "img" attribute: height  
         Vertical dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An height attribute to be added to your element
+
+        """
         
         return BaseAttribute("height", value)
             
@@ -84,9 +109,14 @@ class ImgAttrs:
         "img" attribute: ismap  
         Whether the image is a server-side image map  
 
-        :param value: Boolean attribute  
-        :return: An ismap attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An ismap attribute to be added to your element
+
+        """
         
         return BaseAttribute("ismap", value)
             
@@ -98,9 +128,14 @@ class ImgAttrs:
         "img" attribute: loading  
         Used when determining loading deferral  
 
-        :param value: ['lazy', 'eager']  
-        :return: An loading attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['lazy', 'eager']
+        
+        Returns:
+            An loading attribute to be added to your element
+
+        """
         
         return BaseAttribute("loading", value)
             
@@ -112,9 +147,14 @@ class ImgAttrs:
         "img" attribute: referrerpolicy  
         Referrer policy for fetches initiated by the element  
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Referrer policy
+        
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
         
         return BaseAttribute("referrerpolicy", value)
             
@@ -126,9 +166,14 @@ class ImgAttrs:
         "img" attribute: sizes  
         Image sizes for different page layouts  
 
-        :param value: Valid source size list  
-        :return: An sizes attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid source size list
+        
+        Returns:
+            An sizes attribute to be added to your element
+
+        """
         
         return BaseAttribute("sizes", value)
             
@@ -140,9 +185,14 @@ class ImgAttrs:
         "img" attribute: src  
         Address of the resource  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An src attribute to be added to your element
+
+        """
         
         return BaseAttribute("src", value)
             
@@ -154,9 +204,14 @@ class ImgAttrs:
         "img" attribute: srcset  
         Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
 
-        :param value: Comma-separated list of image candidate strings  
-        :return: An srcset attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Comma-separated list of image candidate strings
+        
+        Returns:
+            An srcset attribute to be added to your element
+
+        """
         
         return BaseAttribute("srcset", value)
             
@@ -168,9 +223,14 @@ class ImgAttrs:
         "img" attribute: usemap  
         Name of image map to use  
 
-        :param value: Valid hash-name reference*  
-        :return: An usemap attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid hash-name reference*
+        
+        Returns:
+            An usemap attribute to be added to your element
+
+        """
         
         return BaseAttribute("usemap", value)
             
@@ -182,9 +242,14 @@ class ImgAttrs:
         "img" attribute: width  
         Horizontal dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An width attribute to be added to your element
+
+        """
         
         return BaseAttribute("width", value)
             

--- a/tools/generated/input_attrs.py
+++ b/tools/generated/input_attrs.py
@@ -14,9 +14,14 @@ class InputAttrs:
         "input" attribute: accept  
         Hint for expected file type in file upload controls  
 
-        :param value: Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*  
-        :return: An accept attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Set of comma-separated tokens* consisting of valid MIME type strings with no parameters or audio/*, video/*, or image/*
+        
+        Returns:
+            An accept attribute to be added to your element
+
+        """
         
         return BaseAttribute("accept", value)
             
@@ -28,9 +33,14 @@ class InputAttrs:
         "input" attribute: alpha  
         Allow the color's alpha component to be set  
 
-        :param value: Boolean attribute  
-        :return: An alpha attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An alpha attribute to be added to your element
+
+        """
         
         return BaseAttribute("alpha", value)
             
@@ -42,9 +52,14 @@ class InputAttrs:
         "input" attribute: alt  
         Replacement text for use when images are not available  
 
-        :param value: Text*  
-        :return: An alt attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An alt attribute to be added to your element
+
+        """
         
         return BaseAttribute("alt", value)
             
@@ -56,9 +71,14 @@ class InputAttrs:
         "input" attribute: autocomplete  
         Hint for form autofill feature  
 
-        :param value: Autofill field name and related tokens*  
-        :return: An autocomplete attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Autofill field name and related tokens*
+        
+        Returns:
+            An autocomplete attribute to be added to your element
+
+        """
         
         return BaseAttribute("autocomplete", value)
             
@@ -70,9 +90,14 @@ class InputAttrs:
         "input" attribute: checked  
         Whether the control is checked  
 
-        :param value: Boolean attribute  
-        :return: An checked attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An checked attribute to be added to your element
+
+        """
         
         return BaseAttribute("checked", value)
             
@@ -84,9 +109,14 @@ class InputAttrs:
         "input" attribute: colorspace  
         The color space of the serialized color  
 
-        :param value: ['limited-srgb', 'display-p3']  
-        :return: An colorspace attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['limited-srgb', 'display-p3']
+        
+        Returns:
+            An colorspace attribute to be added to your element
+
+        """
         
         return BaseAttribute("colorspace", value)
             
@@ -98,9 +128,14 @@ class InputAttrs:
         "input" attribute: dirname  
         Name of form control to use for sending the element's directionality in form submission  
 
-        :param value: Text*  
-        :return: An dirname attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An dirname attribute to be added to your element
+
+        """
         
         return BaseAttribute("dirname", value)
             
@@ -112,9 +147,14 @@ class InputAttrs:
         "input" attribute: disabled  
         Whether the form control is disabled  
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
         
         return BaseAttribute("disabled", value)
             
@@ -126,9 +166,14 @@ class InputAttrs:
         "input" attribute: form  
         Associates the element with a form element  
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An form attribute to be added to your element
+
+        """
         
         return BaseAttribute("form", value)
             
@@ -140,9 +185,14 @@ class InputAttrs:
         "input" attribute: formaction  
         URL to use for form submission  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An formaction attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An formaction attribute to be added to your element
+
+        """
         
         return BaseAttribute("formaction", value)
             
@@ -154,9 +204,14 @@ class InputAttrs:
         "input" attribute: formenctype  
         Entry list encoding type to use for form submission  
 
-        :param value: ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']  
-        :return: An formenctype attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['application/x-www-form-urlencoded', 'multipart/form-data', 'text/plain']
+        
+        Returns:
+            An formenctype attribute to be added to your element
+
+        """
         
         return BaseAttribute("formenctype", value)
             
@@ -168,9 +223,14 @@ class InputAttrs:
         "input" attribute: formmethod  
         Variant to use for form submission  
 
-        :param value: ['GET', 'POST', 'dialog']  
-        :return: An formmethod attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['GET', 'POST', 'dialog']
+        
+        Returns:
+            An formmethod attribute to be added to your element
+
+        """
         
         return BaseAttribute("formmethod", value)
             
@@ -182,9 +242,14 @@ class InputAttrs:
         "input" attribute: formnovalidate  
         Bypass form control validation for form submission  
 
-        :param value: Boolean attribute  
-        :return: An formnovalidate attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An formnovalidate attribute to be added to your element
+
+        """
         
         return BaseAttribute("formnovalidate", value)
             
@@ -196,9 +261,14 @@ class InputAttrs:
         "input" attribute: formtarget  
         Navigable for form submission  
 
-        :param value: Valid navigable target name or keyword  
-        :return: An formtarget attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+        
+        Returns:
+            An formtarget attribute to be added to your element
+
+        """
         
         return BaseAttribute("formtarget", value)
             
@@ -210,9 +280,14 @@ class InputAttrs:
         "input" attribute: height  
         Vertical dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An height attribute to be added to your element
+
+        """
         
         return BaseAttribute("height", value)
             
@@ -224,9 +299,14 @@ class InputAttrs:
         "input" attribute: list  
         List of autocomplete options  
 
-        :param value: ID*  
-        :return: An list attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An list attribute to be added to your element
+
+        """
         
         return BaseAttribute("list", value)
             
@@ -238,9 +318,14 @@ class InputAttrs:
         "input" attribute: max  
         Maximum value  
 
-        :param value: Varies*  
-        :return: An max attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Varies*
+        
+        Returns:
+            An max attribute to be added to your element
+
+        """
         
         return BaseAttribute("max", value)
             
@@ -252,9 +337,14 @@ class InputAttrs:
         "input" attribute: maxlength  
         Maximum length of value  
 
-        :param value: Valid non-negative integer  
-        :return: An maxlength attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An maxlength attribute to be added to your element
+
+        """
         
         return BaseAttribute("maxlength", value)
             
@@ -266,9 +356,14 @@ class InputAttrs:
         "input" attribute: min  
         Minimum value  
 
-        :param value: Varies*  
-        :return: An min attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Varies*
+        
+        Returns:
+            An min attribute to be added to your element
+
+        """
         
         return BaseAttribute("min", value)
             
@@ -280,9 +375,14 @@ class InputAttrs:
         "input" attribute: minlength  
         Minimum length of value  
 
-        :param value: Valid non-negative integer  
-        :return: An minlength attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An minlength attribute to be added to your element
+
+        """
         
         return BaseAttribute("minlength", value)
             
@@ -294,9 +394,14 @@ class InputAttrs:
         "input" attribute: multiple  
         Whether to allow multiple values  
 
-        :param value: Boolean attribute  
-        :return: An multiple attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An multiple attribute to be added to your element
+
+        """
         
         return BaseAttribute("multiple", value)
             
@@ -308,9 +413,14 @@ class InputAttrs:
         "input" attribute: name  
         Name of the element to use for form submission and in the form.elements API  
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             
@@ -322,9 +432,14 @@ class InputAttrs:
         "input" attribute: pattern  
         Pattern to be matched by the form control's value  
 
-        :param value: Regular expression matching the JavaScript Pattern production  
-        :return: An pattern attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Regular expression matching the JavaScript Pattern production
+        
+        Returns:
+            An pattern attribute to be added to your element
+
+        """
         
         return BaseAttribute("pattern", value)
             
@@ -336,9 +451,14 @@ class InputAttrs:
         "input" attribute: placeholder  
         User-visible label to be placed within the form control  
 
-        :param value: Text*  
-        :return: An placeholder attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An placeholder attribute to be added to your element
+
+        """
         
         return BaseAttribute("placeholder", value)
             
@@ -350,9 +470,14 @@ class InputAttrs:
         "input" attribute: popovertarget  
         Targets a popover element to toggle, show, or hide  
 
-        :param value: ID*  
-        :return: An popovertarget attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An popovertarget attribute to be added to your element
+
+        """
         
         return BaseAttribute("popovertarget", value)
             
@@ -364,9 +489,14 @@ class InputAttrs:
         "input" attribute: popovertargetaction  
         Indicates whether a targeted popover element is to be toggled, shown, or hidden  
 
-        :param value: ['toggle', 'show', 'hide']  
-        :return: An popovertargetaction attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['toggle', 'show', 'hide']
+        
+        Returns:
+            An popovertargetaction attribute to be added to your element
+
+        """
         
         return BaseAttribute("popovertargetaction", value)
             
@@ -378,9 +508,14 @@ class InputAttrs:
         "input" attribute: readonly  
         Whether to allow the value to be edited by the user  
 
-        :param value: Boolean attribute  
-        :return: An readonly attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An readonly attribute to be added to your element
+
+        """
         
         return BaseAttribute("readonly", value)
             
@@ -392,9 +527,14 @@ class InputAttrs:
         "input" attribute: required  
         Whether the control is required for form submission  
 
-        :param value: Boolean attribute  
-        :return: An required attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An required attribute to be added to your element
+
+        """
         
         return BaseAttribute("required", value)
             
@@ -406,9 +546,14 @@ class InputAttrs:
         "input" attribute: size  
         Size of the control  
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An size attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+        
+        Returns:
+            An size attribute to be added to your element
+
+        """
         
         return BaseAttribute("size", value)
             
@@ -420,9 +565,14 @@ class InputAttrs:
         "input" attribute: src  
         Address of the resource  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An src attribute to be added to your element
+
+        """
         
         return BaseAttribute("src", value)
             
@@ -434,9 +584,14 @@ class InputAttrs:
         "input" attribute: step  
         Granularity to be matched by the form control's value  
 
-        :param value: Valid floating-point number greater than zero, or "any"  
-        :return: An step attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid floating-point number greater than zero, or "any"
+        
+        Returns:
+            An step attribute to be added to your element
+
+        """
         
         return BaseAttribute("step", value)
             
@@ -448,9 +603,14 @@ class InputAttrs:
         "input" attribute: title  
         Description of pattern (when used with pattern attribute)  
 
-        :param value: Text  
-        :return: An title attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An title attribute to be added to your element
+
+        """
         
         return BaseAttribute("title", value)
             
@@ -462,9 +622,14 @@ class InputAttrs:
         "input" attribute: type  
         Type of form control  
 
-        :param value: input type keyword  
-        :return: An type attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                input type keyword
+        
+        Returns:
+            An type attribute to be added to your element
+
+        """
         
         return BaseAttribute("type", value)
             
@@ -476,9 +641,14 @@ class InputAttrs:
         "input" attribute: value  
         Value of the form control  
 
-        :param value: Varies*  
-        :return: An value attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Varies*
+        
+        Returns:
+            An value attribute to be added to your element
+
+        """
         
         return BaseAttribute("value", value)
             
@@ -490,9 +660,14 @@ class InputAttrs:
         "input" attribute: width  
         Horizontal dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An width attribute to be added to your element
+
+        """
         
         return BaseAttribute("width", value)
             

--- a/tools/generated/ins_attrs.py
+++ b/tools/generated/ins_attrs.py
@@ -14,9 +14,14 @@ class InsAttrs:
         "ins" attribute: cite  
         Link to the source of the quotation or more information about the edit  
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An cite attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+        
+        Returns:
+            An cite attribute to be added to your element
+
+        """
         
         return BaseAttribute("cite", value)
             
@@ -28,9 +33,14 @@ class InsAttrs:
         "ins" attribute: datetime  
         Date and (optionally) time of the change  
 
-        :param value: Valid date string with optional time  
-        :return: An datetime attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid date string with optional time
+        
+        Returns:
+            An datetime attribute to be added to your element
+
+        """
         
         return BaseAttribute("datetime", value)
             

--- a/tools/generated/label_attrs.py
+++ b/tools/generated/label_attrs.py
@@ -14,9 +14,14 @@ class LabelAttrs:
         "label" attribute: for  
         Associate the label with form control  
 
-        :param value: ID*  
-        :return: An for attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An for attribute to be added to your element
+
+        """
         
         return BaseAttribute("for", value)
             

--- a/tools/generated/li_attrs.py
+++ b/tools/generated/li_attrs.py
@@ -14,9 +14,14 @@ class LiAttrs:
         "li" attribute: value  
         Ordinal value of the list item  
 
-        :param value: Valid integer  
-        :return: An value attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid integer
+        
+        Returns:
+            An value attribute to be added to your element
+
+        """
         
         return BaseAttribute("value", value)
             

--- a/tools/generated/link_attrs.py
+++ b/tools/generated/link_attrs.py
@@ -14,9 +14,14 @@ class LinkAttrs:
         "link" attribute: as  
         Potential destination for a preload request (for rel="preload" and rel="modulepreload")  
 
-        :param value: Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"  
-        :return: An as attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Potential destination, for rel="preload"; script-like destination, for rel="modulepreload"
+        
+        Returns:
+            An as attribute to be added to your element
+
+        """
         
         return BaseAttribute("as", value)
             
@@ -28,9 +33,14 @@ class LinkAttrs:
         "link" attribute: blocking  
         Whether the element is potentially render-blocking  
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An blocking attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+        
+        Returns:
+            An blocking attribute to be added to your element
+
+        """
         
         return BaseAttribute("blocking", value)
             
@@ -42,9 +52,14 @@ class LinkAttrs:
         "link" attribute: color  
         Color to use when customizing a site's icon (for rel="mask-icon")  
 
-        :param value: CSS <color>  
-        :return: An color attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                CSS <color>
+        
+        Returns:
+            An color attribute to be added to your element
+
+        """
         
         return BaseAttribute("color", value)
             
@@ -56,9 +71,14 @@ class LinkAttrs:
         "link" attribute: crossorigin  
         How the element handles crossorigin requests  
 
-        :param value: ['anonymous', 'use-credentials']  
-        :return: An crossorigin attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['anonymous', 'use-credentials']
+        
+        Returns:
+            An crossorigin attribute to be added to your element
+
+        """
         
         return BaseAttribute("crossorigin", value)
             
@@ -70,9 +90,14 @@ class LinkAttrs:
         "link" attribute: disabled  
         Whether the link is disabled  
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
         
         return BaseAttribute("disabled", value)
             
@@ -84,9 +109,14 @@ class LinkAttrs:
         "link" attribute: fetchpriority  
         Sets the priority for fetches initiated by the element  
 
-        :param value: ['auto', 'high', 'low']  
-        :return: An fetchpriority attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['auto', 'high', 'low']
+        
+        Returns:
+            An fetchpriority attribute to be added to your element
+
+        """
         
         return BaseAttribute("fetchpriority", value)
             
@@ -98,9 +128,14 @@ class LinkAttrs:
         "link" attribute: href  
         Address of the hyperlink  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An href attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An href attribute to be added to your element
+
+        """
         
         return BaseAttribute("href", value)
             
@@ -112,9 +147,14 @@ class LinkAttrs:
         "link" attribute: hreflang  
         Language of the linked resource  
 
-        :param value: Valid BCP 47 language tag  
-        :return: An hreflang attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid BCP 47 language tag
+        
+        Returns:
+            An hreflang attribute to be added to your element
+
+        """
         
         return BaseAttribute("hreflang", value)
             
@@ -126,9 +166,14 @@ class LinkAttrs:
         "link" attribute: imagesizes  
         Image sizes for different page layouts (for rel="preload")  
 
-        :param value: Valid source size list  
-        :return: An imagesizes attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid source size list
+        
+        Returns:
+            An imagesizes attribute to be added to your element
+
+        """
         
         return BaseAttribute("imagesizes", value)
             
@@ -140,9 +185,14 @@ class LinkAttrs:
         "link" attribute: imagesrcset  
         Images to use in different situations, e.g., high-resolution displays, small monitors, etc. (for rel="preload")  
 
-        :param value: Comma-separated list of image candidate strings  
-        :return: An imagesrcset attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Comma-separated list of image candidate strings
+        
+        Returns:
+            An imagesrcset attribute to be added to your element
+
+        """
         
         return BaseAttribute("imagesrcset", value)
             
@@ -154,9 +204,14 @@ class LinkAttrs:
         "link" attribute: integrity  
         Integrity metadata used in Subresource Integrity checks [SRI]  
 
-        :param value: Text  
-        :return: An integrity attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An integrity attribute to be added to your element
+
+        """
         
         return BaseAttribute("integrity", value)
             
@@ -168,9 +223,14 @@ class LinkAttrs:
         "link" attribute: media  
         Applicable media  
 
-        :param value: Valid media query list  
-        :return: An media attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid media query list
+        
+        Returns:
+            An media attribute to be added to your element
+
+        """
         
         return BaseAttribute("media", value)
             
@@ -182,9 +242,14 @@ class LinkAttrs:
         "link" attribute: referrerpolicy  
         Referrer policy for fetches initiated by the element  
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Referrer policy
+        
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
         
         return BaseAttribute("referrerpolicy", value)
             
@@ -196,9 +261,14 @@ class LinkAttrs:
         "link" attribute: rel  
         Relationship between the document containing the hyperlink and the destination resource  
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An rel attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+        
+        Returns:
+            An rel attribute to be added to your element
+
+        """
         
         return BaseAttribute("rel", value)
             
@@ -210,9 +280,14 @@ class LinkAttrs:
         "link" attribute: sizes  
         Sizes of the icons (for rel="icon")  
 
-        :param value: Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of sizes*  
-        :return: An sizes attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens, ASCII case-insensitive, consisting of sizes*
+        
+        Returns:
+            An sizes attribute to be added to your element
+
+        """
         
         return BaseAttribute("sizes", value)
             
@@ -224,9 +299,14 @@ class LinkAttrs:
         "link" attribute: title  
         Title of the link  OR  CSS style sheet set name  
 
-        :param value: Text  OR  Text  
-        :return: An title attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text  OR  Text
+        
+        Returns:
+            An title attribute to be added to your element
+
+        """
         
         return BaseAttribute("title", value)
             
@@ -238,9 +318,14 @@ class LinkAttrs:
         "link" attribute: type  
         Hint for the type of the referenced resource  
 
-        :param value: Valid MIME type string  
-        :return: An type attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid MIME type string
+        
+        Returns:
+            An type attribute to be added to your element
+
+        """
         
         return BaseAttribute("type", value)
             

--- a/tools/generated/map_attrs.py
+++ b/tools/generated/map_attrs.py
@@ -14,9 +14,14 @@ class MapAttrs:
         "map" attribute: name  
         Name of image map to reference from the usemap attribute  
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             

--- a/tools/generated/meta_attrs.py
+++ b/tools/generated/meta_attrs.py
@@ -14,9 +14,14 @@ class MetaAttrs:
         "meta" attribute: charset  
         Character encoding declaration  
 
-        :param value: ['utf-8']  
-        :return: An charset attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['utf-8']
+        
+        Returns:
+            An charset attribute to be added to your element
+
+        """
         
         return BaseAttribute("charset", value)
             
@@ -28,9 +33,14 @@ class MetaAttrs:
         "meta" attribute: content  
         Value of the element  
 
-        :param value: Text*  
-        :return: An content attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An content attribute to be added to your element
+
+        """
         
         return BaseAttribute("content", value)
             
@@ -42,9 +52,14 @@ class MetaAttrs:
         "meta" attribute: http-equiv  
         Pragma directive  
 
-        :param value: ['content-type', 'default-style', 'refresh', 'x-ua-compatible', 'content-security-policy']  
-        :return: An http-equiv attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['content-type', 'default-style', 'refresh', 'x-ua-compatible', 'content-security-policy']
+        
+        Returns:
+            An http-equiv attribute to be added to your element
+
+        """
         
         return BaseAttribute("http-equiv", value)
             
@@ -56,9 +71,14 @@ class MetaAttrs:
         "meta" attribute: media  
         Applicable media  
 
-        :param value: Valid media query list  
-        :return: An media attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid media query list
+        
+        Returns:
+            An media attribute to be added to your element
+
+        """
         
         return BaseAttribute("media", value)
             
@@ -70,9 +90,14 @@ class MetaAttrs:
         "meta" attribute: name  
         Metadata name  
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             

--- a/tools/generated/meter_attrs.py
+++ b/tools/generated/meter_attrs.py
@@ -14,9 +14,14 @@ class MeterAttrs:
         "meter" attribute: high  
         Low limit of high range  
 
-        :param value: Valid floating-point number*  
-        :return: An high attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+        
+        Returns:
+            An high attribute to be added to your element
+
+        """
         
         return BaseAttribute("high", value)
             
@@ -28,9 +33,14 @@ class MeterAttrs:
         "meter" attribute: low  
         High limit of low range  
 
-        :param value: Valid floating-point number*  
-        :return: An low attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+        
+        Returns:
+            An low attribute to be added to your element
+
+        """
         
         return BaseAttribute("low", value)
             
@@ -42,9 +52,14 @@ class MeterAttrs:
         "meter" attribute: max  
         Upper bound of range  
 
-        :param value: Valid floating-point number*  
-        :return: An max attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+        
+        Returns:
+            An max attribute to be added to your element
+
+        """
         
         return BaseAttribute("max", value)
             
@@ -56,9 +71,14 @@ class MeterAttrs:
         "meter" attribute: min  
         Lower bound of range  
 
-        :param value: Valid floating-point number*  
-        :return: An min attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+        
+        Returns:
+            An min attribute to be added to your element
+
+        """
         
         return BaseAttribute("min", value)
             
@@ -70,9 +90,14 @@ class MeterAttrs:
         "meter" attribute: optimum  
         Optimum value in gauge  
 
-        :param value: Valid floating-point number*  
-        :return: An optimum attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+        
+        Returns:
+            An optimum attribute to be added to your element
+
+        """
         
         return BaseAttribute("optimum", value)
             
@@ -84,9 +109,14 @@ class MeterAttrs:
         "meter" attribute: value  
         Current value of the element  
 
-        :param value: Valid floating-point number  
-        :return: An value attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid floating-point number
+        
+        Returns:
+            An value attribute to be added to your element
+
+        """
         
         return BaseAttribute("value", value)
             

--- a/tools/generated/object_attrs.py
+++ b/tools/generated/object_attrs.py
@@ -14,9 +14,14 @@ class ObjectAttrs:
         "object" attribute: data  
         Address of the resource  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An data attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An data attribute to be added to your element
+
+        """
         
         return BaseAttribute("data", value)
             
@@ -28,9 +33,14 @@ class ObjectAttrs:
         "object" attribute: form  
         Associates the element with a form element  
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An form attribute to be added to your element
+
+        """
         
         return BaseAttribute("form", value)
             
@@ -42,9 +52,14 @@ class ObjectAttrs:
         "object" attribute: height  
         Vertical dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An height attribute to be added to your element
+
+        """
         
         return BaseAttribute("height", value)
             
@@ -56,9 +71,14 @@ class ObjectAttrs:
         "object" attribute: name  
         Name of content navigable  
 
-        :param value: Valid navigable target name or keyword  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid navigable target name or keyword
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             
@@ -70,9 +90,14 @@ class ObjectAttrs:
         "object" attribute: type  
         Type of embedded resource  
 
-        :param value: Valid MIME type string  
-        :return: An type attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid MIME type string
+        
+        Returns:
+            An type attribute to be added to your element
+
+        """
         
         return BaseAttribute("type", value)
             
@@ -84,9 +109,14 @@ class ObjectAttrs:
         "object" attribute: width  
         Horizontal dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An width attribute to be added to your element
+
+        """
         
         return BaseAttribute("width", value)
             

--- a/tools/generated/ol_attrs.py
+++ b/tools/generated/ol_attrs.py
@@ -14,9 +14,14 @@ class OlAttrs:
         "ol" attribute: reversed  
         Number the list backwards  
 
-        :param value: Boolean attribute  
-        :return: An reversed attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An reversed attribute to be added to your element
+
+        """
         
         return BaseAttribute("reversed", value)
             
@@ -28,9 +33,14 @@ class OlAttrs:
         "ol" attribute: start  
         Starting value of the list  
 
-        :param value: Valid integer  
-        :return: An start attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid integer
+        
+        Returns:
+            An start attribute to be added to your element
+
+        """
         
         return BaseAttribute("start", value)
             
@@ -42,9 +52,14 @@ class OlAttrs:
         "ol" attribute: type  
         Kind of list marker  
 
-        :param value: ['1', 'a', 'A', 'i', 'I']  
-        :return: An type attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['1', 'a', 'A', 'i', 'I']
+        
+        Returns:
+            An type attribute to be added to your element
+
+        """
         
         return BaseAttribute("type", value)
             

--- a/tools/generated/optgroup_attrs.py
+++ b/tools/generated/optgroup_attrs.py
@@ -14,9 +14,14 @@ class OptgroupAttrs:
         "optgroup" attribute: disabled  
         Whether the form control is disabled  
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
         
         return BaseAttribute("disabled", value)
             
@@ -28,9 +33,14 @@ class OptgroupAttrs:
         "optgroup" attribute: label  
         User-visible label  
 
-        :param value: Text  
-        :return: An label attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An label attribute to be added to your element
+
+        """
         
         return BaseAttribute("label", value)
             

--- a/tools/generated/option_attrs.py
+++ b/tools/generated/option_attrs.py
@@ -14,9 +14,14 @@ class OptionAttrs:
         "option" attribute: disabled  
         Whether the form control is disabled  
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
         
         return BaseAttribute("disabled", value)
             
@@ -28,9 +33,14 @@ class OptionAttrs:
         "option" attribute: label  
         User-visible label  
 
-        :param value: Text  
-        :return: An label attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An label attribute to be added to your element
+
+        """
         
         return BaseAttribute("label", value)
             
@@ -42,9 +52,14 @@ class OptionAttrs:
         "option" attribute: selected  
         Whether the option is selected by default  
 
-        :param value: Boolean attribute  
-        :return: An selected attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An selected attribute to be added to your element
+
+        """
         
         return BaseAttribute("selected", value)
             
@@ -56,9 +71,14 @@ class OptionAttrs:
         "option" attribute: value  
         Value to be used for form submission  
 
-        :param value: Text  
-        :return: An value attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An value attribute to be added to your element
+
+        """
         
         return BaseAttribute("value", value)
             

--- a/tools/generated/output_attrs.py
+++ b/tools/generated/output_attrs.py
@@ -14,9 +14,14 @@ class OutputAttrs:
         "output" attribute: for  
         Specifies controls from which the output was calculated  
 
-        :param value: Unordered set of unique space-separated tokens consisting of IDs*  
-        :return: An for attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of IDs*
+        
+        Returns:
+            An for attribute to be added to your element
+
+        """
         
         return BaseAttribute("for", value)
             
@@ -28,9 +33,14 @@ class OutputAttrs:
         "output" attribute: form  
         Associates the element with a form element  
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An form attribute to be added to your element
+
+        """
         
         return BaseAttribute("form", value)
             
@@ -42,9 +52,14 @@ class OutputAttrs:
         "output" attribute: name  
         Name of the element to use for form submission and in the form.elements API  
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             

--- a/tools/generated/progress_attrs.py
+++ b/tools/generated/progress_attrs.py
@@ -14,9 +14,14 @@ class ProgressAttrs:
         "progress" attribute: max  
         Upper bound of range  
 
-        :param value: Valid floating-point number*  
-        :return: An max attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid floating-point number*
+        
+        Returns:
+            An max attribute to be added to your element
+
+        """
         
         return BaseAttribute("max", value)
             
@@ -28,9 +33,14 @@ class ProgressAttrs:
         "progress" attribute: value  
         Current value of the element  
 
-        :param value: Valid floating-point number  
-        :return: An value attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid floating-point number
+        
+        Returns:
+            An value attribute to be added to your element
+
+        """
         
         return BaseAttribute("value", value)
             

--- a/tools/generated/q_attrs.py
+++ b/tools/generated/q_attrs.py
@@ -14,9 +14,14 @@ class QAttrs:
         "q" attribute: cite  
         Link to the source of the quotation or more information about the edit  
 
-        :param value: Valid URL potentially surrounded by spaces  
-        :return: An cite attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid URL potentially surrounded by spaces
+        
+        Returns:
+            An cite attribute to be added to your element
+
+        """
         
         return BaseAttribute("cite", value)
             

--- a/tools/generated/script_attrs.py
+++ b/tools/generated/script_attrs.py
@@ -14,9 +14,14 @@ class ScriptAttrs:
         "script" attribute: async  
         Execute script when available, without blocking while fetching  
 
-        :param value: Boolean attribute  
-        :return: An async attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An async attribute to be added to your element
+
+        """
         
         return BaseAttribute("async", value)
             
@@ -28,9 +33,14 @@ class ScriptAttrs:
         "script" attribute: blocking  
         Whether the element is potentially render-blocking  
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An blocking attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+        
+        Returns:
+            An blocking attribute to be added to your element
+
+        """
         
         return BaseAttribute("blocking", value)
             
@@ -42,9 +52,14 @@ class ScriptAttrs:
         "script" attribute: crossorigin  
         How the element handles crossorigin requests  
 
-        :param value: ['anonymous', 'use-credentials']  
-        :return: An crossorigin attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['anonymous', 'use-credentials']
+        
+        Returns:
+            An crossorigin attribute to be added to your element
+
+        """
         
         return BaseAttribute("crossorigin", value)
             
@@ -56,9 +71,14 @@ class ScriptAttrs:
         "script" attribute: defer  
         Defer script execution  
 
-        :param value: Boolean attribute  
-        :return: An defer attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An defer attribute to be added to your element
+
+        """
         
         return BaseAttribute("defer", value)
             
@@ -70,9 +90,14 @@ class ScriptAttrs:
         "script" attribute: fetchpriority  
         Sets the priority for fetches initiated by the element  
 
-        :param value: ['auto', 'high', 'low']  
-        :return: An fetchpriority attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['auto', 'high', 'low']
+        
+        Returns:
+            An fetchpriority attribute to be added to your element
+
+        """
         
         return BaseAttribute("fetchpriority", value)
             
@@ -84,9 +109,14 @@ class ScriptAttrs:
         "script" attribute: integrity  
         Integrity metadata used in Subresource Integrity checks [SRI]  
 
-        :param value: Text  
-        :return: An integrity attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An integrity attribute to be added to your element
+
+        """
         
         return BaseAttribute("integrity", value)
             
@@ -98,9 +128,14 @@ class ScriptAttrs:
         "script" attribute: nomodule  
         Prevents execution in user agents that support module scripts  
 
-        :param value: Boolean attribute  
-        :return: An nomodule attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An nomodule attribute to be added to your element
+
+        """
         
         return BaseAttribute("nomodule", value)
             
@@ -112,9 +147,14 @@ class ScriptAttrs:
         "script" attribute: referrerpolicy  
         Referrer policy for fetches initiated by the element  
 
-        :param value: Referrer policy  
-        :return: An referrerpolicy attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Referrer policy
+        
+        Returns:
+            An referrerpolicy attribute to be added to your element
+
+        """
         
         return BaseAttribute("referrerpolicy", value)
             
@@ -126,9 +166,14 @@ class ScriptAttrs:
         "script" attribute: src  
         Address of the resource  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An src attribute to be added to your element
+
+        """
         
         return BaseAttribute("src", value)
             
@@ -140,9 +185,14 @@ class ScriptAttrs:
         "script" attribute: type  
         Type of script  
 
-        :param value: "module"; a valid MIME type string that is not a JavaScript MIME type essence match  
-        :return: An type attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                "module"; a valid MIME type string that is not a JavaScript MIME type essence match
+        
+        Returns:
+            An type attribute to be added to your element
+
+        """
         
         return BaseAttribute("type", value)
             

--- a/tools/generated/select_attrs.py
+++ b/tools/generated/select_attrs.py
@@ -14,9 +14,14 @@ class SelectAttrs:
         "select" attribute: autocomplete  
         Hint for form autofill feature  
 
-        :param value: Autofill field name and related tokens*  
-        :return: An autocomplete attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Autofill field name and related tokens*
+        
+        Returns:
+            An autocomplete attribute to be added to your element
+
+        """
         
         return BaseAttribute("autocomplete", value)
             
@@ -28,9 +33,14 @@ class SelectAttrs:
         "select" attribute: disabled  
         Whether the form control is disabled  
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
         
         return BaseAttribute("disabled", value)
             
@@ -42,9 +52,14 @@ class SelectAttrs:
         "select" attribute: form  
         Associates the element with a form element  
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An form attribute to be added to your element
+
+        """
         
         return BaseAttribute("form", value)
             
@@ -56,9 +71,14 @@ class SelectAttrs:
         "select" attribute: multiple  
         Whether to allow multiple values  
 
-        :param value: Boolean attribute  
-        :return: An multiple attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An multiple attribute to be added to your element
+
+        """
         
         return BaseAttribute("multiple", value)
             
@@ -70,9 +90,14 @@ class SelectAttrs:
         "select" attribute: name  
         Name of the element to use for form submission and in the form.elements API  
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             
@@ -84,9 +109,14 @@ class SelectAttrs:
         "select" attribute: required  
         Whether the control is required for form submission  
 
-        :param value: Boolean attribute  
-        :return: An required attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An required attribute to be added to your element
+
+        """
         
         return BaseAttribute("required", value)
             
@@ -98,9 +128,14 @@ class SelectAttrs:
         "select" attribute: size  
         Size of the control  
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An size attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+        
+        Returns:
+            An size attribute to be added to your element
+
+        """
         
         return BaseAttribute("size", value)
             

--- a/tools/generated/slot_attrs.py
+++ b/tools/generated/slot_attrs.py
@@ -14,9 +14,14 @@ class SlotAttrs:
         "slot" attribute: name  
         Name of shadow tree slot  
 
-        :param value: Text  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             

--- a/tools/generated/source_attrs.py
+++ b/tools/generated/source_attrs.py
@@ -14,9 +14,14 @@ class SourceAttrs:
         "source" attribute: height  
         Vertical dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An height attribute to be added to your element
+
+        """
         
         return BaseAttribute("height", value)
             
@@ -28,9 +33,14 @@ class SourceAttrs:
         "source" attribute: media  
         Applicable media  
 
-        :param value: Valid media query list  
-        :return: An media attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid media query list
+        
+        Returns:
+            An media attribute to be added to your element
+
+        """
         
         return BaseAttribute("media", value)
             
@@ -42,9 +52,14 @@ class SourceAttrs:
         "source" attribute: sizes  
         Image sizes for different page layouts  
 
-        :param value: Valid source size list  
-        :return: An sizes attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid source size list
+        
+        Returns:
+            An sizes attribute to be added to your element
+
+        """
         
         return BaseAttribute("sizes", value)
             
@@ -56,9 +71,14 @@ class SourceAttrs:
         "source" attribute: src  
         Address of the resource  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An src attribute to be added to your element
+
+        """
         
         return BaseAttribute("src", value)
             
@@ -70,9 +90,14 @@ class SourceAttrs:
         "source" attribute: srcset  
         Images to use in different situations, e.g., high-resolution displays, small monitors, etc.  
 
-        :param value: Comma-separated list of image candidate strings  
-        :return: An srcset attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Comma-separated list of image candidate strings
+        
+        Returns:
+            An srcset attribute to be added to your element
+
+        """
         
         return BaseAttribute("srcset", value)
             
@@ -84,9 +109,14 @@ class SourceAttrs:
         "source" attribute: type  
         Type of embedded resource  
 
-        :param value: Valid MIME type string  
-        :return: An type attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid MIME type string
+        
+        Returns:
+            An type attribute to be added to your element
+
+        """
         
         return BaseAttribute("type", value)
             
@@ -98,9 +128,14 @@ class SourceAttrs:
         "source" attribute: width  
         Horizontal dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An width attribute to be added to your element
+
+        """
         
         return BaseAttribute("width", value)
             

--- a/tools/generated/style_attrs.py
+++ b/tools/generated/style_attrs.py
@@ -14,9 +14,14 @@ class StyleAttrs:
         "style" attribute: blocking  
         Whether the element is potentially render-blocking  
 
-        :param value: Unordered set of unique space-separated tokens*  
-        :return: An blocking attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens*
+        
+        Returns:
+            An blocking attribute to be added to your element
+
+        """
         
         return BaseAttribute("blocking", value)
             
@@ -28,9 +33,14 @@ class StyleAttrs:
         "style" attribute: media  
         Applicable media  
 
-        :param value: Valid media query list  
-        :return: An media attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid media query list
+        
+        Returns:
+            An media attribute to be added to your element
+
+        """
         
         return BaseAttribute("media", value)
             
@@ -42,9 +52,14 @@ class StyleAttrs:
         "style" attribute: title  
         CSS style sheet set name  
 
-        :param value: Text  
-        :return: An title attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An title attribute to be added to your element
+
+        """
         
         return BaseAttribute("title", value)
             

--- a/tools/generated/td_attrs.py
+++ b/tools/generated/td_attrs.py
@@ -14,9 +14,14 @@ class TdAttrs:
         "td" attribute: colspan  
         Number of columns that the cell is to span  
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An colspan attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+        
+        Returns:
+            An colspan attribute to be added to your element
+
+        """
         
         return BaseAttribute("colspan", value)
             
@@ -28,9 +33,14 @@ class TdAttrs:
         "td" attribute: headers  
         The header cells for this cell  
 
-        :param value: Unordered set of unique space-separated tokens consisting of IDs*  
-        :return: An headers attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of IDs*
+        
+        Returns:
+            An headers attribute to be added to your element
+
+        """
         
         return BaseAttribute("headers", value)
             
@@ -42,9 +52,14 @@ class TdAttrs:
         "td" attribute: rowspan  
         Number of rows that the cell is to span  
 
-        :param value: Valid non-negative integer  
-        :return: An rowspan attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An rowspan attribute to be added to your element
+
+        """
         
         return BaseAttribute("rowspan", value)
             

--- a/tools/generated/template_attrs.py
+++ b/tools/generated/template_attrs.py
@@ -14,9 +14,14 @@ class TemplateAttrs:
         "template" attribute: shadowrootclonable  
         Sets clonable on a declarative shadow root  
 
-        :param value: Boolean attribute  
-        :return: An shadowrootclonable attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An shadowrootclonable attribute to be added to your element
+
+        """
         
         return BaseAttribute("shadowrootclonable", value)
             
@@ -28,9 +33,14 @@ class TemplateAttrs:
         "template" attribute: shadowrootdelegatesfocus  
         Sets delegates focus on a declarative shadow root  
 
-        :param value: Boolean attribute  
-        :return: An shadowrootdelegatesfocus attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An shadowrootdelegatesfocus attribute to be added to your element
+
+        """
         
         return BaseAttribute("shadowrootdelegatesfocus", value)
             
@@ -42,9 +52,14 @@ class TemplateAttrs:
         "template" attribute: shadowrootmode  
         Enables streaming declarative shadow roots  
 
-        :param value: ['open', 'closed']  
-        :return: An shadowrootmode attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['open', 'closed']
+        
+        Returns:
+            An shadowrootmode attribute to be added to your element
+
+        """
         
         return BaseAttribute("shadowrootmode", value)
             
@@ -56,9 +71,14 @@ class TemplateAttrs:
         "template" attribute: shadowrootserializable  
         Sets serializable on a declarative shadow root  
 
-        :param value: Boolean attribute  
-        :return: An shadowrootserializable attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An shadowrootserializable attribute to be added to your element
+
+        """
         
         return BaseAttribute("shadowrootserializable", value)
             

--- a/tools/generated/textarea_attrs.py
+++ b/tools/generated/textarea_attrs.py
@@ -14,9 +14,14 @@ class TextareaAttrs:
         "textarea" attribute: autocomplete  
         Hint for form autofill feature  
 
-        :param value: Autofill field name and related tokens*  
-        :return: An autocomplete attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Autofill field name and related tokens*
+        
+        Returns:
+            An autocomplete attribute to be added to your element
+
+        """
         
         return BaseAttribute("autocomplete", value)
             
@@ -28,9 +33,14 @@ class TextareaAttrs:
         "textarea" attribute: cols  
         Maximum number of characters per line  
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An cols attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+        
+        Returns:
+            An cols attribute to be added to your element
+
+        """
         
         return BaseAttribute("cols", value)
             
@@ -42,9 +52,14 @@ class TextareaAttrs:
         "textarea" attribute: dirname  
         Name of form control to use for sending the element's directionality in form submission  
 
-        :param value: Text*  
-        :return: An dirname attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An dirname attribute to be added to your element
+
+        """
         
         return BaseAttribute("dirname", value)
             
@@ -56,9 +71,14 @@ class TextareaAttrs:
         "textarea" attribute: disabled  
         Whether the form control is disabled  
 
-        :param value: Boolean attribute  
-        :return: An disabled attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An disabled attribute to be added to your element
+
+        """
         
         return BaseAttribute("disabled", value)
             
@@ -70,9 +90,14 @@ class TextareaAttrs:
         "textarea" attribute: form  
         Associates the element with a form element  
 
-        :param value: ID*  
-        :return: An form attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ID*
+        
+        Returns:
+            An form attribute to be added to your element
+
+        """
         
         return BaseAttribute("form", value)
             
@@ -84,9 +109,14 @@ class TextareaAttrs:
         "textarea" attribute: maxlength  
         Maximum length of value  
 
-        :param value: Valid non-negative integer  
-        :return: An maxlength attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An maxlength attribute to be added to your element
+
+        """
         
         return BaseAttribute("maxlength", value)
             
@@ -98,9 +128,14 @@ class TextareaAttrs:
         "textarea" attribute: minlength  
         Minimum length of value  
 
-        :param value: Valid non-negative integer  
-        :return: An minlength attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An minlength attribute to be added to your element
+
+        """
         
         return BaseAttribute("minlength", value)
             
@@ -112,9 +147,14 @@ class TextareaAttrs:
         "textarea" attribute: name  
         Name of the element to use for form submission and in the form.elements API  
 
-        :param value: Text*  
-        :return: An name attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An name attribute to be added to your element
+
+        """
         
         return BaseAttribute("name", value)
             
@@ -126,9 +166,14 @@ class TextareaAttrs:
         "textarea" attribute: placeholder  
         User-visible label to be placed within the form control  
 
-        :param value: Text*  
-        :return: An placeholder attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An placeholder attribute to be added to your element
+
+        """
         
         return BaseAttribute("placeholder", value)
             
@@ -140,9 +185,14 @@ class TextareaAttrs:
         "textarea" attribute: readonly  
         Whether to allow the value to be edited by the user  
 
-        :param value: Boolean attribute  
-        :return: An readonly attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An readonly attribute to be added to your element
+
+        """
         
         return BaseAttribute("readonly", value)
             
@@ -154,9 +204,14 @@ class TextareaAttrs:
         "textarea" attribute: required  
         Whether the control is required for form submission  
 
-        :param value: Boolean attribute  
-        :return: An required attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An required attribute to be added to your element
+
+        """
         
         return BaseAttribute("required", value)
             
@@ -168,9 +223,14 @@ class TextareaAttrs:
         "textarea" attribute: rows  
         Number of lines to show  
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An rows attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+        
+        Returns:
+            An rows attribute to be added to your element
+
+        """
         
         return BaseAttribute("rows", value)
             
@@ -182,9 +242,14 @@ class TextareaAttrs:
         "textarea" attribute: wrap  
         How the value of the form control is to be wrapped for form submission  
 
-        :param value: ['soft', 'hard']  
-        :return: An wrap attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['soft', 'hard']
+        
+        Returns:
+            An wrap attribute to be added to your element
+
+        """
         
         return BaseAttribute("wrap", value)
             

--- a/tools/generated/th_attrs.py
+++ b/tools/generated/th_attrs.py
@@ -14,9 +14,14 @@ class ThAttrs:
         "th" attribute: abbr  
         Alternative label to use for the header cell when referencing the cell in other contexts  
 
-        :param value: Text*  
-        :return: An abbr attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text*
+        
+        Returns:
+            An abbr attribute to be added to your element
+
+        """
         
         return BaseAttribute("abbr", value)
             
@@ -28,9 +33,14 @@ class ThAttrs:
         "th" attribute: colspan  
         Number of columns that the cell is to span  
 
-        :param value: Valid non-negative integer greater than zero  
-        :return: An colspan attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer greater than zero
+        
+        Returns:
+            An colspan attribute to be added to your element
+
+        """
         
         return BaseAttribute("colspan", value)
             
@@ -42,9 +52,14 @@ class ThAttrs:
         "th" attribute: headers  
         The header cells for this cell  
 
-        :param value: Unordered set of unique space-separated tokens consisting of IDs*  
-        :return: An headers attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Unordered set of unique space-separated tokens consisting of IDs*
+        
+        Returns:
+            An headers attribute to be added to your element
+
+        """
         
         return BaseAttribute("headers", value)
             
@@ -56,9 +71,14 @@ class ThAttrs:
         "th" attribute: rowspan  
         Number of rows that the cell is to span  
 
-        :param value: Valid non-negative integer  
-        :return: An rowspan attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An rowspan attribute to be added to your element
+
+        """
         
         return BaseAttribute("rowspan", value)
             
@@ -70,9 +90,14 @@ class ThAttrs:
         "th" attribute: scope  
         Specifies which cells the header cell applies to  
 
-        :param value: ['row', 'col', 'rowgroup', 'colgroup']  
-        :return: An scope attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['row', 'col', 'rowgroup', 'colgroup']
+        
+        Returns:
+            An scope attribute to be added to your element
+
+        """
         
         return BaseAttribute("scope", value)
             

--- a/tools/generated/time_attrs.py
+++ b/tools/generated/time_attrs.py
@@ -14,9 +14,14 @@ class TimeAttrs:
         "time" attribute: datetime  
         Machine-readable value  
 
-        :param value: Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string  
-        :return: An datetime attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid month string, valid date string, valid yearless date string, valid time string, valid local date and time string, valid time-zone offset string, valid global date and time string, valid week string, valid non-negative integer, or valid duration string
+        
+        Returns:
+            An datetime attribute to be added to your element
+
+        """
         
         return BaseAttribute("datetime", value)
             

--- a/tools/generated/track_attrs.py
+++ b/tools/generated/track_attrs.py
@@ -14,9 +14,14 @@ class TrackAttrs:
         "track" attribute: default  
         Enable the track if no other text track is more suitable  
 
-        :param value: Boolean attribute  
-        :return: An default attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An default attribute to be added to your element
+
+        """
         
         return BaseAttribute("default", value)
             
@@ -28,9 +33,14 @@ class TrackAttrs:
         "track" attribute: kind  
         The type of text track  
 
-        :param value: ['subtitles', 'captions', 'descriptions', 'chapters', 'metadata']  
-        :return: An kind attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['subtitles', 'captions', 'descriptions', 'chapters', 'metadata']
+        
+        Returns:
+            An kind attribute to be added to your element
+
+        """
         
         return BaseAttribute("kind", value)
             
@@ -42,9 +52,14 @@ class TrackAttrs:
         "track" attribute: label  
         User-visible label  
 
-        :param value: Text  
-        :return: An label attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Text
+        
+        Returns:
+            An label attribute to be added to your element
+
+        """
         
         return BaseAttribute("label", value)
             
@@ -56,9 +71,14 @@ class TrackAttrs:
         "track" attribute: src  
         Address of the resource  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An src attribute to be added to your element
+
+        """
         
         return BaseAttribute("src", value)
             
@@ -70,9 +90,14 @@ class TrackAttrs:
         "track" attribute: srclang  
         Language of the text track  
 
-        :param value: Valid BCP 47 language tag  
-        :return: An srclang attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid BCP 47 language tag
+        
+        Returns:
+            An srclang attribute to be added to your element
+
+        """
         
         return BaseAttribute("srclang", value)
             

--- a/tools/generated/video_attrs.py
+++ b/tools/generated/video_attrs.py
@@ -14,9 +14,14 @@ class VideoAttrs:
         "video" attribute: autoplay  
         Hint that the media resource can be started automatically when the page is loaded  
 
-        :param value: Boolean attribute  
-        :return: An autoplay attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An autoplay attribute to be added to your element
+
+        """
         
         return BaseAttribute("autoplay", value)
             
@@ -28,9 +33,14 @@ class VideoAttrs:
         "video" attribute: controls  
         Show user agent controls  
 
-        :param value: Boolean attribute  
-        :return: An controls attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An controls attribute to be added to your element
+
+        """
         
         return BaseAttribute("controls", value)
             
@@ -42,9 +52,14 @@ class VideoAttrs:
         "video" attribute: crossorigin  
         How the element handles crossorigin requests  
 
-        :param value: ['anonymous', 'use-credentials']  
-        :return: An crossorigin attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['anonymous', 'use-credentials']
+        
+        Returns:
+            An crossorigin attribute to be added to your element
+
+        """
         
         return BaseAttribute("crossorigin", value)
             
@@ -56,9 +71,14 @@ class VideoAttrs:
         "video" attribute: height  
         Vertical dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An height attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An height attribute to be added to your element
+
+        """
         
         return BaseAttribute("height", value)
             
@@ -70,9 +90,14 @@ class VideoAttrs:
         "video" attribute: loop  
         Whether to loop the media resource  
 
-        :param value: Boolean attribute  
-        :return: An loop attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An loop attribute to be added to your element
+
+        """
         
         return BaseAttribute("loop", value)
             
@@ -84,9 +109,14 @@ class VideoAttrs:
         "video" attribute: muted  
         Whether to mute the media resource by default  
 
-        :param value: Boolean attribute  
-        :return: An muted attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An muted attribute to be added to your element
+
+        """
         
         return BaseAttribute("muted", value)
             
@@ -98,9 +128,14 @@ class VideoAttrs:
         "video" attribute: playsinline  
         Encourage the user agent to display video content within the element's playback area  
 
-        :param value: Boolean attribute  
-        :return: An playsinline attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Boolean attribute
+        
+        Returns:
+            An playsinline attribute to be added to your element
+
+        """
         
         return BaseAttribute("playsinline", value)
             
@@ -112,9 +147,14 @@ class VideoAttrs:
         "video" attribute: poster  
         Poster frame to show prior to video playback  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An poster attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An poster attribute to be added to your element
+
+        """
         
         return BaseAttribute("poster", value)
             
@@ -126,9 +166,14 @@ class VideoAttrs:
         "video" attribute: preload  
         Hints how much buffering the media resource will likely need  
 
-        :param value: ['none', 'metadata', 'auto']  
-        :return: An preload attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                ['none', 'metadata', 'auto']
+        
+        Returns:
+            An preload attribute to be added to your element
+
+        """
         
         return BaseAttribute("preload", value)
             
@@ -140,9 +185,14 @@ class VideoAttrs:
         "video" attribute: src  
         Address of the resource  
 
-        :param value: Valid non-empty URL potentially surrounded by spaces  
-        :return: An src attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-empty URL potentially surrounded by spaces
+        
+        Returns:
+            An src attribute to be added to your element
+
+        """
         
         return BaseAttribute("src", value)
             
@@ -154,9 +204,14 @@ class VideoAttrs:
         "video" attribute: width  
         Horizontal dimension  
 
-        :param value: Valid non-negative integer  
-        :return: An width attribute to be added to your element
-        """ # fmt: skip
+        Args:
+            value:
+                Valid non-negative integer
+        
+        Returns:
+            An width attribute to be added to your element
+
+        """
         
         return BaseAttribute("width", value)
             


### PR DESCRIPTION
# 0.11.0
* Add html_compose.resource module which includes 
  js_import, css_import, and font_import helpers
* html_compose.document: Add streaming document generators which will produce
  head element before other content.
* Add js/css/font composition along with other changes to html_compose.document
* [breaking] Change HTML5Document into a class with a .render and .stream function
  which wrap other functionality in the module. 
  The signature is now different which may require updates.
* HTML converter improvements: Survive round trip for more text. 
  Output single elements when we identify an attribute could be a list
* Documentation improvements
  * Migrate element/attr docstrings to Google style.  
    Pyright on Zed seems to tolerate this better.
  * Fix a weird pylance bug on WatchCond
* Live reload now accepts daemon host/port/timeout and can wait to send browser
  reload until after the server responds
* py.typed improvements to module exports
* Child elements passed uninstantiated will be instantiated at render time
  * This means you can `p['line 1', br, 'line 2']` where previously you had to `br()`
* notebook.render accepts _HasHtml which includes documents and elements